### PR TITLE
Populate roles in Bearer and Forwarded auth providers

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -167,26 +167,53 @@ This is configured via the `serverAuth` key in `servers.json`. See the [proxy mo
     "bearer": {
       "tokens": {
         "tok-alice": "alice",
-        "tok-bob": "bob"
+        "tok-bob": { "subject": "bob", "roles": ["dev", "oncall"] }
       }
     },
     "acl": {
       "default": "allow",
       "rules": [
-        { "subjects": ["bob"], "tools": ["sentry__*"], "policy": "deny" }
+        { "roles": ["dev"], "tools": ["sentry__*"], "policy": "deny" }
       ]
     }
   }
 }
 ```
 
+Each entry in `tokens` supports two shapes:
+
+- **Legacy (string):** `"tok-alice": "alice"` — subject only, no roles.
+- **Extended (object):** `"tok-bob": { "subject": "bob", "roles": ["dev", "oncall"] }` — subject plus a list of roles that will flow into ACL evaluation.
+
+Both forms can coexist in the same config file.
+
 ### Available providers
 
 | Provider | Use case |
 |----------|----------|
 | `none` (default) | No auth — all requests are anonymous |
-| `bearer` | Static token-to-user mapping |
-| `forwarded` | Trust reverse proxy `X-Forwarded-User` header |
+| `bearer` | Static token-to-user mapping, with optional per-token roles |
+| `forwarded` | Trust reverse proxy `X-Forwarded-User` header (and optional `X-Forwarded-Groups` for roles) |
+
+### Forwarded provider and roles
+
+When `provider` is `forwarded`, the proxy reads the user from the configured user header (default `x-forwarded-user`) and, optionally, a groups header (default `x-forwarded-groups`, following the oauth2-proxy convention) to populate roles.
+
+```json
+{
+  "serverAuth": {
+    "provider": "forwarded",
+    "forwarded": {
+      "header": "x-forwarded-user",
+      "groups_header": "x-forwarded-groups"
+    }
+  }
+}
+```
+
+Groups header value is parsed as a comma-separated list: each entry is trimmed and empty entries are dropped. Missing header yields an empty role list (not an error). Role matching is **case-sensitive**.
+
+> Only use `forwarded` behind a trusted reverse proxy that strips these headers from incoming client requests — otherwise clients could forge identities and roles.
 
 ### Access control (ACL)
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -205,14 +205,19 @@ Optional. Configures authentication for `mcp serve --http`. Ignored for direct C
 
 ### Bearer config
 
-Required when `provider` is `"bearer"`.
+Required when `provider` is `"bearer"`. Each entry in `tokens` accepts two shapes:
+
+- **Legacy (string):** `"<token>": "<subject>"` — subject only, no roles.
+- **Extended (object):** `"<token>": { "subject": "<subject>", "roles": ["<role>", ...] }` — subject plus roles used by ACL evaluation.
+
+Both forms can coexist in the same file.
 
 ```json
 {
   "bearer": {
     "tokens": {
-      "<token>": "<subject>",
-      "secret-abc": "alice"
+      "secret-abc": "alice",
+      "secret-def": { "subject": "bob", "roles": ["dev", "oncall"] }
     }
   }
 }
@@ -220,16 +225,24 @@ Required when `provider` is `"bearer"`.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `tokens` | object | Map of token → subject identity |
+| `tokens` | object | Map of token → subject string **or** `{subject, roles}` object |
+
+Each extended entry:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `subject` | string | *required* | User identity for this token |
+| `roles` | string[] | `[]` | Roles assigned to this identity (used by ACL rules) |
 
 ### Forwarded config
 
-Optional when `provider` is `"forwarded"`. Defaults to `x-forwarded-user`.
+Optional when `provider` is `"forwarded"`. Reads the authenticated user from a header set by a trusted reverse proxy, and optionally reads a groups header to populate roles.
 
 ```json
 {
   "forwarded": {
-    "header": "x-forwarded-user"
+    "header": "x-forwarded-user",
+    "groups_header": "x-forwarded-groups"
   }
 }
 ```
