### PR TITLE
Add --health flag, JSONC config support, and gh CLI discovery

### DIFF
--- a/src/cli_discovery.rs
+++ b/src/cli_discovery.rs
@@ -146,15 +146,16 @@ fn parse_subcommands(help: &str) -> Vec<(String, String)> {
     // Match section headers like:
     //   "Commands:", "Available Commands:", "SUBCOMMANDS:",
     //   "Basic Commands (Beginner):", "Deploy Commands:", etc.
-    // Match section headers containing "command" or "subcommand" followed by ":"
-    // e.g. "Commands:", "Basic Commands (Beginner):", "Subcommands provided by plugins:"
-    let section_re = Regex::new(r"(?i)^.*\b(sub)?commands?\b.*:\s*$").unwrap();
-    let cmd_re = Regex::new(r"^\s{2,}(\w[\w-]*)\s{2,}(.*)$").unwrap();
+    // Match section headers containing "command" or "subcommand"
+    // e.g. "Commands:", "Basic Commands (Beginner):", "CORE COMMANDS", "ADDITIONAL COMMANDS"
+    let section_re = Regex::new(r"(?i)^.*\b(sub)?commands?\b.*:?\s*$").unwrap();
+    let cmd_re = Regex::new(r"^\s{2,}(\w[\w-]*):?\s{2,}(.*)$").unwrap();
 
     for line in help.lines() {
         let trimmed = line.trim();
 
-        if section_re.is_match(trimmed) {
+        // Section headers are not indented (e.g. "CORE COMMANDS", "Commands:")
+        if !line.starts_with(' ') && !line.starts_with('\t') && section_re.is_match(trimmed) {
             in_commands_section = true;
             continue;
         }
@@ -517,6 +518,55 @@ Subcommands provided by plugins:
         assert!(names.contains(&"scale"));
         assert!(names.contains(&"ctx"));
         assert_eq!(subs.len(), 7);
+    }
+
+    #[test]
+    fn test_parse_subcommands_gh_style() {
+        let help = r#"Work seamlessly with GitHub from the command line.
+
+USAGE
+  gh <command> <subcommand> [flags]
+
+CORE COMMANDS
+  auth:          Authenticate gh and git with GitHub
+  browse:        Open repositories, issues, pull requests, and more in the browser
+  issue:         Manage issues
+  pr:            Manage pull requests
+  repo:          Manage repositories
+
+GITHUB ACTIONS COMMANDS
+  run:           View details about workflow runs
+  workflow:      View details about GitHub Actions workflows
+
+ADDITIONAL COMMANDS
+  alias:         Create command shortcuts
+  api:           Make an authenticated GitHub API request
+  config:        Manage configuration for gh
+  extension:     Manage gh extensions
+  search:        Search for repositories, issues, and pull requests
+  secret:        Manage GitHub secrets
+  ssh-key:       Manage SSH keys
+  status:        Print information about relevant issues, pull requests, and notifications
+
+HELP TOPICS
+  environment:   Environment variables that can be used with gh
+
+FLAGS
+  --version   Show gh version
+
+LEARN MORE
+  Use `gh <command> <subcommand> --help` for more information about a command.
+"#;
+        let subs = parse_subcommands(help);
+        let names: Vec<&str> = subs.iter().map(|s| s.0.as_str()).collect();
+        assert!(names.contains(&"auth"), "missing auth: {:?}", names);
+        assert!(names.contains(&"pr"), "missing pr: {:?}", names);
+        assert!(names.contains(&"issue"), "missing issue: {:?}", names);
+        assert!(names.contains(&"repo"), "missing repo: {:?}", names);
+        assert!(names.contains(&"run"), "missing run: {:?}", names);
+        assert!(names.contains(&"api"), "missing api: {:?}", names);
+        assert!(names.contains(&"ssh-key"), "missing ssh-key: {:?}", names);
+        assert_eq!(subs.len(), 15);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,6 +174,61 @@ pub fn config_path() -> Result<PathBuf> {
     Ok(config_dir()?.join("servers.json"))
 }
 
+/// Strip single-line (`//`) and multi-line (`/* */`) comments from JSON,
+/// respecting string literals so that `"http://example.com"` is preserved.
+fn strip_json_comments(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        match bytes[i] {
+            b'"' => {
+                out.push('"');
+                i += 1;
+                while i < len {
+                    if bytes[i] == b'\\' && i + 1 < len {
+                        out.push(bytes[i] as char);
+                        out.push(bytes[i + 1] as char);
+                        i += 2;
+                    } else if bytes[i] == b'"' {
+                        out.push('"');
+                        i += 1;
+                        break;
+                    } else {
+                        out.push(bytes[i] as char);
+                        i += 1;
+                    }
+                }
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
+                // Single-line comment: skip until end of line
+                i += 2;
+                while i < len && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                // Multi-line comment: skip until */
+                i += 2;
+                while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                if i + 1 < len {
+                    i += 2; // skip */
+                }
+            }
+            _ => {
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+    }
+
+    out
+}
+
 pub fn load_config() -> Result<Config> {
     let path = config_path()?;
     load_config_from_path(&path)
@@ -193,6 +248,7 @@ pub fn load_config_from_path(path: &PathBuf) -> Result<Config> {
         .with_context(|| format!("failed to read config file: {}", path.display()))?;
 
     let content = substitute_env_vars(&content);
+    let content = strip_json_comments(&content);
 
     let raw: Value = serde_json::from_str(&content)
         .with_context(|| format!("failed to parse config file: {}", path.display()))?;
@@ -584,5 +640,80 @@ mod tests {
         assert!(config.audit.enabled); // default
         assert!(!config.audit.log_arguments); // default
         assert!(config.audit.path.is_none());
+    }
+
+    #[test]
+    fn test_strip_single_line_comments() {
+        let input = r#"{
+            // this is a comment
+            "mcpServers": {}
+        }"#;
+        let stripped = strip_json_comments(input);
+        let _: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+    }
+
+    #[test]
+    fn test_strip_block_comments() {
+        let input = r#"{
+            /* block comment */
+            "mcpServers": {}
+        }"#;
+        let stripped = strip_json_comments(input);
+        let _: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+    }
+
+    #[test]
+    fn test_strip_comments_preserves_urls() {
+        let input = r#"{
+            "mcpServers": {
+                "sentry": {
+                    "url": "https://mcp.sentry.dev/mcp"
+                }
+            }
+        }"#;
+        let stripped = strip_json_comments(input);
+        let v: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert_eq!(
+            v["mcpServers"]["sentry"]["url"],
+            "https://mcp.sentry.dev/mcp"
+        );
+    }
+
+    #[test]
+    fn test_strip_comments_commented_out_server() {
+        let input = r#"{
+            "mcpServers": {
+                // "disabled": {
+                //   "url": "https://example.com"
+                // },
+                "enabled": {
+                    "url": "https://active.example.com"
+                }
+            }
+        }"#;
+        let stripped = strip_json_comments(input);
+        let v: serde_json::Value = serde_json::from_str(&stripped).unwrap();
+        assert!(v["mcpServers"]["disabled"].is_null());
+        assert_eq!(
+            v["mcpServers"]["enabled"]["url"],
+            "https://active.example.com"
+        );
+    }
+
+    #[test]
+    fn test_config_with_comments() {
+        let config = config_from_json(
+            r#"{
+                "mcpServers": {
+                    // "disabled": { "url": "https://example.com" },
+                    "active": {
+                        "url": "https://active.example.com"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        assert!(config.servers.contains_key("active"));
+        assert!(!config.servers.contains_key("disabled"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn print_usage() {
     eprintln!("  mcp --list                          List configured servers");
     eprintln!("  mcp <server> --list                 List tools from a server");
     eprintln!("  mcp <server> --info                 List tools with input schemas");
+    eprintln!("  mcp <server> --health               Check if server is reachable");
     eprintln!("  mcp <server> <tool> [json]          Call a tool");
     eprintln!("  mcp search <query>                  Search MCP registry");
     eprintln!("  mcp add <name>                      Add server from registry");
@@ -291,6 +292,38 @@ async fn handle_server_command(
             result?;
         }
         client.shutdown().await?;
+        return Ok(());
+    }
+
+    if args.len() >= 2 && args[1] == "--health" {
+        let start = std::time::Instant::now();
+
+        audit.log(audit::AuditEntry {
+            timestamp: chrono::Local::now().to_rfc3339(),
+            source: "cli".to_string(),
+            method: "health".to_string(),
+            tool_name: None,
+            server_name: Some(server_name.clone()),
+            identity: "local".to_string(),
+            duration_ms: start.elapsed().as_millis() as u64,
+            success: true,
+            error_message: None,
+            arguments: None,
+        });
+
+        client.shutdown().await?;
+
+        match fmt {
+            OutputFormat::Json => {
+                println!(
+                    "{}",
+                    serde_json::json!({"server": server_name, "status": "ok"})
+                );
+            }
+            OutputFormat::Text => {
+                println!("{server_name}: ok");
+            }
+        }
         return Ok(());
     }
 


### PR DESCRIPTION
The MCP CLI had no lightweight way to check server reachability (only --list which fetches all tools), config files broke on // comments that users naturally add, and gh's help format (uppercase headers like "CORE COMMANDS", colon-suffixed names like "auth:") wasn't recognized by the parser.

Health check does connect-handshake-disconnect reusing the existing initialize flow, returning exit 0/1. Config parser now strips single-line and block comments before JSON parsing, respecting string literals so URLs survive. CLI discovery relaxes section header regex to not require trailing colon and accepts colon-suffixed command names, with an indentation guard to prevent description text from false-matching as section headers.

closes #11