### PR TITLE
fix: capture child process stderr and handle malformed config gracefully

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -359,12 +359,10 @@ mod tests {
         let mut root = json!([1, 2, 3]);
         let result = get_servers_mut(&mut root);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("JSON object at the top level")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("JSON object at the top level"));
     }
 
     #[test]

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -100,7 +100,10 @@ impl StdioTransport {
         loop {
             let mut line = String::new();
             let n = match timeout(duration, self.reader.read_line(&mut line)).await {
-                Err(_) => bail!("timeout waiting for server response{}", self.stderr_context()),
+                Err(_) => bail!(
+                    "timeout waiting for server response{}",
+                    self.stderr_context()
+                ),
                 Ok(result) => result.context("failed to read from stdout")?,
             };
 


### PR DESCRIPTION
- Forward server stderr to user terminal with [server stderr] prefix
- Include captured stderr in timeout/EOF error messages for debugging
- Replace .unwrap() panics in config manager with proper error handling
- Add get_servers_mut() helper to validate JSON structure before access

fixed: #12
fixed: #15