@@ -237,6 +250,11 @@ Optional when `provider` is `"forwarded"`. Defaults to `x-forwarded-user`.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `header` | string | `"x-forwarded-user"` | Header name to read the authenticated user from |
+| `groups_header` | string | `"x-forwarded-groups"` | Header name to read roles from (comma-separated, oauth2-proxy convention) |
+
+Groups header value is parsed as a comma-separated list: each entry is trimmed and empty entries are dropped. Missing header yields empty roles (not an error). Role matching is case-sensitive.
+
+> Only use `forwarded` behind a trusted reverse proxy. The proxy **must** strip these headers from incoming client requests — otherwise a client could forge identity and roles.
 
 ### ACL config
 

--- a/src/server_auth/mod.rs
+++ b/src/server_auth/mod.rs
@@ -74,19 +74,39 @@ fn default_provider() -> String {
     "none".to_string()
 }
 
+/// A single bearer token entry. Accepts two shapes for backwards compatibility:
+/// - Legacy: `"tok-alice": "alice"` → subject only, no roles.
+/// - Extended: `"tok-bob": { "subject": "bob", "roles": ["dev"] }`.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum BearerToken {
+    Subject(String),
+    Extended {
+        subject: String,
+        #[serde(default)]
+        roles: Vec<String>,
+    },
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct BearerConfig {
-    pub tokens: HashMap<String, String>,
+    pub tokens: HashMap<String, BearerToken>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ForwardedConfig {
     #[serde(default = "default_header")]
     pub header: String,
+    #[serde(default = "default_groups_header")]
+    pub groups_header: String,
 }
 
 fn default_header() -> String {
     "x-forwarded-user".to_string()
+}
+
+fn default_groups_header() -> String {
+    "x-forwarded-groups".to_string()
 }
 
 /// Build an AuthProvider from config.
@@ -101,12 +121,12 @@ pub fn build_auth_provider(config: &ServerAuthConfig) -> Result<Arc<dyn AuthProv
             Ok(Arc::new(BearerTokenAuth::new(bearer.tokens.clone())))
         }
         "forwarded" => {
-            let header = config
+            let (header, groups_header) = config
                 .forwarded
                 .as_ref()
-                .map(|f| f.header.clone())
-                .unwrap_or_else(default_header);
-            Ok(Arc::new(ForwardedUserAuth::new(header)))
+                .map(|f| (f.header.clone(), f.groups_header.clone()))
+                .unwrap_or_else(|| (default_header(), default_groups_header()));
+            Ok(Arc::new(ForwardedUserAuth::new(header, groups_header)))
         }
         other => anyhow::bail!("unknown auth provider: {other}"),
     }
