### PR TITLE
Add read/write tool classifier with manual override

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -284,3 +284,47 @@ Fails if:
 - Server is not in the registry
 
 > If the server changed type in the registry (stdio ↔ http), `mcp update` warns and drops type-specific fields that no longer apply.
+
+## ACL commands
+
+### `mcp acl classify`
+
+Classify every tool of every configured backend as `read`, `write`, or
+`ambiguous`, using the automatic classifier combined with manual
+`tool_acl` overrides from `servers.json`. This is metadata only — no
+enforcement path changes yet.
+
+```bash
+mcp acl classify                      # all servers, table output
+mcp acl classify --server grafana     # one server
+mcp acl classify --format json        # machine-readable
+```
+
+**Flags:**
+- `--server <alias>` — restrict to one backend
+- `--format table|json` — override the auto-detected output format
+
+**Table columns:**
+
+| Column | Meaning |
+|---|---|
+| `SERVER` | Backend alias |
+| `TOOL` | Upstream tool name (not namespaced) |
+| `KIND` | `read`, `write`, or `ambiguous` |
+| `CONF` | Classifier confidence (0.00–1.00) |
+| `SOURCE` | `override`, `annotation`, `classifier`, or `fallback` |
+| `reasons` | Which signals fired (name tokens, description patterns, schema hints) |
+
+Rows prefixed with `[!]` are **ambiguous** — the classifier could not
+decide. They are treated as `write` at runtime (fail-safe). Add a
+`tool_acl` entry in `servers.json` to pin them explicitly.
+
+**Example (JSON):**
+
+```bash
+mcp acl classify --server databricks --format json | jq '.[] | {tool, kind}'
+```
+
+The JSON form is an array of `{server, tool, kind, confidence, source, reasons}` objects, suitable for scripting or diffing across config changes.
+
+See [Tool ACL overrides](./config-file.md#tool-acl-overrides) for how to pin tools manually, and [`docs/acl-redesign-plan.md`](../acl-redesign-plan.md) for the full redesign context.

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -186,8 +186,8 @@ Semantics:
   same server — that fails loudly at load time.
 - If two different globs on the same server both match a single tool name
   (e.g. `get_*` in `read` and `*_thing` in `write` both match `get_thing`),
-  the proxy fails safe to `write` at classification time and logs the
-  conflict. Narrow your globs to avoid this.
+  the proxy fails safe to `write` at classification time. Narrow your
+  globs to avoid this.
 - Overrides are **never cached** — they are re-read from the config on
   every startup.
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -38,6 +38,7 @@ Three variants, distinguished by their fields:
 | `command` | string | *required* | Executable to spawn |
 | `args` | string[] | `[]` | Arguments passed to the command |
 | `env` | object | `{}` | Environment variables for the process |
+| `tool_acl` | object | `null` | Manual read/write classification overrides (see [Tool ACL overrides](#tool-acl-overrides)) |
 | `idle_timeout` | string | `"adaptive"` | Idle shutdown policy (see [Idle timeout](#idle-timeout)) |
 | `min_idle_timeout` | string | `"1m"` | Minimum idle timeout for adaptive mode |
 | `max_idle_timeout` | string | `"5m"` | Maximum idle timeout for adaptive mode |
@@ -57,6 +58,7 @@ Three variants, distinguished by their fields:
 |---|---|---|---|
 | `url` | string | *required* | Server endpoint URL |
 | `headers` | object | `{}` | HTTP headers for every request |
+| `tool_acl` | object | `null` | Manual read/write classification overrides (see [Tool ACL overrides](#tool-acl-overrides)) |
 | `idle_timeout` | string | `"adaptive"` | Idle shutdown policy (see [Idle timeout](#idle-timeout)) |
 | `min_idle_timeout` | string | `"1m"` | Minimum idle timeout for adaptive mode |
 | `max_idle_timeout` | string | `"5m"` | Maximum idle timeout for adaptive mode |
@@ -83,6 +85,7 @@ Three variants, distinguished by their fields:
 | `args` | string[] | `[]` | Base arguments prepended to every invocation |
 | `env` | object | `{}` | Environment variables for the CLI process |
 | `tools` | array | `[]` | Preset tool definitions (skips auto-discovery when set) |
+| `tool_acl` | object | `null` | Manual read/write classification overrides (see [Tool ACL overrides](#tool-acl-overrides)) |
 | `idle_timeout` | string | `"adaptive"` | Idle shutdown policy (see [Idle timeout](#idle-timeout)) |
 | `min_idle_timeout` | string | `"1m"` | Minimum idle timeout for adaptive mode |
 | `max_idle_timeout` | string | `"5m"` | Maximum idle timeout for adaptive mode |
@@ -141,6 +144,55 @@ When a backend is shut down due to inactivity, its tools remain visible in `tool
   }
 }
 ```
+
+## Tool ACL overrides
+
+The proxy ships with an automatic classifier that labels every tool of every
+upstream MCP as `read`, `write`, or `ambiguous` (treated as write, fail-safe).
+The classifier is auditable — run `mcp acl classify` to see the verdict,
+confidence, source, and reasons for each tool.
+
+When the classifier is wrong (or when you just want to be explicit),
+add `tool_acl` to any server and pin individual tools to `read` or `write`
+using the same glob syntax as the ACL rules (`*`, prefix, suffix, contains).
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "mcp-grafana",
+      "tool_acl": {
+        "read":  ["get_*", "list_*", "search_*", "find_*", "query_*", "generate_deeplink"],
+        "write": ["update_dashboard", "create_*", "alerting_manage_*"]
+      }
+    },
+    "databricks": {
+      "command": "databricks-mcp",
+      "tool_acl": {
+        "read":  ["execute_sql_read_only", "poll_sql_result"],
+        "write": ["execute_sql"]
+      }
+    }
+  }
+}
+```
+
+Semantics:
+
+- Both `read` and `write` are optional — omit either or both.
+- Overrides run **before** the classifier. A tool that matches an override
+  is never scored.
+- The same pattern string may not appear in both `read` and `write` for the
+  same server — that fails loudly at load time.
+- If two different globs on the same server both match a single tool name
+  (e.g. `get_*` in `read` and `*_thing` in `write` both match `get_thing`),
+  the proxy fails safe to `write` at classification time and logs the
+  conflict. Narrow your globs to avoid this.
+- Overrides are **never cached** — they are re-read from the config on
+  every startup.
+
+For the full redesign plan and the token/description dictionaries the
+classifier uses, see [`docs/acl-redesign-plan.md`](../acl-redesign-plan.md).
 
 ## Type detection
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -9,6 +9,7 @@ These variables configure `mcp` behavior:
 | `MCP_CONFIG_PATH` | `~/.config/mcp/servers.json` | Path to the config file |
 | `MCP_TIMEOUT` | `60` | Timeout in seconds for stdio server responses |
 | `MCP_PROXY_REQUEST_TIMEOUT` | `120` | (proxy mode) Hard upper bound, in seconds, that any single client request can spend inside `mcp serve` before the proxy returns a JSON-RPC error. Acts as a belt-and-suspenders boundary on top of the per-transport `MCP_TIMEOUT`. |
+| `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Path to the persistent tool read/write classification cache (see [`mcp acl classify`](./cli.md#mcp-acl-classify)). Override this in CI/containers that cannot write to `$HOME`. |
 
 ### `MCP_CONFIG_PATH`
 
@@ -35,6 +36,23 @@ Only applies to `mcp serve`. Bounds how long the proxy will wait for any single 
 ```bash
 MCP_PROXY_REQUEST_TIMEOUT=60 mcp serve --http :7332
 ```
+
+### `MCP_CLASSIFIER_CACHE`
+
+Override the path of the tool read/write classification cache. The cache is
+a JSON file populated lazily by `mcp serve` and `mcp acl classify`, keyed
+by `(server, tool, hash(description))`. If the description changes, that
+tool's entry is transparently invalidated.
+
+Useful when `$HOME` is read-only (CI workers, containers) — point the
+cache at an ephemeral path:
+
+```bash
+MCP_CLASSIFIER_CACHE=/tmp/classify.json mcp acl classify
+```
+
+Corrupt or unreadable cache files are non-fatal: a warning is logged and
+the process proceeds with fresh in-memory classifications.
 
 ## Config variables
 

--- a/src/classifier.rs
+++ b/src/classifier.rs
@@ -1,0 +1,657 @@
+//! Tool read/write classifier.
+//!
+//! Pure function over `(tool name, description, input schema, annotations)`.
+//! Produces a [`ToolClassification`] that downstream ACL enforcement will
+//! consume. This module does no I/O — persistence lives in
+//! [`crate::classifier_cache`] and the hot-path wiring in `serve.rs`.
+//!
+//! Decision order (first hit wins):
+//! 1. Manual override in `servers.json` → `Source::Override`
+//! 2. `readOnlyHint` / `destructiveHint` annotations → `Source::Annotation`
+//! 3. Name-token + description-regex + inputSchema scoring → `Source::Classifier`
+//! 4. Fallback `Ambiguous` (fail-safe; downstream treats as write)
+
+use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+
+use crate::config::ToolOverrides;
+use crate::protocol::Tool;
+use crate::server_auth::glob_match;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    Read,
+    Write,
+    Ambiguous,
+}
+
+impl Kind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Kind::Read => "read",
+            Kind::Write => "write",
+            Kind::Ambiguous => "ambiguous",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Source {
+    Override,
+    Annotation,
+    Classifier,
+    Fallback,
+}
+
+impl Source {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Source::Override => "override",
+            Source::Annotation => "annotation",
+            Source::Classifier => "classifier",
+            Source::Fallback => "fallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolClassification {
+    pub kind: Kind,
+    pub confidence: f32,
+    pub source: Source,
+    pub reasons: Vec<String>,
+}
+
+// --- Token dictionaries (from docs/acl-redesign-plan.md §2.3) ---
+
+const READ_TOKENS: &[&str] = &[
+    "get",
+    "list",
+    "search",
+    "find",
+    "query",
+    "read",
+    "fetch",
+    "describe",
+    "show",
+    "view",
+    "inspect",
+    "analyze",
+    "check",
+    "status",
+    "history",
+    "logs",
+    "events",
+    "explain",
+    "diff",
+    "top",
+    "snapshot",
+    "dump",
+    "export",
+    "poll",
+    "info",
+    "stats",
+    "count",
+    "whoami",
+    "version",
+    "resolve",
+    "backlinks",
+];
+
+const WRITE_TOKENS: &[&str] = &[
+    "create", "update", "delete", "remove", "write", "set", "patch", "put", "post", "send",
+    "apply", "execute", "run", "start", "stop", "cancel", "kill", "drop", "insert", "upsert",
+    "modify", "edit", "rename", "move", "copy", "upload", "publish", "deploy", "rollout", "scale",
+    "drain", "cordon", "taint", "exec", "attach", "click", "navigate", "type", "fill", "press",
+    "drag", "reply", "react", "add",
+];
+
+// --- Description regex bundles ---
+
+struct DescPattern {
+    re: regex::Regex,
+    weight: i32,
+    label: &'static str,
+}
+
+static READ_STRONG: LazyLock<Vec<DescPattern>> = LazyLock::new(|| {
+    [
+        (r"(?i)read[\s\-]only", 4, "read-only"),
+        (r"(?i)without modifying", 4, "without modifying"),
+        (r"(?i)does not modify", 4, "does not modify"),
+        (r"(?i)returns information", 3, "returns information"),
+        (r"(?i)\bretrieves\b", 3, "retrieves"),
+        (r"(?i)\bfetches\b", 3, "fetches"),
+    ]
+    .into_iter()
+    .map(|(p, w, l)| DescPattern {
+        re: regex::Regex::new(p).unwrap(),
+        weight: w,
+        label: l,
+    })
+    .collect()
+});
+
+static READ_WEAK: LazyLock<Vec<DescPattern>> = LazyLock::new(|| {
+    [
+        (r"(?i)\blists?\b", 1, "list"),
+        (r"(?i)\bshows?\b", 1, "show"),
+        (r"(?i)\bdescribes?\b", 1, "describe"),
+        (r"(?i)\bsearch(es|ing|ed)?\b", 1, "search"),
+        (r"(?i)\binspects?\b", 1, "inspect"),
+        (r"(?i)\breturns?\b", 1, "returns"),
+        (r"(?i)\bquer(y|ies)\b", 1, "query"),
+    ]
+    .into_iter()
+    .map(|(p, w, l)| DescPattern {
+        re: regex::Regex::new(p).unwrap(),
+        weight: w,
+        label: l,
+    })
+    .collect()
+});
+
+static WRITE_DESC: LazyLock<Vec<DescPattern>> = LazyLock::new(|| {
+    [
+        (r"(?i)\bcreates?\b", -3, "creates"),
+        (r"(?i)\bupdates?\b", -3, "updates"),
+        (r"(?i)\bdeletes?\b", -3, "deletes"),
+        (r"(?i)\bmodif(y|ies)\b", -3, "modifies"),
+        (r"(?i)\bwrites?\b", -3, "writes"),
+        (r"(?i)\bsends?\b", -2, "sends"),
+        (r"(?i)\bexecutes?\b", -3, "executes"),
+        (r"(?i)\bapplies\b", -2, "applies"),
+        (r"(?i)\bremoves?\b", -3, "removes"),
+        (r"(?i)\bpublishes?\b", -2, "publishes"),
+        (r"(?i)\bposts?\b", -2, "posts"),
+        (r"(?i)\buploads?\b", -2, "uploads"),
+    ]
+    .into_iter()
+    .map(|(p, w, l)| DescPattern {
+        re: regex::Regex::new(p).unwrap(),
+        weight: w,
+        label: l,
+    })
+    .collect()
+});
+
+/// Split a tool name into lowercased tokens (handles `_`, `-`, camelCase).
+pub(crate) fn tokenize(name: &str) -> Vec<String> {
+    let mut tokens: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for ch in name.chars() {
+        if ch == '_' || ch == '-' || ch == ' ' || ch == '.' {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current).to_lowercase());
+            }
+        } else if ch.is_ascii_uppercase() && !current.is_empty() {
+            tokens.push(std::mem::take(&mut current).to_lowercase());
+            current.push(ch);
+        } else {
+            current.push(ch);
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current.to_lowercase());
+    }
+    tokens
+}
+
+/// Classify a single tool.
+pub fn classify(tool: &Tool, overrides: Option<&ToolOverrides>) -> ToolClassification {
+    // 1. Manual override — highest priority.
+    if let Some(ov) = overrides {
+        let read_hit = ov.read.iter().any(|p| glob_match(p, &tool.name));
+        let write_hit = ov.write.iter().any(|p| glob_match(p, &tool.name));
+        match (read_hit, write_hit) {
+            (true, true) => {
+                // Conflicting overrides at runtime: fail-safe to write.
+                return ToolClassification {
+                    kind: Kind::Write,
+                    confidence: 1.0,
+                    source: Source::Override,
+                    reasons: vec![format!(
+                        "conflicting override: '{}' matches both read and write → write (fail-safe)",
+                        tool.name
+                    )],
+                };
+            }
+            (true, false) => {
+                return ToolClassification {
+                    kind: Kind::Read,
+                    confidence: 1.0,
+                    source: Source::Override,
+                    reasons: vec![format!("override: '{}' → read", tool.name)],
+                };
+            }
+            (false, true) => {
+                return ToolClassification {
+                    kind: Kind::Write,
+                    confidence: 1.0,
+                    source: Source::Override,
+                    reasons: vec![format!("override: '{}' → write", tool.name)],
+                };
+            }
+            (false, false) => {}
+        }
+    }
+
+    // 2. Protocol annotations.
+    if let Some(ann) = tool.annotations.as_ref() {
+        if ann.read_only_hint == Some(true) {
+            return ToolClassification {
+                kind: Kind::Read,
+                confidence: 0.95,
+                source: Source::Annotation,
+                reasons: vec!["annotation: readOnlyHint=true".to_string()],
+            };
+        }
+        if ann.destructive_hint == Some(true) {
+            return ToolClassification {
+                kind: Kind::Write,
+                confidence: 0.95,
+                source: Source::Annotation,
+                reasons: vec!["annotation: destructiveHint=true".to_string()],
+            };
+        }
+    }
+
+    // 3. Scoring classifier. Positive score → read, negative → write.
+    let mut score: i32 = 0;
+    let mut reasons: Vec<String> = Vec::new();
+
+    // Name tokens
+    for tok in tokenize(&tool.name) {
+        if READ_TOKENS.contains(&tok.as_str()) {
+            score += 1;
+            reasons.push(format!("name token '{tok}' → read (+1)"));
+        } else if WRITE_TOKENS.contains(&tok.as_str()) {
+            score -= 2;
+            reasons.push(format!("name token '{tok}' → write (-2)"));
+        }
+    }
+
+    // Description patterns
+    if let Some(desc) = tool.description.as_deref() {
+        for p in READ_STRONG.iter() {
+            if p.re.is_match(desc) {
+                score += p.weight;
+                reasons.push(format!("desc '{}' → read (+{})", p.label, p.weight));
+            }
+        }
+        for p in READ_WEAK.iter() {
+            if p.re.is_match(desc) {
+                score += p.weight;
+                reasons.push(format!("desc '{}' → read (+{})", p.label, p.weight));
+            }
+        }
+        for p in WRITE_DESC.iter() {
+            if p.re.is_match(desc) {
+                score += p.weight;
+                reasons.push(format!("desc '{}' → write ({})", p.label, p.weight));
+            }
+        }
+    }
+
+    // Input schema hints
+    if let Some(schema) = tool.input_schema.as_ref() {
+        if let Some(props) = schema.get("properties").and_then(|v| v.as_object()) {
+            let mut read_props = 0;
+            let mut write_props = 0;
+            for key in props.keys() {
+                let k = key.to_lowercase();
+                if matches!(
+                    k.as_str(),
+                    "limit" | "offset" | "page" | "cursor" | "filter" | "pattern"
+                ) {
+                    read_props += 1;
+                } else if matches!(k.as_str(), "body" | "content" | "payload") {
+                    write_props += 1;
+                }
+            }
+            if read_props > 0 {
+                score += read_props;
+                reasons.push(format!(
+                    "schema pagination/filter props → read (+{read_props})"
+                ));
+            }
+            if write_props > 0 {
+                score -= write_props;
+                reasons.push(format!(
+                    "schema body/content/payload → write (-{write_props})"
+                ));
+            }
+        }
+    }
+
+    // Decision thresholds. Chosen empirically from the real MCP set in this
+    // repo; tuning is a one-line change.
+    let (kind, source, confidence) = if score >= 2 {
+        let c = (score as f32 / 10.0).clamp(0.5, 1.0);
+        (Kind::Read, Source::Classifier, c)
+    } else if score <= -2 {
+        let c = ((-score) as f32 / 10.0).clamp(0.5, 1.0);
+        (Kind::Write, Source::Classifier, c)
+    } else {
+        reasons.push(format!(
+            "score {score} in undecided band → ambiguous (fail-safe: treat as write)"
+        ));
+        (Kind::Ambiguous, Source::Fallback, 0.0)
+    };
+
+    ToolClassification {
+        kind,
+        confidence,
+        source,
+        reasons,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{Tool, ToolAnnotations};
+    use serde_json::json;
+
+    fn tool(name: &str, desc: Option<&str>) -> Tool {
+        Tool {
+            name: name.to_string(),
+            description: desc.map(String::from),
+            input_schema: None,
+            annotations: None,
+        }
+    }
+
+    // --- Tokenizer ---
+
+    #[test]
+    fn tokenize_underscore() {
+        assert_eq!(
+            tokenize("execute_sql_read_only"),
+            vec!["execute", "sql", "read", "only"]
+        );
+    }
+
+    #[test]
+    fn tokenize_camel_case() {
+        assert_eq!(tokenize("getUserInfo"), vec!["get", "user", "info"]);
+    }
+
+    #[test]
+    fn tokenize_mixed() {
+        assert_eq!(
+            tokenize("gh_pullRequest-list"),
+            vec!["gh", "pull", "request", "list"]
+        );
+    }
+
+    // --- Motivating case from the issue ---
+
+    #[test]
+    fn execute_sql_is_write() {
+        let c = classify(
+            &tool(
+                "execute_sql",
+                Some("Executes a SQL statement against the warehouse."),
+            ),
+            None,
+        );
+        assert_eq!(c.kind, Kind::Write, "reasons={:?}", c.reasons);
+    }
+
+    #[test]
+    fn execute_sql_read_only_is_read() {
+        let c = classify(
+            &tool(
+                "execute_sql_read_only",
+                Some("Runs a read-only SQL query and returns the result set."),
+            ),
+            None,
+        );
+        assert_eq!(c.kind, Kind::Read, "reasons={:?}", c.reasons);
+    }
+
+    // --- Grafana read-heavy tools (real MCP set) ---
+
+    #[test]
+    fn grafana_get_list_query_find_search_are_read() {
+        for name in &[
+            "get_dashboard_by_uid",
+            "list_datasources",
+            "query_prometheus",
+            "find_slow_requests",
+            "search_dashboards",
+            "get_alert_group",
+            "list_loki_label_names",
+        ] {
+            let c = classify(&tool(name, Some("Retrieves data from Grafana.")), None);
+            assert_eq!(c.kind, Kind::Read, "{name} should be read: {:?}", c.reasons);
+        }
+    }
+
+    #[test]
+    fn grafana_write_tools_are_write() {
+        for name in &[
+            "update_dashboard",
+            "create_annotation",
+            "create_incident",
+            "delete_page",
+        ] {
+            let c = classify(&tool(name, Some("Updates or creates a resource.")), None);
+            assert_eq!(
+                c.kind,
+                Kind::Write,
+                "{name} should be write: {:?}",
+                c.reasons
+            );
+        }
+    }
+
+    // --- Annotation source ---
+
+    #[test]
+    fn read_only_hint_wins_over_write_tokens() {
+        let mut t = tool("send_message", Some("Sends a message."));
+        t.annotations = Some(ToolAnnotations {
+            read_only_hint: Some(true),
+            ..Default::default()
+        });
+        let c = classify(&t, None);
+        assert_eq!(c.kind, Kind::Read);
+        assert_eq!(c.source, Source::Annotation);
+    }
+
+    #[test]
+    fn destructive_hint_wins_over_read_tokens() {
+        let mut t = tool("get_thing", Some("Retrieves."));
+        t.annotations = Some(ToolAnnotations {
+            destructive_hint: Some(true),
+            ..Default::default()
+        });
+        let c = classify(&t, None);
+        assert_eq!(c.kind, Kind::Write);
+        assert_eq!(c.source, Source::Annotation);
+    }
+
+    // --- Override source (from config) ---
+
+    #[test]
+    fn override_read_beats_classifier() {
+        let ov = ToolOverrides {
+            read: vec!["execute_sql".to_string()],
+            write: vec![],
+        };
+        let c = classify(&tool("execute_sql", Some("Executes SQL.")), Some(&ov));
+        assert_eq!(c.kind, Kind::Read);
+        assert_eq!(c.source, Source::Override);
+    }
+
+    #[test]
+    fn override_write_beats_classifier() {
+        let ov = ToolOverrides {
+            read: vec![],
+            write: vec!["get_*".to_string()],
+        };
+        let c = classify(&tool("get_thing", Some("Reads.")), Some(&ov));
+        assert_eq!(c.kind, Kind::Write);
+        assert_eq!(c.source, Source::Override);
+    }
+
+    #[test]
+    fn override_glob_matches() {
+        let ov = ToolOverrides {
+            read: vec!["list_*".to_string(), "get_*".to_string()],
+            write: vec![],
+        };
+        let c = classify(&tool("list_repos", None), Some(&ov));
+        assert_eq!(c.kind, Kind::Read);
+    }
+
+    #[test]
+    fn conflicting_override_fails_safe_to_write() {
+        // Cross-glob intersection: read pattern `get_*` and write pattern `*_thing`
+        // both match `get_thing`. Runtime check must NOT trust it as Read.
+        let ov = ToolOverrides {
+            read: vec!["get_*".to_string()],
+            write: vec!["*_thing".to_string()],
+        };
+        let c = classify(&tool("get_thing", None), Some(&ov));
+        assert_eq!(c.kind, Kind::Write);
+        assert_eq!(c.source, Source::Override);
+    }
+
+    // --- Ambiguous fallback ---
+
+    #[test]
+    fn unknown_tool_falls_to_ambiguous() {
+        let c = classify(&tool("foo_bar", None), None);
+        assert_eq!(c.kind, Kind::Ambiguous);
+        assert_eq!(c.source, Source::Fallback);
+    }
+
+    #[test]
+    fn tool_without_description_never_becomes_read_silently() {
+        // Security: a bare tool with no signals must NOT be classified as read.
+        let c = classify(&tool("do_thing", None), None);
+        assert_ne!(c.kind, Kind::Read);
+    }
+
+    // --- InputSchema hints ---
+
+    #[test]
+    fn pagination_props_nudge_to_read() {
+        let mut t = tool("query_things", Some("Runs a query."));
+        t.input_schema = Some(json!({
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer"},
+                "offset": {"type": "integer"},
+                "cursor": {"type": "string"},
+                "filter": {"type": "string"}
+            }
+        }));
+        let c = classify(&t, None);
+        assert_eq!(c.kind, Kind::Read, "{:?}", c.reasons);
+    }
+
+    // --- Real MCP sample set (github, kubectl, sentry, slack, honeycomb, playwright) ---
+
+    #[test]
+    fn kubectl_writes() {
+        for name in &[
+            "kubectl_apply",
+            "kubectl_delete",
+            "kubectl_patch",
+            "kubectl_scale",
+            "kubectl_exec",
+            "kubectl_drain",
+            "kubectl_cordon",
+        ] {
+            let c = classify(&tool(name, Some("Modifies cluster state.")), None);
+            assert_eq!(
+                c.kind,
+                Kind::Write,
+                "{name} should be write: {:?}",
+                c.reasons
+            );
+        }
+    }
+
+    #[test]
+    fn kubectl_reads() {
+        for name in &[
+            "kubectl_get",
+            "kubectl_describe",
+            "kubectl_logs",
+            "kubectl_top",
+            "kubectl_events",
+            "kubectl_explain",
+            "kubectl_api_versions",
+            "kubectl_version",
+        ] {
+            let c = classify(&tool(name, Some("Retrieves information.")), None);
+            assert_eq!(c.kind, Kind::Read, "{name} should be read: {:?}", c.reasons);
+        }
+    }
+
+    #[test]
+    fn sentry_find_and_search_are_read() {
+        for name in &[
+            "find_organizations",
+            "find_projects",
+            "search_events",
+            "search_issues",
+            "search_docs",
+            "get_issue_tag_values",
+            "whoami",
+        ] {
+            let c = classify(&tool(name, Some("Searches Sentry.")), None);
+            assert_eq!(c.kind, Kind::Read, "{name} should be read: {:?}", c.reasons);
+        }
+    }
+
+    #[test]
+    fn playwright_actions_are_write() {
+        for name in &[
+            "browser_click",
+            "browser_navigate",
+            "browser_type",
+            "browser_press_key",
+            "browser_drag",
+            "browser_fill_form",
+        ] {
+            let c = classify(&tool(name, Some("Interacts with the page.")), None);
+            assert_eq!(
+                c.kind,
+                Kind::Write,
+                "{name} should be write: {:?}",
+                c.reasons
+            );
+        }
+    }
+
+    #[test]
+    fn playwright_snapshot_is_read() {
+        let c = classify(
+            &tool("browser_snapshot", Some("Returns a DOM snapshot.")),
+            None,
+        );
+        assert_eq!(c.kind, Kind::Read);
+    }
+
+    #[test]
+    fn slack_writes_vs_reads() {
+        let w = classify(
+            &tool("conversations_mark", Some("Marks a channel as read.")),
+            None,
+        );
+        // "marks" isn't in our token list; "read" is — but "mark" on a channel
+        // mutates state. This is a legitimate ambiguous case — document it.
+        assert_ne!(w.kind, Kind::Read, "mark is ambiguous at best");
+
+        let r = classify(&tool("channels_list", Some("Lists channels.")), None);
+        assert_eq!(r.kind, Kind::Read);
+    }
+}

--- a/src/classifier_cache.rs
+++ b/src/classifier_cache.rs
@@ -1,0 +1,200 @@
+//! Persistent classification cache for tool read/write metadata.
+//!
+//! Lives at `~/.config/mcp/tool-classification.json` by default, or at the
+//! path given by `$MCP_CLASSIFIER_CACHE` (for CI/container use).
+//!
+//! Key format: `server_alias:tool_name:blake2b(description)`. When the
+//! description changes, the cache key changes and the old entry is
+//! transparently replaced.
+//!
+//! Corrupt or unreadable cache is **not fatal**: we log a warning and
+//! proceed with an empty cache. Overrides are never cached — they are
+//! re-read from config on every run.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::classifier::ToolClassification;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ClassifierCache {
+    #[serde(default)]
+    entries: HashMap<String, ToolClassification>,
+    #[serde(skip)]
+    path: PathBuf,
+    #[serde(skip)]
+    dirty: bool,
+}
+
+fn default_cache_path() -> Option<PathBuf> {
+    if let Ok(env) = std::env::var("MCP_CLASSIFIER_CACHE") {
+        return Some(PathBuf::from(env));
+    }
+    crate::config::config_dir()
+        .ok()
+        .map(|d| d.join("tool-classification.json"))
+}
+
+pub fn cache_key(server: &str, tool: &str, description: Option<&str>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(description.unwrap_or("").as_bytes());
+    let hash = hasher.finalize();
+    // First 8 bytes hex is enough — collision within a single (server,tool) is
+    // effectively impossible for any realistic description set.
+    let short: String = hash.iter().take(8).map(|b| format!("{b:02x}")).collect();
+    format!("{server}:{tool}:{short}")
+}
+
+impl ClassifierCache {
+    pub fn load() -> Self {
+        let Some(path) = default_cache_path() else {
+            return Self::default();
+        };
+        if !path.exists() {
+            return Self {
+                path,
+                ..Default::default()
+            };
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(content) => match serde_json::from_str::<ClassifierCache>(&content) {
+                Ok(mut cache) => {
+                    cache.path = path;
+                    cache
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[classifier-cache] warning: cache at {} is corrupt, starting fresh: {e}",
+                        path.display()
+                    );
+                    Self {
+                        path,
+                        ..Default::default()
+                    }
+                }
+            },
+            Err(e) => {
+                eprintln!(
+                    "[classifier-cache] warning: could not read {}: {e}",
+                    path.display()
+                );
+                Self {
+                    path,
+                    ..Default::default()
+                }
+            }
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<&ToolClassification> {
+        self.entries.get(key)
+    }
+
+    pub fn put(&mut self, key: String, value: ToolClassification) {
+        self.entries.insert(key, value);
+        self.dirty = true;
+    }
+
+    /// Persist to disk. No-op if nothing changed or the path is unset.
+    pub fn save(&mut self) {
+        if !self.dirty || self.path.as_os_str().is_empty() {
+            return;
+        }
+        if let Some(parent) = self.path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        match serde_json::to_string_pretty(&self) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(&self.path, json) {
+                    eprintln!(
+                        "[classifier-cache] warning: failed to write {}: {e}",
+                        self.path.display()
+                    );
+                } else {
+                    self.dirty = false;
+                }
+            }
+            Err(e) => {
+                eprintln!("[classifier-cache] warning: failed to serialize cache: {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classifier::{Kind, Source, ToolClassification};
+
+    fn sample() -> ToolClassification {
+        ToolClassification {
+            kind: Kind::Read,
+            confidence: 0.8,
+            source: Source::Classifier,
+            reasons: vec!["name token 'get' → read".to_string()],
+        }
+    }
+
+    #[test]
+    fn key_changes_when_description_changes() {
+        let k1 = cache_key("grafana", "get_thing", Some("returns data"));
+        let k2 = cache_key("grafana", "get_thing", Some("returns NEW data"));
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn key_stable_for_same_description() {
+        let k1 = cache_key("grafana", "get_thing", Some("x"));
+        let k2 = cache_key("grafana", "get_thing", Some("x"));
+        assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("roundtrip.json");
+        // Serial access to avoid env var races with the other cache tests.
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_CLASSIFIER_CACHE", &path);
+
+        let mut cache = ClassifierCache::load();
+        cache.put("k1".to_string(), sample());
+        cache.save();
+
+        let reloaded = ClassifierCache::load();
+        let got = reloaded.get("k1").unwrap();
+        assert_eq!(got.kind, Kind::Read);
+        assert_eq!(got.source, Source::Classifier);
+
+        std::env::remove_var("MCP_CLASSIFIER_CACHE");
+    }
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn corrupt_cache_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("corrupt.json");
+        std::fs::write(&path, "this is not json {{{").unwrap();
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_CLASSIFIER_CACHE", &path);
+
+        let cache = ClassifierCache::load();
+        assert!(cache.get("anything").is_none());
+
+        std::env::remove_var("MCP_CLASSIFIER_CACHE");
+    }
+
+    #[test]
+    fn missing_cache_starts_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_CLASSIFIER_CACHE", &path);
+        let cache = ClassifierCache::load();
+        assert!(cache.get("anything").is_none());
+        std::env::remove_var("MCP_CLASSIFIER_CACHE");
+    }
+}

--- a/src/classifier_cache.rs
+++ b/src/classifier_cache.rs
@@ -3,7 +3,7 @@
 //! Lives at `~/.config/mcp/tool-classification.json` by default, or at the
 //! path given by `$MCP_CLASSIFIER_CACHE` (for CI/container use).
 //!
-//! Key format: `server_alias:tool_name:blake2b(description)`. When the
+//! Key format: `server_alias:tool_name:sha256(description+annotations)`. When the
 //! description changes, the cache key changes and the old entry is
 //! transparently replaced.
 //!
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::classifier::ToolClassification;
+use crate::protocol::ToolAnnotations;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ClassifierCache {
@@ -37,9 +38,24 @@ fn default_cache_path() -> Option<PathBuf> {
         .map(|d| d.join("tool-classification.json"))
 }
 
-pub fn cache_key(server: &str, tool: &str, description: Option<&str>) -> String {
+pub fn cache_key(
+    server: &str,
+    tool: &str,
+    description: Option<&str>,
+    annotations: Option<&ToolAnnotations>,
+) -> String {
     let mut hasher = Sha256::new();
     hasher.update(description.unwrap_or("").as_bytes());
+    // Include annotations so that changes to readOnlyHint/destructiveHint
+    // invalidate the cache entry even when the description is unchanged.
+    if let Some(ann) = annotations {
+        if let Some(v) = ann.read_only_hint {
+            hasher.update(if v { b"ro:1" } else { b"ro:0" });
+        }
+        if let Some(v) = ann.destructive_hint {
+            hasher.update(if v { b"dh:1" } else { b"dh:0" });
+        }
+    }
     let hash = hasher.finalize();
     // First 8 bytes hex is enough — collision within a single (server,tool) is
     // effectively impossible for any realistic description set.
@@ -139,16 +155,35 @@ mod tests {
 
     #[test]
     fn key_changes_when_description_changes() {
-        let k1 = cache_key("grafana", "get_thing", Some("returns data"));
-        let k2 = cache_key("grafana", "get_thing", Some("returns NEW data"));
+        let k1 = cache_key("grafana", "get_thing", Some("returns data"), None);
+        let k2 = cache_key("grafana", "get_thing", Some("returns NEW data"), None);
         assert_ne!(k1, k2);
     }
 
     #[test]
     fn key_stable_for_same_description() {
-        let k1 = cache_key("grafana", "get_thing", Some("x"));
-        let k2 = cache_key("grafana", "get_thing", Some("x"));
+        let k1 = cache_key("grafana", "get_thing", Some("x"), None);
+        let k2 = cache_key("grafana", "get_thing", Some("x"), None);
         assert_eq!(k1, k2);
+    }
+
+    #[test]
+    fn key_changes_when_annotations_change() {
+        use crate::protocol::ToolAnnotations;
+        let ann_ro = ToolAnnotations {
+            read_only_hint: Some(true),
+            ..Default::default()
+        };
+        let ann_dh = ToolAnnotations {
+            destructive_hint: Some(true),
+            ..Default::default()
+        };
+        let k_none = cache_key("s", "t", Some("d"), None);
+        let k_ro = cache_key("s", "t", Some("d"), Some(&ann_ro));
+        let k_dh = cache_key("s", "t", Some("d"), Some(&ann_dh));
+        assert_ne!(k_none, k_ro);
+        assert_ne!(k_none, k_dh);
+        assert_ne!(k_ro, k_dh);
     }
 
     #[test]

--- a/src/cli_discovery.rs
+++ b/src/cli_discovery.rs
@@ -381,6 +381,7 @@ fn build_tool(name: &str, description: &str, flags: &[Flag]) -> Tool {
             Some(description.to_string())
         },
         input_schema: Some(schema),
+        annotations: None,
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -45,6 +45,7 @@ impl McpClient {
                             name: t.name.clone(),
                             description: t.description.clone(),
                             input_schema: t.input_schema.clone(),
+                            annotations: None,
                         }
                     })
                     .collect();

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,19 @@ pub fn parse_duration_str(s: &str) -> Option<Duration> {
 pub const DEFAULT_MIN_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 pub const DEFAULT_MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 
+/// Per-server manual classification overrides for tools.
+/// Glob patterns follow the same syntax as `server_auth::acl::glob_match`.
+/// Both fields are optional; if a tool name matches an override glob, the
+/// classifier is bypassed for it. A tool name matching **both** `read` and
+/// `write` is a configuration error and is rejected at load time.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ToolOverrides {
+    #[serde(default)]
+    pub read: Vec<String>,
+    #[serde(default)]
+    pub write: Vec<String>,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct CliToolConfig {
     pub name: String,
@@ -72,6 +85,8 @@ pub enum ServerConfig {
         #[serde(default)]
         tools: Vec<CliToolConfig>,
         #[serde(default)]
+        tool_acl: Option<ToolOverrides>,
+        #[serde(default)]
         idle_timeout: IdleTimeoutPolicy,
         #[serde(default)]
         min_idle_timeout: Option<String>,
@@ -85,6 +100,8 @@ pub enum ServerConfig {
         #[serde(default)]
         env: HashMap<String, String>,
         #[serde(default)]
+        tool_acl: Option<ToolOverrides>,
+        #[serde(default)]
         idle_timeout: IdleTimeoutPolicy,
         #[serde(default)]
         min_idle_timeout: Option<String>,
@@ -95,6 +112,8 @@ pub enum ServerConfig {
         url: String,
         #[serde(default)]
         headers: HashMap<String, String>,
+        #[serde(default)]
+        tool_acl: Option<ToolOverrides>,
         #[serde(default)]
         idle_timeout: IdleTimeoutPolicy,
         #[serde(default)]
@@ -135,6 +154,14 @@ impl ServerConfig {
         };
         raw.and_then(parse_duration_str)
             .unwrap_or(DEFAULT_MIN_IDLE_TIMEOUT)
+    }
+
+    pub fn tool_acl(&self) -> Option<&ToolOverrides> {
+        match self {
+            ServerConfig::Cli { tool_acl, .. } => tool_acl.as_ref(),
+            ServerConfig::Stdio { tool_acl, .. } => tool_acl.as_ref(),
+            ServerConfig::Http { tool_acl, .. } => tool_acl.as_ref(),
+        }
     }
 
     pub fn max_idle_timeout(&self) -> Duration {
@@ -317,6 +344,9 @@ pub fn load_config_from_path(path: &PathBuf) -> Result<Config> {
                 );
             }
         }
+        if let Some(overrides) = config.tool_acl() {
+            validate_tool_overrides(name, overrides)?;
+        }
     }
 
     let server_auth: ServerAuthConfig = raw
@@ -349,6 +379,25 @@ fn substitute_env_vars(input: &str) -> String {
         std::env::var(var_name).unwrap_or_default()
     })
     .to_string()
+}
+
+/// Reject `tool_acl` configs where a single pattern (or one exactly equal
+/// pattern) appears in both `read` and `write`. This catches the obvious
+/// typo-class footgun at load time. Full cross-glob intersection analysis
+/// isn't worth the complexity — the classifier runtime check below still
+/// fires if a real tool name happens to match both lists.
+fn validate_tool_overrides(
+    server_name: &str,
+    overrides: &crate::config::ToolOverrides,
+) -> Result<()> {
+    for r in &overrides.read {
+        if overrides.write.iter().any(|w| w == r) {
+            anyhow::bail!(
+                "server '{server_name}': tool_acl pattern '{r}' appears in both 'read' and 'write'"
+            );
+        }
+    }
+    Ok(())
 }
 
 pub fn validate_server_names(config: &Config) -> Vec<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod audit;
 mod auth;
 mod cache;
+mod classifier;
+mod classifier_cache;
 mod cli_discovery;
 mod client;
 mod config;
@@ -50,6 +52,9 @@ fn print_usage() {
     eprintln!("  mcp logs --errors                   Show only failures");
     eprintln!("  mcp logs --since <duration>         Filter by time (5m, 1h, 24h, 7d)");
     eprintln!("  mcp logs -f                         Follow mode (streams new entries live)");
+    eprintln!("  mcp acl classify                    Classify tools as read/write");
+    eprintln!("  mcp acl classify --server <alias>   Classify tools for one backend");
+    eprintln!("  mcp acl classify --format json      Emit classification as JSON");
     eprintln!();
     eprintln!("Flags:");
     eprintln!("  --json                              Force JSON output");
@@ -212,6 +217,9 @@ async fn run() -> Result<()> {
         "logs" => {
             return handle_logs_command(&args[1..], &cfg, fmt, db_pool.clone()).await;
         }
+        "acl" => {
+            return handle_acl_command(&args[1..], &cfg, fmt).await;
+        }
         _ => {}
     }
 
@@ -281,6 +289,139 @@ async fn handle_logs_follow(
         }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
+}
+
+/// `mcp acl classify [--server <alias>] [--format table|json]`
+///
+/// Connects to each configured backend (or one named via --server), runs
+/// `tools/list`, and classifies each tool via `classifier::classify`.
+/// No HTTP listener, no ACL enforcement — this is the inspection path that
+/// validates the classifier itself (issue #54).
+async fn handle_acl_command(
+    args: &[String],
+    cfg: &config::Config,
+    fmt: OutputFormat,
+) -> Result<()> {
+    let sub = args.first().map(String::as_str).ok_or_else(|| {
+        anyhow::anyhow!("usage: mcp acl classify [--server <alias>] [--format table|json]")
+    })?;
+    if sub != "classify" {
+        bail!("unknown acl subcommand: {sub} (did you mean 'classify'?)");
+    }
+
+    // Parse flags
+    let mut server_filter: Option<String> = None;
+    let mut format_override: Option<String> = None;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--server" => {
+                server_filter = args.get(i + 1).cloned();
+                i += 2;
+            }
+            "--format" => {
+                format_override = args.get(i + 1).cloned();
+                i += 2;
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+    let use_json = match format_override.as_deref() {
+        Some("json") => true,
+        Some("table") => false,
+        Some(other) => bail!("unknown --format: {other} (expected 'table' or 'json')"),
+        None => matches!(fmt, OutputFormat::Json),
+    };
+
+    // Pick servers to classify.
+    let targets: Vec<(&String, &config::ServerConfig)> = match &server_filter {
+        Some(name) => {
+            let cfg_entry = cfg
+                .servers
+                .get(name)
+                .ok_or_else(|| anyhow::anyhow!("server \"{name}\" not found in config"))?;
+            vec![(name, cfg_entry)]
+        }
+        None => cfg.servers.iter().collect(),
+    };
+
+    #[derive(serde::Serialize)]
+    struct Row {
+        server: String,
+        tool: String,
+        kind: &'static str,
+        confidence: f32,
+        source: &'static str,
+        reasons: Vec<String>,
+    }
+
+    let mut rows: Vec<Row> = Vec::new();
+
+    for (name, server_config) in targets {
+        if !use_json {
+            eprintln!("[acl] listing tools from {name}...");
+        }
+        let client = match client::McpClient::connect(server_config).await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("[acl] {name}: failed to connect: {e:#}");
+                continue;
+            }
+        };
+        let tools = match client.list_tools().await {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("[acl] {name}: failed to list tools: {e:#}");
+                let _ = client.shutdown().await;
+                continue;
+            }
+        };
+        let overrides = server_config.tool_acl();
+        for tool in &tools {
+            let c = classifier::classify(tool, overrides);
+            rows.push(Row {
+                server: name.clone(),
+                tool: tool.name.clone(),
+                kind: c.kind.as_str(),
+                confidence: c.confidence,
+                source: c.source.as_str(),
+                reasons: c.reasons,
+            });
+        }
+        let _ = client.shutdown().await;
+    }
+
+    // Stable ordering.
+    rows.sort_by(|a, b| a.server.cmp(&b.server).then(a.tool.cmp(&b.tool)));
+
+    if use_json {
+        println!("{}", serde_json::to_string_pretty(&rows)?);
+        return Ok(());
+    }
+
+    // Table output. Highlight Ambiguous with a `[!]` prefix for easy grep.
+    println!(
+        "{:<20} {:<40} {:<10} {:<6} {:<11} reasons",
+        "SERVER", "TOOL", "KIND", "CONF", "SOURCE"
+    );
+    for r in &rows {
+        let flag = if r.kind == "ambiguous" { "[!]" } else { "   " };
+        let reasons = if r.reasons.is_empty() {
+            String::new()
+        } else {
+            r.reasons.join("; ")
+        };
+        println!(
+            "{flag} {server:<16} {tool:<40} {kind:<10} {conf:<6.2} {source:<11} {reasons}",
+            server = r.server,
+            tool = r.tool,
+            kind = r.kind,
+            conf = r.confidence,
+            source = r.source,
+        );
+    }
+
+    Ok(())
 }
 
 async fn handle_server_command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,17 +310,26 @@ async fn handle_acl_command(
     }
 
     // Parse flags
+    let usage = "usage: mcp acl classify [--server <alias>] [--format table|json]";
     let mut server_filter: Option<String> = None;
     let mut format_override: Option<String> = None;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
             "--server" => {
-                server_filter = args.get(i + 1).cloned();
+                let value = args
+                    .get(i + 1)
+                    .filter(|v| !v.starts_with("--"))
+                    .ok_or_else(|| anyhow::anyhow!("{usage}"))?;
+                server_filter = Some(value.clone());
                 i += 2;
             }
             "--format" => {
-                format_override = args.get(i + 1).cloned();
+                let value = args
+                    .get(i + 1)
+                    .filter(|v| !v.starts_with("--"))
+                    .ok_or_else(|| anyhow::anyhow!("{usage}"))?;
+                format_override = Some(value.clone());
                 i += 2;
             }
             other => bail!("unknown flag: {other}"),
@@ -356,6 +365,7 @@ async fn handle_acl_command(
     }
 
     let mut rows: Vec<Row> = Vec::new();
+    let mut cache = classifier_cache::ClassifierCache::load();
 
     for (name, server_config) in targets {
         if !use_json {
@@ -377,8 +387,25 @@ async fn handle_acl_command(
             }
         };
         let overrides = server_config.tool_acl();
+        let has_overrides = overrides.is_some_and(|o| !o.read.is_empty() || !o.write.is_empty());
         for tool in &tools {
-            let c = classifier::classify(tool, overrides);
+            let c = if has_overrides {
+                classifier::classify(tool, overrides)
+            } else {
+                let key = classifier_cache::cache_key(
+                    name,
+                    &tool.name,
+                    tool.description.as_deref(),
+                    tool.annotations.as_ref(),
+                );
+                if let Some(cached) = cache.get(&key).cloned() {
+                    cached
+                } else {
+                    let c = classifier::classify(tool, None);
+                    cache.put(key, c.clone());
+                    c
+                }
+            };
             rows.push(Row {
                 server: name.clone(),
                 tool: tool.name.clone(),
@@ -390,6 +417,8 @@ async fn handle_acl_command(
         }
         let _ = client.shutdown().await;
     }
+
+    cache.save();
 
     // Stable ordering.
     rows.sort_by(|a, b| a.server.cmp(&b.server).then(a.tool.cmp(&b.tool)));

--- a/src/output.rs
+++ b/src/output.rs
@@ -619,6 +619,7 @@ mod tests {
                 command: "echo".to_string(),
                 args: vec!["hello".to_string()],
                 env: HashMap::new(),
+                tool_acl: None,
                 idle_timeout: Default::default(),
                 min_idle_timeout: None,
                 max_idle_timeout: None,
@@ -629,6 +630,7 @@ mod tests {
             ServerConfig::Http {
                 url: "https://example.com/mcp".to_string(),
                 headers: HashMap::new(),
+                tool_acl: None,
                 idle_timeout: Default::default(),
                 min_idle_timeout: None,
                 max_idle_timeout: None,
@@ -651,6 +653,7 @@ mod tests {
             ServerConfig::Http {
                 url: "https://mcp.sentry.dev/sse".to_string(),
                 headers: HashMap::new(),
+                tool_acl: None,
                 idle_timeout: Default::default(),
                 min_idle_timeout: None,
                 max_idle_timeout: None,
@@ -662,6 +665,7 @@ mod tests {
                 command: "npx".to_string(),
                 args: vec!["-y".to_string(), "slack-mcp-server".to_string()],
                 env: HashMap::new(),
+                tool_acl: None,
                 idle_timeout: Default::default(),
                 min_idle_timeout: None,
                 max_idle_timeout: None,
@@ -673,6 +677,7 @@ mod tests {
                 command: "uvx".to_string(),
                 args: vec![],
                 env: HashMap::new(),
+                tool_acl: None,
                 idle_timeout: Default::default(),
                 min_idle_timeout: None,
                 max_idle_timeout: None,
@@ -689,6 +694,7 @@ mod tests {
             name: "search".to_string(),
             description: Some("Search things".to_string()),
             input_schema: None,
+            annotations: None,
         }];
         print_tools_json(&tools).unwrap();
     }
@@ -705,11 +711,13 @@ mod tests {
                 name: "search_issues".to_string(),
                 description: Some("Search for issues in Sentry".to_string()),
                 input_schema: None,
+                annotations: None,
             },
             Tool {
                 name: "ping".to_string(),
                 description: None,
                 input_schema: None,
+                annotations: None,
             },
         ];
         print_tools_text(&tools).unwrap();
@@ -735,6 +743,7 @@ mod tests {
                 },
                 "required": ["query"]
             })),
+            annotations: None,
         }];
         print_tools_info_text(&tools).unwrap();
     }
@@ -745,6 +754,7 @@ mod tests {
             name: "ping".to_string(),
             description: None,
             input_schema: None,
+            annotations: None,
         }];
         print_tools_info_text(&tools).unwrap();
     }
@@ -764,6 +774,7 @@ mod tests {
                 "properties": {"q": {"type": "string"}},
                 "required": ["q"]
             })),
+            annotations: None,
         }];
         print_tools_info_json(&tools).unwrap();
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -109,7 +109,35 @@ pub struct ClientInfo {
 
 // --- MCP Tools ---
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct ToolAnnotations {
+    #[serde(
+        default,
+        rename = "readOnlyHint",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub read_only_hint: Option<bool>,
+    #[serde(
+        default,
+        rename = "destructiveHint",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub destructive_hint: Option<bool>,
+    #[serde(
+        default,
+        rename = "idempotentHint",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub idempotent_hint: Option<bool>,
+    #[serde(
+        default,
+        rename = "openWorldHint",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub open_world_hint: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
 pub struct Tool {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -120,6 +148,8 @@ pub struct Tool {
         skip_serializing_if = "Option::is_none"
     )]
     pub input_schema: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ToolAnnotations>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -8,6 +8,8 @@ use tokio::sync::Mutex;
 
 use crate::audit::{AuditEntry, AuditLogger};
 use crate::cache::{BackendToolCache, ToolCacheStore};
+use crate::classifier::{classify, Kind, ToolClassification};
+use crate::classifier_cache::{cache_key, ClassifierCache};
 use crate::client::McpClient;
 use crate::config::{parse_duration_str, Config, IdleTimeoutPolicy, ServerConfig};
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse, Tool, PROTOCOL_VERSION};
@@ -131,6 +133,13 @@ struct ProxyServer {
     backends: HashMap<String, BackendState>,
     tool_map: HashMap<String, (String, String)>, // namespaced -> (server, original_name)
     tools: Vec<Tool>,
+    /// Per-tool read/write classification, keyed by namespaced tool name.
+    /// Populated after each successful `tools/list` from an upstream and
+    /// consumed by future ACL enforcement (issue #54 only produces it).
+    classifications: HashMap<String, ToolClassification>,
+    /// Persistent classifier cache. Loaded at startup, saved after each
+    /// successful discovery batch. Overrides are never cached.
+    classifier_cache: ClassifierCache,
     audit: Arc<AuditLogger>,
     /// Tracks which backends have been successfully discovered.
     discovered_backends: std::collections::HashSet<String>,
@@ -166,6 +175,8 @@ impl ProxyServer {
             backends: HashMap::new(),
             tool_map: HashMap::new(),
             tools: Vec::new(),
+            classifications: HashMap::new(),
+            classifier_cache: ClassifierCache::load(),
             audit,
             discovered_backends: std::collections::HashSet::new(),
             discovery_failures: HashMap::new(),
@@ -186,6 +197,11 @@ impl ProxyServer {
     }
 
     fn register_tools(&mut self, server_name: &str, tools: &[Tool]) {
+        let overrides = self
+            .configs
+            .get(server_name)
+            .and_then(|c| c.tool_acl())
+            .cloned();
         for tool in tools {
             let namespaced = format!("{server_name}{SEPARATOR}{}", tool.name);
             let description = match &tool.description {
@@ -196,10 +212,35 @@ impl ProxyServer {
                 namespaced.clone(),
                 (server_name.to_string(), tool.name.clone()),
             );
+            // Classify against raw tool (with annotations + original description).
+            // Consult the persistent cache first — overrides are NEVER cached,
+            // so re-classify when an override is defined for this server.
+            let classification = if overrides.is_none() {
+                let key = cache_key(server_name, &tool.name, tool.description.as_deref());
+                if let Some(cached) = self.classifier_cache.get(&key).cloned() {
+                    cached
+                } else {
+                    let c = classify(tool, None);
+                    self.classifier_cache.put(key, c.clone());
+                    c
+                }
+            } else {
+                classify(tool, overrides.as_ref())
+            };
+            if classification.kind == Kind::Ambiguous {
+                eprintln!(
+                    "[serve] {server_name}:{tool_name}: classification ambiguous → treated as write (reasons: {reasons})",
+                    tool_name = tool.name,
+                    reasons = classification.reasons.join("; "),
+                );
+            }
+            self.classifications
+                .insert(namespaced.clone(), classification);
             self.tools.push(Tool {
                 name: namespaced,
                 description,
                 input_schema: tool.input_schema.clone(),
+                annotations: tool.annotations.clone(),
             });
         }
     }
@@ -208,6 +249,7 @@ impl ProxyServer {
         let prefix = format!("{server_name}{SEPARATOR}");
         self.tools.retain(|t| !t.name.starts_with(&prefix));
         self.tool_map.retain(|k, _| !k.starts_with(&prefix));
+        self.classifications.retain(|k, _| !k.starts_with(&prefix));
     }
 
     /// Collect cached tools for a server from the current tool list (for storing in Disconnected state).
@@ -266,6 +308,7 @@ impl ProxyServer {
                         name: original_name,
                         description: original_desc,
                         input_schema: t.input_schema.clone(),
+                        annotations: t.annotations.clone(),
                     }
                 })
                 .collect();
@@ -674,6 +717,12 @@ async fn discover_pending_backends(proxy: &SharedProxy) {
     };
     for (name, entry) in &cache_entries {
         cache_store.save_backend(name, entry);
+    }
+
+    // Persist classifier cache (fresh entries from register_tools).
+    {
+        let mut p = proxy.lock().await;
+        p.classifier_cache.save();
     }
 }
 
@@ -1529,6 +1578,7 @@ mod tests {
             name: "search_issues".to_string(),
             description: Some("Search for issues".to_string()),
             input_schema: None,
+            annotations: None,
         };
 
         let server_name = "sentry";
@@ -1591,6 +1641,7 @@ mod tests {
             name: "sentry__search_issues".to_string(),
             description: Some("[sentry] Search for issues".to_string()),
             input_schema: None,
+            annotations: None,
         });
         server.tool_map.insert(
             "sentry__search_issues".to_string(),
@@ -1812,11 +1863,13 @@ mod tests {
             name: "sentry__search_issues".to_string(),
             description: Some("[sentry] Search".to_string()),
             input_schema: None,
+            annotations: None,
         });
         server.tools.push(Tool {
             name: "slack__send_message".to_string(),
             description: Some("[slack] Send".to_string()),
             input_schema: None,
+            annotations: None,
         });
 
         let acl = Some(AclConfig {
@@ -1988,11 +2041,13 @@ mod tests {
                 name: "search".to_string(),
                 description: Some("Search stuff".to_string()),
                 input_schema: None,
+                annotations: None,
             },
             Tool {
                 name: "create".to_string(),
                 description: None,
                 input_schema: None,
+                annotations: None,
             },
         ];
 
@@ -2009,6 +2064,7 @@ mod tests {
                 name: "send".to_string(),
                 description: Some("Send msg".to_string()),
                 input_schema: None,
+                annotations: None,
             }],
         );
         assert_eq!(server.tools.len(), 3);
@@ -2029,6 +2085,7 @@ mod tests {
                 name: "search".to_string(),
                 description: Some("Search".to_string()),
                 input_schema: None,
+                annotations: None,
             }],
         );
         server.register_tools(
@@ -2037,6 +2094,7 @@ mod tests {
                 name: "send".to_string(),
                 description: Some("Send".to_string()),
                 input_schema: None,
+                annotations: None,
             }],
         );
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -201,6 +201,7 @@ impl ProxyServer {
             .configs
             .get(server_name)
             .and_then(|c| c.tool_acl())
+            .filter(|o| !o.read.is_empty() || !o.write.is_empty())
             .cloned();
         for tool in tools {
             let namespaced = format!("{server_name}{SEPARATOR}{}", tool.name);
@@ -216,7 +217,12 @@ impl ProxyServer {
             // Consult the persistent cache first — overrides are NEVER cached,
             // so re-classify when an override is defined for this server.
             let classification = if overrides.is_none() {
-                let key = cache_key(server_name, &tool.name, tool.description.as_deref());
+                let key = cache_key(
+                    server_name,
+                    &tool.name,
+                    tool.description.as_deref(),
+                    tool.annotations.as_ref(),
+                );
                 if let Some(cached) = self.classifier_cache.get(&key).cloned() {
                     cached
                 } else {
@@ -935,7 +941,10 @@ async fn connect_backend(proxy: &SharedProxy, server_name: &str) -> Result<Arc<M
 
     let prev = {
         let mut p = proxy.lock().await;
-        p.install_client(server_name, Arc::clone(&client), &tools)
+        let prev = p.install_client(server_name, Arc::clone(&client), &tools);
+        // Persist new classifications from register_tools.
+        p.classifier_cache.save();
+        prev
     };
 
     // Shut down any displaced previous client outside the lock.

--- a/src/server_auth/acl.rs
+++ b/src/server_auth/acl.rs
@@ -70,7 +70,7 @@ fn matches_tool(tool_name: &str, patterns: &[String]) -> bool {
 
 /// Glob matching: supports `*` as wildcard for any characters.
 /// Handles multiple wildcards (e.g., `*admin*`, `foo*bar*baz`).
-fn glob_match(pattern: &str, value: &str) -> bool {
+pub(crate) fn glob_match(pattern: &str, value: &str) -> bool {
     let segments: Vec<&str> = pattern.split('*').collect();
 
     if segments.len() == 1 {

--- a/src/server_auth/mod.rs
+++ b/src/server_auth/mod.rs
@@ -1,6 +1,7 @@
 mod acl;
 mod providers;
 
+pub(crate) use acl::glob_match;
 pub use acl::AclConfig;
 pub use providers::{BearerTokenAuth, ForwardedUserAuth, NoAuth};
 

--- a/src/transport/cli.rs
+++ b/src/transport/cli.rs
@@ -409,6 +409,7 @@ mod tests {
                     name: format!("{command}_test"),
                     description: Some("test tool".to_string()),
                     input_schema: None,
+                    annotations: None,
                 }],
                 subcommand_map: HashMap::from([(format!("{command}_test"), "test".to_string())]),
                 discovered: true,
@@ -533,6 +534,7 @@ mod tests {
                     name: "kubectl_api_versions".to_string(),
                     description: Some("Print API versions".to_string()),
                     input_schema: None,
+                    annotations: None,
                 }],
                 subcommand_map: HashMap::from([(
                     "kubectl_api_versions".to_string(),


### PR DESCRIPTION
The proxy needs to know whether each upstream MCP tool is a read or a write before ACL enforcement can express rules like "dev can read grafana but not write". MCP's readOnlyHint/destructiveHint are rarely populated, and a pure name-prefix heuristic fails dangerously on cases like execute_sql vs execute_sql_read_only.

Ship a pure classifier that combines manual tool_acl overrides in servers.json, protocol annotations, and a score from name tokens, description regexes, and input schema hints (threshold +-2, ambiguous falls back to write). Hook it into ProxyServer::register_tools with a persistent cache at ~/.config/mcp/tool-classification.json (overridable via MCP_CLASSIFIER_CACHE for CI), log WARN on ambiguous tools, and expose everything through `mcp acl classify` for auditing. No enforcement yet — this issue only produces the metadata the next one will consume.

fixed: #54