@@ -150,7 +170,10 @@ mod tests {
     #[tokio::test]
     async fn test_build_bearer_auth() {
         let mut tokens = HashMap::new();
-        tokens.insert("secret-abc".to_string(), "alice".to_string());
+        tokens.insert(
+            "secret-abc".to_string(),
+            BearerToken::Subject("alice".to_string()),
+        );
         let config = ServerAuthConfig {
             provider: "bearer".to_string(),
             bearer: Some(BearerConfig { tokens }),
@@ -180,6 +203,7 @@ mod tests {
             provider: "forwarded".to_string(),
             forwarded: Some(ForwardedConfig {
                 header: "x-forwarded-user".to_string(),
+                groups_header: "x-forwarded-groups".to_string(),
             }),
             ..Default::default()
         };
@@ -231,5 +255,76 @@ mod tests {
         assert_eq!(config.bearer.unwrap().tokens.len(), 2);
         let acl = config.acl.unwrap();
         assert_eq!(acl.rules.len(), 1);
+    }
+
+    #[test]
+    fn test_bearer_config_deserialize_mixed() {
+        // Legacy string form and extended object form must coexist.
+        let json = r#"{
+            "tokens": {
+                "tok-alice": "alice",
+                "tok-bob": { "subject": "bob", "roles": ["dev", "oncall"] },
+                "tok-carol": { "subject": "carol" }
+            }
+        }"#;
+        let cfg: BearerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.tokens.len(), 3);
+        match cfg.tokens.get("tok-alice").unwrap() {
+            BearerToken::Subject(s) => assert_eq!(s, "alice"),
+            _ => panic!("expected legacy subject form for tok-alice"),
+        }
+        match cfg.tokens.get("tok-bob").unwrap() {
+            BearerToken::Extended { subject, roles } => {
+                assert_eq!(subject, "bob");
+                assert_eq!(roles, &vec!["dev".to_string(), "oncall".to_string()]);
+            }
+            _ => panic!("expected extended form for tok-bob"),
+        }
+        // Missing roles defaults to empty vec.
+        match cfg.tokens.get("tok-carol").unwrap() {
+            BearerToken::Extended { subject, roles } => {
+                assert_eq!(subject, "carol");
+                assert!(roles.is_empty());
+            }
+            _ => panic!("expected extended form for tok-carol"),
+        }
+    }
+
+    #[test]
+    fn test_bearer_config_deserialize_malformed_roles_type() {
+        // roles must be an array — string should fail.
+        let json = r#"{
+            "tokens": {
+                "tok-x": { "subject": "x", "roles": "admin" }
+            }
+        }"#;
+        assert!(serde_json::from_str::<BearerConfig>(json).is_err());
+    }
+
+    #[test]
+    fn test_bearer_config_deserialize_extended_missing_subject() {
+        // Extended form without subject is invalid.
+        let json = r#"{
+            "tokens": {
+                "tok-x": { "roles": ["dev"] }
+            }
+        }"#;
+        assert!(serde_json::from_str::<BearerConfig>(json).is_err());
+    }
+
+    #[test]
+    fn test_forwarded_config_default_groups_header() {
+        let json = r#"{}"#;
+        let cfg: ForwardedConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.header, "x-forwarded-user");
+        assert_eq!(cfg.groups_header, "x-forwarded-groups");
+    }
+
+    #[test]
+    fn test_forwarded_config_custom_groups_header() {
+        let json = r#"{"header":"x-user","groups_header":"x-groups"}"#;
+        let cfg: ForwardedConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.header, "x-user");
+        assert_eq!(cfg.groups_header, "x-groups");
     }
 }

--- a/src/server_auth/providers.rs
+++ b/src/server_auth/providers.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Result};
 use async_trait::async_trait;
 use std::collections::HashMap;
 
-use super::{AuthIdentity, AuthProvider, Credentials};
+use super::{AuthIdentity, AuthProvider, BearerToken, Credentials};
 
 /// No authentication — always returns anonymous identity.
 /// Default for development and stdio mode.
@@ -16,13 +16,13 @@ impl AuthProvider for NoAuth {
 }
 
 /// Validates static bearer tokens from config.
-/// Maps token -> subject.
+/// Maps token -> BearerToken (legacy string subject or extended {subject, roles}).
 pub struct BearerTokenAuth {
-    tokens: HashMap<String, String>,
+    tokens: HashMap<String, BearerToken>,
 }
 
 impl BearerTokenAuth {
-    pub fn new(tokens: HashMap<String, String>) -> Self {
+    pub fn new(tokens: HashMap<String, BearerToken>) -> Self {
         Self { tokens }
     }
 }
@@ -41,7 +41,10 @@ impl AuthProvider for BearerTokenAuth {
         let token = &header[7..];
 
         match self.tokens.get(token) {
-            Some(subject) => Ok(AuthIdentity::new(subject.clone(), vec![])),
+            Some(BearerToken::Subject(subject)) => Ok(AuthIdentity::new(subject.clone(), vec![])),
+            Some(BearerToken::Extended { subject, roles }) => {
+                Ok(AuthIdentity::new(subject.clone(), roles.clone()))
+            }
             None => bail!("invalid bearer token"),
         }
     }
@@ -49,16 +52,34 @@ impl AuthProvider for BearerTokenAuth {
 
 /// Trusts a reverse proxy header (e.g. X-Forwarded-User).
 /// Only use behind a trusted proxy that sets this header.
+///
+/// Optionally reads a groups header (default `x-forwarded-groups`, oauth2-proxy
+/// convention) to populate roles. Value is parsed as a comma-separated list:
+/// each entry is trimmed and empty entries are dropped. Missing header yields
+/// empty roles (not an error).
 pub struct ForwardedUserAuth {
     header: String,
+    groups_header: String,
 }
 
 impl ForwardedUserAuth {
-    pub fn new(header: String) -> Self {
+    pub fn new(header: String, groups_header: String) -> Self {
         Self {
             header: header.to_lowercase(),
+            groups_header: groups_header.to_lowercase(),
         }
     }
+}
+
+/// Parse a comma-separated groups header into a list of role names.
+/// Trims each entry and drops empty ones. Case is preserved (role matching
+/// is case-sensitive).
+fn parse_groups(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
 }
 
 #[async_trait]
@@ -72,7 +93,12 @@ impl AuthProvider for ForwardedUserAuth {
             bail!("{} header is empty", self.header);
         }
 
-        Ok(AuthIdentity::new(user.clone(), vec![]))
+        let roles = creds
+            .get(&self.groups_header)
+            .map(|raw| parse_groups(raw))
+            .unwrap_or_default();
+
+        Ok(AuthIdentity::new(user.clone(), roles))
     }
 }
 
@@ -91,8 +117,14 @@ mod tests {
     #[tokio::test]
     async fn test_bearer_valid_token() {
         let mut tokens = HashMap::new();
-        tokens.insert("secret-abc".to_string(), "alice".to_string());
-        tokens.insert("secret-def".to_string(), "bob".to_string());
+        tokens.insert(
+            "secret-abc".to_string(),
+            BearerToken::Subject("alice".to_string()),
+        );
+        tokens.insert(
+            "secret-def".to_string(),
+            BearerToken::Subject("bob".to_string()),
+        );
         let provider = BearerTokenAuth::new(tokens);
 
         let mut creds = Credentials::new();
@@ -104,7 +136,10 @@ mod tests {
     #[tokio::test]
     async fn test_bearer_case_insensitive_scheme() {
         let mut tokens = HashMap::new();
-        tokens.insert("secret-abc".to_string(), "alice".to_string());
+        tokens.insert(
+            "secret-abc".to_string(),
+            BearerToken::Subject("alice".to_string()),
+        );
         let provider = BearerTokenAuth::new(tokens);
 
         for scheme in &["bearer", "BEARER", "Bearer", "bEaReR"] {
@@ -118,7 +153,10 @@ mod tests {
     #[tokio::test]
     async fn test_bearer_invalid_token() {
         let mut tokens = HashMap::new();
-        tokens.insert("secret-abc".to_string(), "alice".to_string());
+        tokens.insert(
+            "secret-abc".to_string(),
+            BearerToken::Subject("alice".to_string()),
+        );
         let provider = BearerTokenAuth::new(tokens);
 
         let mut creds = Credentials::new();
@@ -146,7 +184,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_forwarded_valid_user() {
-        let provider = ForwardedUserAuth::new("x-forwarded-user".to_string());
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
         let mut creds = Credentials::new();
         creds.insert("x-forwarded-user".to_string(), "charlie".to_string());
         let identity = provider.authenticate(&creds).await.unwrap();
@@ -155,13 +196,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_forwarded_missing_header() {
-        let provider = ForwardedUserAuth::new("x-forwarded-user".to_string());
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
         assert!(provider.authenticate(&Credentials::new()).await.is_err());
     }
 
     #[tokio::test]
     async fn test_forwarded_empty_header() {
-        let provider = ForwardedUserAuth::new("x-forwarded-user".to_string());
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
         let mut creds = Credentials::new();
         creds.insert("x-forwarded-user".to_string(), String::new());
         assert!(provider.authenticate(&creds).await.is_err());
@@ -169,10 +216,314 @@ mod tests {
 
     #[tokio::test]
     async fn test_forwarded_custom_header() {
-        let provider = ForwardedUserAuth::new("X-Remote-User".to_string());
+        let provider = ForwardedUserAuth::new(
+            "X-Remote-User".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
         let mut creds = Credentials::new();
         creds.insert("x-remote-user".to_string(), "dave".to_string());
         let identity = provider.authenticate(&creds).await.unwrap();
         assert_eq!(identity.subject, "dave");
+    }
+
+    // ---------------------------------------------------------------------
+    // Bearer — roles population
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_bearer_legacy_form_has_empty_roles() {
+        // Backwards-compat: string form must produce exactly roles=[].
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-alice".to_string(),
+            BearerToken::Subject("alice".to_string()),
+        );
+        let provider = BearerTokenAuth::new(tokens);
+
+        let mut creds = Credentials::new();
+        creds.insert("authorization".to_string(), "Bearer tok-alice".to_string());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.subject, "alice");
+        assert!(
+            identity.roles.is_empty(),
+            "legacy form must never populate roles"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bearer_extended_form_populates_roles() {
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-bob".to_string(),
+            BearerToken::Extended {
+                subject: "bob".to_string(),
+                roles: vec!["dev".to_string(), "oncall".to_string()],
+            },
+        );
+        let provider = BearerTokenAuth::new(tokens);
+
+        let mut creds = Credentials::new();
+        creds.insert("authorization".to_string(), "Bearer tok-bob".to_string());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.subject, "bob");
+        assert_eq!(
+            identity.roles,
+            vec!["dev".to_string(), "oncall".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bearer_extended_form_with_empty_roles() {
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-carol".to_string(),
+            BearerToken::Extended {
+                subject: "carol".to_string(),
+                roles: vec![],
+            },
+        );
+        let provider = BearerTokenAuth::new(tokens);
+
+        let mut creds = Credentials::new();
+        creds.insert("authorization".to_string(), "Bearer tok-carol".to_string());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.subject, "carol");
+        assert!(identity.roles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_bearer_mixed_forms_coexist() {
+        // Legacy and extended tokens in the same provider must both work.
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-legacy".to_string(),
+            BearerToken::Subject("alice".to_string()),
+        );
+        tokens.insert(
+            "tok-ext".to_string(),
+            BearerToken::Extended {
+                subject: "bob".to_string(),
+                roles: vec!["admin".to_string()],
+            },
+        );
+        let provider = BearerTokenAuth::new(tokens);
+
+        let mut c1 = Credentials::new();
+        c1.insert("authorization".to_string(), "Bearer tok-legacy".to_string());
+        let id1 = provider.authenticate(&c1).await.unwrap();
+        assert_eq!(id1.subject, "alice");
+        assert!(id1.roles.is_empty());
+
+        let mut c2 = Credentials::new();
+        c2.insert("authorization".to_string(), "Bearer tok-ext".to_string());
+        let id2 = provider.authenticate(&c2).await.unwrap();
+        assert_eq!(id2.subject, "bob");
+        assert_eq!(id2.roles, vec!["admin".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_bearer_roles_do_not_leak_between_tokens() {
+        // Privilege escalation guard: authenticating with a legacy token must
+        // never return roles from a different extended token in the map.
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-admin".to_string(),
+            BearerToken::Extended {
+                subject: "admin".to_string(),
+                roles: vec!["admin".to_string(), "superuser".to_string()],
+            },
+        );
+        tokens.insert(
+            "tok-guest".to_string(),
+            BearerToken::Subject("guest".to_string()),
+        );
+        let provider = BearerTokenAuth::new(tokens);
+
+        let mut creds = Credentials::new();
+        creds.insert("authorization".to_string(), "Bearer tok-guest".to_string());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.subject, "guest");
+        assert!(
+            identity.roles.is_empty(),
+            "guest must never inherit admin roles"
+        );
+        assert!(!identity.roles.contains(&"admin".to_string()));
+        assert!(!identity.roles.contains(&"superuser".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_bearer_invalid_token_with_extended_tokens_present() {
+        // Bypass guard: invalid token must fail even when extended tokens exist.
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-real".to_string(),
+            BearerToken::Extended {
+                subject: "alice".to_string(),
+                roles: vec!["admin".to_string()],
+            },
+        );
+        let provider = BearerTokenAuth::new(tokens);
+
+        let mut creds = Credentials::new();
+        creds.insert("authorization".to_string(), "Bearer tok-fake".to_string());
+        assert!(provider.authenticate(&creds).await.is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // Forwarded — groups header parsing
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_groups_basic() {
+        assert_eq!(parse_groups("dev,oncall"), vec!["dev", "oncall"]);
+    }
+
+    #[test]
+    fn test_parse_groups_trims_whitespace() {
+        assert_eq!(
+            parse_groups(" dev , oncall ,  admin"),
+            vec!["dev", "oncall", "admin"]
+        );
+    }
+
+    #[test]
+    fn test_parse_groups_drops_empty_entries() {
+        assert_eq!(
+            parse_groups("dev,,oncall, ,admin"),
+            vec!["dev", "oncall", "admin"]
+        );
+    }
+
+    #[test]
+    fn test_parse_groups_only_separators() {
+        assert!(parse_groups(",,,").is_empty());
+        assert!(parse_groups(" , , ").is_empty());
+    }
+
+    #[test]
+    fn test_parse_groups_empty_string() {
+        assert!(parse_groups("").is_empty());
+    }
+
+    #[test]
+    fn test_parse_groups_single_value() {
+        assert_eq!(parse_groups("admin"), vec!["admin"]);
+    }
+
+    #[test]
+    fn test_parse_groups_preserves_case() {
+        // Role matching is case-sensitive — parser must not normalize.
+        assert_eq!(
+            parse_groups("Admin,DEV,oncall"),
+            vec!["Admin", "DEV", "oncall"]
+        );
+    }
+
+    #[test]
+    fn test_parse_groups_preserves_duplicates() {
+        // If the upstream header has duplicates, we keep them (don't silently dedupe).
+        assert_eq!(parse_groups("dev,dev,admin"), vec!["dev", "dev", "admin"]);
+    }
+
+    #[test]
+    fn test_parse_groups_unicode() {
+        assert_eq!(
+            parse_groups("développeur, 管理员"),
+            vec!["développeur", "管理员"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_groups_header_populates_roles() {
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        creds.insert(
+            "x-forwarded-groups".to_string(),
+            "dev, oncall, ,admin".to_string(),
+        );
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.subject, "alice");
+        assert_eq!(
+            identity.roles,
+            vec!["dev".to_string(), "oncall".to_string(), "admin".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_missing_groups_header_yields_empty_roles() {
+        // Missing groups header is NOT an error — just no roles.
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.subject, "alice");
+        assert!(identity.roles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_empty_groups_header_yields_empty_roles() {
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        creds.insert("x-forwarded-groups".to_string(), String::new());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert!(identity.roles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_custom_groups_header_name() {
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "X-Remote-Groups".to_string(),
+        );
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        creds.insert("x-remote-groups".to_string(), "dev,admin".to_string());
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert_eq!(identity.roles, vec!["dev".to_string(), "admin".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_default_groups_header_ignored_when_custom_set() {
+        // Privilege escalation guard: if operator configures a custom groups
+        // header, the default `x-forwarded-groups` must NOT be read — otherwise
+        // an attacker who can set one but not the other could inject roles.
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-remote-groups".to_string(),
+        );
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        creds.insert(
+            "x-forwarded-groups".to_string(),
+            "admin,superuser".to_string(),
+        );
+        let identity = provider.authenticate(&creds).await.unwrap();
+        assert!(
+            identity.roles.is_empty(),
+            "default groups header must be ignored when a custom one is configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_forwarded_missing_user_still_errors_even_with_groups() {
+        // Bypass guard: groups header alone must not authenticate anyone.
+        let provider = ForwardedUserAuth::new(
+            "x-forwarded-user".to_string(),
+            "x-forwarded-groups".to_string(),
+        );
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-groups".to_string(), "admin".to_string());
+        assert!(provider.authenticate(&creds).await.is_err());
     }
 }


### PR DESCRIPTION
AuthIdentity.roles existed but no provider ever populated it, so any role-based ACL rule was dead code — the whole foundation of the ACL redesign had nothing to evaluate against.

BearerTokenAuth now accepts an extended token shape alongside the legacy string form: "tok-bob": { "subject": "bob", "roles": ["dev"] } via an untagged enum, so existing configs keep working untouched. ForwardedUserAuth reads a configurable groups header (default x-forwarded-groups, oauth2-proxy convention) and parses it as a trimmed comma-separated list, with a missing header yielding empty roles instead of an error. Ships with a heavy security test battery covering bypass, privilege escalation between tokens, backwards compat, and parsing edge cases, plus doc updates for authentication guide, config reference, and the ACL redesign plan.

Closes #53