### PR TITLE
Add role-based ACL with union evaluation and read/write enforcement

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -187,6 +187,35 @@ Each entry in `tokens` supports two shapes:
 
 Both forms can coexist in the same config file.
 
+#### Role-based ACL (recommended for new setups)
+
+```json
+{
+  "mcpServers": { ... },
+  "serverAuth": {
+    "provider": "bearer",
+    "bearer": {
+      "tokens": {
+        "tok-alice": { "subject": "alice", "roles": ["admin"] },
+        "tok-bob": { "subject": "bob", "roles": ["dev"] }
+      }
+    },
+    "acl": {
+      "default": "deny",
+      "roles": {
+        "admin": [{ "server": "*", "access": "*" }],
+        "dev": [
+          { "server": ["github", "grafana"], "access": "read" },
+          { "server": "github", "access": "write", "tools": ["gh_pr", "gh_issue"] }
+        ]
+      }
+    }
+  }
+}
+```
+
+See [proxy mode ACL docs](proxy-mode.md#access-control-acl) for the full schema, access expansion table, and evaluation model.
+
 ### Available providers
 
 | Provider | Use case |
@@ -217,4 +246,9 @@ Groups header value is parsed as a comma-separated list: each entry is trimmed a
 
 ### Access control (ACL)
 
-Rules control which authenticated users can access which tools. Rules are evaluated in order — first match wins. Tool patterns support full glob matching with `*` wildcards (prefix, suffix, contains, and multiple). See [proxy mode ACL docs](proxy-mode.md#access-control-acl) for the full rule syntax.
+The ACL controls which authenticated users can access which tools. It supports two schemas:
+
+- **Role-based** (recommended) — define reusable roles with server-aware, read/write-aware grants. Evaluation is union-based and order-independent. Deny always wins.
+- **Legacy** — flat rules list with first-match-wins semantics, fully backward compatible.
+
+See [proxy mode ACL docs](proxy-mode.md#access-control-acl) for the full schema reference and examples.

--- a/docs/guides/proxy-mode.md
+++ b/docs/guides/proxy-mode.md
@@ -496,7 +496,11 @@ Trusts a reverse proxy header (e.g. `X-Forwarded-User`). Only use behind a trust
 
 ### Access control (ACL)
 
-Control which users can access which tools using glob patterns:
+The ACL supports two schemas: a **role-based schema** (recommended) and a **legacy schema** (for backward compatibility). Detection is automatic based on the JSON keys present.
+
+#### Role-based schema (recommended)
+
+Define reusable roles with server-aware, read/write-aware grants:
 
 ```json
 {
@@ -505,25 +509,98 @@ Control which users can access which tools using glob patterns:
     "provider": "bearer",
     "bearer": {
       "tokens": {
-        "tok-alice": "alice",
-        "tok-bob": "bob"
+        "tok-alice": { "subject": "alice", "roles": ["admin"] },
+        "tok-bob": { "subject": "bob", "roles": ["dev"] },
+        "tok-charlie": { "subject": "charlie", "roles": ["readonly"] }
       }
     },
     "acl": {
-      "default": "allow",
-      "rules": [
-        { "subjects": ["bob"], "tools": ["sentry__*"], "policy": "deny" },
-        { "subjects": ["bob"], "tools": ["*admin*"], "policy": "deny" },
-        { "roles": ["admin"], "tools": ["*"], "policy": "allow" }
-      ]
+      "default": "deny",
+      "strictClassification": false,
+      "roles": {
+        "admin":    [{ "server": "*", "access": "*" }],
+        "dev": [
+          { "server": ["github", "grafana"], "access": "read" },
+          { "server": "github", "access": "write", "tools": ["gh_pr", "gh_issue"] }
+        ],
+        "readonly": [{ "server": "*", "access": "read" }]
+      },
+      "subjects": {
+        "charlie": {
+          "roles": ["readonly"],
+          "extra": [{ "server": "sentry", "access": "read" }]
+        }
+      }
     }
   }
 }
 ```
 
-Rules are evaluated in order — first match wins. If no rule matches, the default policy applies.
+**How it works:**
 
-ACL fields:
+- **`roles`** — Map of role name to a list of grants. Roles are reusable and referenced by subjects.
+- **`subjects`** — Map of subject identifier to `{ roles, extra }`. Roles reference entries in the top-level `roles` map. `extra` is a per-subject list of additional grants.
+- **Evaluation is union-based** — collect all grants from all roles the identity has (token roles + subject config roles + extra). If any grant with `deny: true` matches, access is denied. Otherwise, if any allow grant matches, access is allowed. No match falls back to `default`.
+- **Order doesn't matter** — unlike the legacy schema, rules are not position-sensitive.
+
+**Grant fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `server` | string or string[] | Server alias(es) to match. `"*"` matches any server. |
+| `access` | `"read"` \| `"write"` \| `"*"` | Access level (see below) |
+| `tools` | string[] | Optional tool name globs to narrow the grant. Empty = all tools. |
+| `resources` | string[] | Optional (parsed, not enforced yet) |
+| `prompts` | string[] | Optional (parsed, not enforced yet) |
+| `deny` | bool | If `true`, turns this into an explicit deny that always wins over allows |
+
+**Access expansion:**
+
+The `access` field interacts with the tool classifier (read/write/ambiguous):
+
+| `access` | Read tools | Write tools | Ambiguous tools |
+|-----------|-----------|-------------|-----------------|
+| `"read"` | allowed | denied | denied |
+| `"write"` | denied | allowed | allowed |
+| `"*"` | allowed | allowed | allowed |
+
+When `strictClassification: true`, ambiguous tools are blocked entirely — even with `access: "write"`. This forces explicit classification overrides in the server config.
+
+**Deny always wins:**
+
+```json
+{
+  "roles": {
+    "dev": [
+      { "server": "github", "access": "*" },
+      { "server": "github", "access": "write", "tools": ["gh_repo_delete"], "deny": true }
+    ]
+  }
+}
+```
+
+The `dev` role has full access to github, except `gh_repo_delete` is explicitly denied.
+
+#### Legacy schema
+
+The original flat rules list, still fully supported. Detected when `rules` is present in the ACL config:
+
+```json
+{
+  "acl": {
+    "default": "allow",
+    "rules": [
+      { "subjects": ["bob"], "tools": ["sentry__*"], "policy": "deny" },
+      { "subjects": ["bob"], "tools": ["*admin*"], "policy": "deny" },
+      { "roles": ["admin"], "tools": ["*"], "policy": "allow" }
+    ]
+  }
+}
+```
+
+Rules are evaluated in order — **first match wins**. If no rule matches, the default policy applies.
+
+Legacy ACL fields:
 - `subjects` — list of user subjects to match (supports `*` wildcard)
 - `roles` — list of roles to match (supports `*` wildcard)
 - `tools` — list of tool name patterns (supports `*` wildcards: prefix `sentry__*`, suffix `*_issues`, contains `*admin*`, multiple `sentry__*_admin__*`, exact match, or `*` for all)
@@ -531,7 +608,37 @@ ACL fields:
 
 Both `subjects` and `roles` must match for a rule to apply. Empty `subjects` or `roles` means "match all".
 
+#### Schema detection
+
+| JSON keys present | Schema used |
+|-------------------|-------------|
+| `roles` (as object) or `subjects` (as object) | Role-based |
+| `rules` (as array) | Legacy |
+| Both `rules` and `roles`/`subjects` | Config error (fails loudly) |
+| Neither | Legacy with default allow |
+
 > **Note:** Stdio mode always uses anonymous identity. ACL rules still apply but the subject is always "anonymous".
+
+### ACL enforcement points
+
+The ACL is enforced at two points in the proxy:
+
+1. **`tools/list`** — The response is **filtered** to only include tools the identity is allowed to call. A tool the identity cannot reach is invisible in the listing.
+2. **`tools/call`** — The request is checked against the ACL before it reaches the backend. Denied requests return a JSON-RPC error (`-32603`) with the subject and tool name.
+
+This dual enforcement means an unauthorized identity can't discover tool names via `tools/list` and can't bypass the filter by guessing tool names in `tools/call`.
+
+### Request timeout
+
+Each client request has a hard upper bound of 120 seconds (configurable via `MCP_PROXY_REQUEST_TIMEOUT`). If a backend takes longer, the client gets a JSON-RPC error and the in-flight request is dropped. Other concurrent clients are unaffected.
+
+```bash
+MCP_PROXY_REQUEST_TIMEOUT=300 mcp serve --http
+```
+
+### Discovery retry with backoff
+
+When a backend fails to connect during discovery, the proxy applies exponential backoff: 30s → 60s → 120s → 240s (capped at 300s). This prevents a flaky backend from repeatedly stealing the discovery lock and blocking healthy backends. After the backoff expires, the proxy retries on the next `tools/call` or discovery cycle. Success clears the backoff.
 
 ## Security considerations
 
@@ -571,10 +678,14 @@ Backend tokens (Slack, GitHub, etc.) live in `servers.json` on the proxy server.
 
 All standard `mcp` env vars apply:
 
-| Variable | Effect |
-|----------|--------|
-| `MCP_CONFIG_PATH` | Custom config file path |
-| `MCP_TIMEOUT` | Timeout in seconds for backend connections (default: 60) |
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `MCP_CONFIG_PATH` | `~/.config/mcp/servers.json` | Custom config file path |
+| `MCP_TIMEOUT` | `60` | Timeout in seconds for backend connections |
+| `MCP_PROXY_REQUEST_TIMEOUT` | `120` | Hard upper bound (seconds) per client request in proxy mode |
+| `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Path to the tool classification cache |
+
+See [environment variables reference](../reference/environment-variables.md) for full details.
 
 ## When to use each mode
 

--- a/docs/guides/proxy-mode.md
+++ b/docs/guides/proxy-mode.md
@@ -564,7 +564,7 @@ The `access` field interacts with the tool classifier (read/write/ambiguous):
 | `"write"` | denied | allowed | allowed |
 | `"*"` | allowed | allowed | allowed |
 
-When `strictClassification: true`, ambiguous tools are blocked entirely — even with `access: "write"`. This forces explicit classification overrides in the server config.
+When `strictClassification: true`, ambiguous tools are blocked entirely — regardless of access level (including `"*"`). This forces explicit classification overrides in the server config before ambiguous tools can be used.
 
 **Deny always wins:**
 

--- a/docs/howto/troubleshooting.md
+++ b/docs/howto/troubleshooting.md
@@ -108,6 +108,52 @@ Validate your JSON:
 python3 -m json.tool ~/.config/mcp/servers.json
 ```
 
+## Proxy mode errors
+
+### Backend stuck in discovery retry
+
+When a backend fails to connect during `mcp serve`, the proxy applies exponential backoff before retrying: 30s → 60s → 120s → 240s (capped at 300s). This prevents a flaky backend from stealing the discovery lock and blocking healthy backends.
+
+If you see repeated discovery failures in stderr:
+
+```
+[serve] backend "slack" discovery failed: timeout waiting for server response
+```
+
+**Fixes:**
+
+1. **Check the backend command works standalone:**
+   ```bash
+   mcp slack --list
+   ```
+2. **Increase timeout for slow backends:**
+   ```bash
+   MCP_TIMEOUT=120 mcp serve --http
+   ```
+3. **Check credentials** — a backend stuck on an auth prompt will hang until timeout.
+
+After fixing the issue, restart `mcp serve` — the backoff state is in-memory and resets on restart.
+
+### "access denied" on tools/call
+
+The ACL blocks both `tools/call` requests **and** filters `tools/list` responses. If a tool doesn't appear in `tools/list`, the identity doesn't have access to it. If a tool appears but `tools/call` returns access denied, the ACL rules may have changed between the list and the call, or the tool's read/write classification doesn't match the identity's access level.
+
+**Debug:** Check what the classifier thinks about the tool:
+
+```bash
+mcp acl classify --server <backend>
+```
+
+Tools marked `[!]` (ambiguous) are treated as write by default. Add explicit `tool_acl` overrides in `servers.json` if the classifier is wrong.
+
+### Request timeout in proxy mode
+
+Each client request has a hard timeout of 120 seconds (configurable via `MCP_PROXY_REQUEST_TIMEOUT`). If a backend takes longer than this, the client gets a JSON-RPC error with code `-32000`. Other concurrent requests are unaffected.
+
+```bash
+MCP_PROXY_REQUEST_TIMEOUT=300 mcp serve --http
+```
+
 ## Tool errors
 
 ### "tools/call failed: ..."

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -193,7 +193,7 @@ Exposes the proxy over HTTP with the following endpoints:
 |--------|------|-------------|
 | `POST` | `/mcp` | JSON-RPC 2.0 request/response endpoint |
 | `GET` | `/mcp/sse` | SSE endpoint for streaming (per MCP spec) |
-| `GET` | `/health` | Health check (returns JSON status) |
+| `GET` | `/health` | Health check (returns JSON status, see below) |
 
 Default bind address is `127.0.0.1:8080` (localhost only). To bind to a different address:
 
@@ -205,6 +205,32 @@ mcp serve --http :3000              # shorthand for 0.0.0.0:3000 — requires --
 #### `--insecure`
 
 Allow binding to non-loopback addresses without TLS. Required when using addresses like `0.0.0.0`, `192.168.x.x`, etc. Without this flag, the server refuses to start on non-loopback interfaces to prevent accidental plaintext exposure.
+
+#### Health check (`GET /health`)
+
+Returns the proxy status as JSON:
+
+```json
+{
+  "status": "ok",
+  "backends_configured": 9,
+  "backends_connected": 3,
+  "active_clients": 5,
+  "tools": 213,
+  "version": "0.4.3"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `status` | Always `"ok"` |
+| `backends_configured` | Total servers in `servers.json` |
+| `backends_connected` | Backends currently running (others are idle-shutdown or not yet connected) |
+| `active_clients` | Number of SSE sessions currently registered |
+| `tools` | Total tools across all backends (including idle ones — tools are cached) |
+| `version` | `mcp` binary version |
+
+`backends_connected` should **not** grow with `active_clients` — that's the proxy doing its job (N clients sharing M backends). If they grow together, clients may be bypassing the proxy.
 
 #### Graceful shutdown
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -310,7 +310,79 @@ Groups header value is parsed as a comma-separated list: each entry is trimmed a
 
 ### ACL config
 
-Optional. Controls which users can access which tools.
+Optional. Controls which users can access which tools. Supports two schemas: **role-based** (recommended) and **legacy** (backward compatible). Detection is automatic — see [schema detection](#schema-detection).
+
+#### Role-based schema (recommended)
+
+```json
+{
+  "acl": {
+    "default": "deny",
+    "strictClassification": false,
+    "roles": {
+      "admin": [{ "server": "*", "access": "*" }],
+      "dev": [
+        { "server": ["github", "grafana"], "access": "read" },
+        { "server": "github", "access": "write", "tools": ["gh_pr", "gh_issue"] }
+      ],
+      "readonly": [{ "server": "*", "access": "read" }]
+    },
+    "subjects": {
+      "alice": { "roles": ["admin"] },
+      "bob":   { "roles": ["dev"] },
+      "charlie": {
+        "roles": ["readonly"],
+        "extra": [{ "server": "sentry", "access": "read" }]
+      }
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `default` | `"allow"` \| `"deny"` | `"allow"` | Policy when no grant matches |
+| `strictClassification` | bool | `false` | Block ambiguous tools entirely (require explicit override) |
+| `roles` | object | `{}` | Map of role name → list of grants |
+| `subjects` | object | `{}` | Map of subject → `{ roles, extra }` |
+
+#### Grant
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `server` | string or string[] | *required* | Server alias(es) to match (`"*"` = any) |
+| `access` | `"read"` \| `"write"` \| `"*"` | *required* | Access level |
+| `tools` | string[] | `[]` (all tools) | Tool name globs to narrow the grant |
+| `resources` | string[] | `[]` | Parsed but not enforced yet |
+| `prompts` | string[] | `[]` | Parsed but not enforced yet |
+| `deny` | bool | `false` | Turns grant into explicit deny (always wins over allows) |
+
+#### Subject config
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `roles` | string[] | `[]` | Roles assigned to this subject (merged with token roles) |
+| `extra` | Grant[] | `[]` | Additional per-subject grants |
+
+#### Access expansion
+
+| `access` | Read tools | Write tools | Ambiguous tools | Ambiguous (strict) |
+|-----------|-----------|-------------|-----------------|-------------------|
+| `"read"` | allowed | denied | denied | denied |
+| `"write"` | denied | allowed | allowed | **denied** |
+| `"*"` | allowed | allowed | allowed | allowed |
+
+#### Evaluation model
+
+1. Collect all grants from all roles (token roles + subject config roles) + `extra`
+2. Filter to grants matching the target server and tool
+3. If any matching grant has `deny: true` → **deny**
+4. If any matching allow grant covers the access level → **allow**
+5. No match → apply `default`
+
+Union-based, order-independent. Deny always wins.
+
+#### Legacy schema
 
 ```json
 {
@@ -333,7 +405,7 @@ Optional. Controls which users can access which tools.
 | `default` | `"allow"` \| `"deny"` | `"allow"` | Default policy when no rule matches |
 | `rules` | array | `[]` | Ordered list of ACL rules (first match wins) |
 
-#### ACL rule
+#### Legacy ACL rule
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -344,9 +416,18 @@ Optional. Controls which users can access which tools.
 
 Both `subjects` and `roles` must match for a rule to apply. Empty means "match all".
 
+#### Schema detection
+
+| JSON keys present | Schema used |
+|-------------------|-------------|
+| `roles` (as object) or `subjects` (as object) | Role-based |
+| `rules` (as array) | Legacy |
+| Both `rules` and `roles`/`subjects` | Config error |
+| Neither | Legacy with default allow |
+
 #### Tool pattern glob syntax
 
-The `tools` field supports glob patterns with `*` wildcards:
+The `tools` field supports glob patterns with `*` wildcards (both schemas):
 
 | Pattern | Matches | Example |
 |---------|---------|---------|

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -370,7 +370,7 @@ Optional. Controls which users can access which tools. Supports two schemas: **r
 |-----------|-----------|-------------|-----------------|-------------------|
 | `"read"` | allowed | denied | denied | denied |
 | `"write"` | denied | allowed | allowed | **denied** |
-| `"*"` | allowed | allowed | allowed | allowed |
+| `"*"` | allowed | allowed | allowed | **denied** |
 
 #### Evaluation model
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -10,6 +10,7 @@ These variables configure `mcp` behavior:
 | `MCP_TIMEOUT` | `60` | Timeout in seconds for stdio server responses |
 | `MCP_PROXY_REQUEST_TIMEOUT` | `120` | (proxy mode) Hard upper bound, in seconds, that any single client request can spend inside `mcp serve` before the proxy returns a JSON-RPC error. Acts as a belt-and-suspenders boundary on top of the per-transport `MCP_TIMEOUT`. |
 | `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Path to the persistent tool read/write classification cache (see [`mcp acl classify`](./cli.md#mcp-acl-classify)). Override this in CI/containers that cannot write to `$HOME`. |
+| `MCP_DISCOVERY_CONCURRENCY` | `10` | Max parallel `--help` calls during CLI subcommand discovery (see [CLI as MCP](../guides/cli-as-mcp.md)) |
 
 ### `MCP_CONFIG_PATH`
 
@@ -53,6 +54,14 @@ MCP_CLASSIFIER_CACHE=/tmp/classify.json mcp acl classify
 
 Corrupt or unreadable cache files are non-fatal: a warning is logged and
 the process proceeds with fresh in-memory classifications.
+
+### `MCP_DISCOVERY_CONCURRENCY`
+
+Only applies to CLI servers (`cli: true`). Limits how many `--help` calls run in parallel during subcommand discovery. Lower this if your machine struggles with many concurrent child processes, or raise it to speed up discovery for deeply nested CLIs.
+
+```bash
+MCP_DISCOVERY_CONCURRENCY=5 mcp kubectl --list
+```
 
 ## Config variables
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -543,17 +543,6 @@ impl ProxyServer {
             }
         };
 
-        if !server_auth::is_tool_allowed(identity, &tool_name, acl) {
-            return Err(JsonRpcResponse::error(
-                id.clone(),
-                -32603,
-                &format!(
-                    "access denied: '{}' cannot use tool '{tool_name}'",
-                    identity.subject
-                ),
-            ));
-        }
-
         let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
 
         let (server_name, original_name) = match self.tool_map.get(&tool_name) {
@@ -566,6 +555,24 @@ impl ProxyServer {
                 ));
             }
         };
+
+        let classification = self.classifications.get(&tool_name);
+        let ctx = server_auth::ToolContext {
+            server_alias: &server_name,
+            tool_name: &original_name,
+            classification,
+        };
+
+        if !server_auth::is_tool_allowed(identity, &tool_name, acl, Some(&ctx)) {
+            return Err(JsonRpcResponse::error(
+                id.clone(),
+                -32603,
+                &format!(
+                    "access denied: '{}' cannot use tool '{tool_name}'",
+                    identity.subject
+                ),
+            ));
+        }
 
         Ok((server_name, original_name, arguments))
     }
@@ -778,7 +785,16 @@ async fn dispatch_request(
                 let p = proxy.lock().await;
                 p.tools
                     .iter()
-                    .filter(|t| server_auth::is_tool_allowed(identity, &t.name, acl))
+                    .filter(|t| {
+                        let ctx = p.tool_map.get(&t.name).map(|(server, orig)| {
+                            server_auth::ToolContext {
+                                server_alias: server.as_str(),
+                                tool_name: orig.as_str(),
+                                classification: p.classifications.get(&t.name),
+                            }
+                        });
+                        server_auth::is_tool_allowed(identity, &t.name, acl, ctx.as_ref())
+                    })
                     .map(|t| serde_json::to_value(t).unwrap())
                     .collect()
             };
@@ -1864,7 +1880,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tools_list_filtered_by_acl() {
-        use crate::server_auth::{AclConfig, AclPolicy, AclRule};
+        use crate::server_auth::{AclPolicy, AclRule};
 
         let mut server = test_server();
         // No configs → has_undiscovered_backends() is false, discovery is skipped
@@ -1881,15 +1897,15 @@ mod tests {
             annotations: None,
         });
 
-        let acl = Some(AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![AclRule {
+        let acl = Some(AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![AclRule {
                 subjects: vec!["bob".to_string()],
                 roles: vec![],
                 tools: vec!["sentry__*".to_string()],
                 policy: AclPolicy::Deny,
             }],
-        });
+        ));
 
         let bob = AuthIdentity::new("bob", vec![]);
         let req = JsonRpcRequest::new(10, "tools/list", None);
@@ -1902,7 +1918,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tools_call_denied_by_acl() {
-        use crate::server_auth::{AclConfig, AclPolicy, AclRule};
+        use crate::server_auth::{AclPolicy, AclRule};
 
         let mut server = test_server();
         server.tool_map.insert(
@@ -1910,15 +1926,15 @@ mod tests {
             ("sentry".to_string(), "search".to_string()),
         );
 
-        let acl = Some(AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![AclRule {
+        let acl = Some(AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![AclRule {
                 subjects: vec!["bob".to_string()],
                 roles: vec![],
                 tools: vec!["sentry__*".to_string()],
                 policy: AclPolicy::Deny,
             }],
-        });
+        ));
 
         let bob = AuthIdentity::new("bob", vec![]);
         let req = JsonRpcRequest::new(

--- a/src/server_auth/acl.rs
+++ b/src/server_auth/acl.rs
@@ -120,9 +120,9 @@ impl<'de> Deserialize<'de> for AclConfig {
             .ok_or_else(|| serde::de::Error::custom("ACL config must be a JSON object"))?;
 
         let has_rules = obj.contains_key("rules");
-        let has_roles_map = obj.get("roles").is_some_and(|v| v.is_object());
-        let has_subjects_map = obj.get("subjects").is_some_and(|v| v.is_object());
-        let is_new = has_roles_map || has_subjects_map;
+        let has_roles = obj.contains_key("roles");
+        let has_subjects = obj.contains_key("subjects");
+        let is_new = has_roles || has_subjects;
 
         if has_rules && is_new {
             return Err(serde::de::Error::custom(
@@ -133,6 +133,17 @@ impl<'de> Deserialize<'de> for AclConfig {
         if is_new {
             let rbac: RoleBasedAclConfig =
                 serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
+            // Validate that all roles referenced by subjects exist in the roles map.
+            for (subject, config) in &rbac.subjects {
+                for role in &config.roles {
+                    if !rbac.roles.contains_key(role) {
+                        return Err(serde::de::Error::custom(format!(
+                            "subject '{}' references unknown role '{}'",
+                            subject, role
+                        )));
+                    }
+                }
+            }
             Ok(AclConfig::RoleBased(rbac))
         } else {
             let legacy: LegacyAclConfig =
@@ -245,12 +256,16 @@ fn is_tool_allowed_rbac(
         .filter(|g| matches_server(g, ctx.server_alias) && matches_tool_grant(g, ctx.tool_name))
         .collect();
 
-    // Union evaluation: deny always wins.
-    if matching.iter().any(|g| g.deny) {
+    let kind = ctx.classification.map(|c| c.kind);
+
+    // Union evaluation: deny always wins, but only for grants that also
+    // cover the current access classification.
+    if matching
+        .iter()
+        .any(|g| g.deny && deny_covers_access(g, kind, acl.strict_classification))
+    {
         return false;
     }
-
-    let kind = ctx.classification.map(|c| c.kind);
 
     if matching
         .iter()
@@ -300,18 +315,32 @@ fn matches_tool_grant(grant: &Grant, tool_name: &str) -> bool {
         .any(|pattern| glob_match(pattern, tool_name))
 }
 
+/// Check if a grant's access level covers the tool's classified kind (for allow grants).
 fn grant_covers_access(grant: &Grant, kind: Option<Kind>, strict: bool) -> bool {
     if grant.deny {
+        return false;
+    }
+    // Strict mode blocks ambiguous tools entirely, regardless of access level.
+    if strict && matches!(kind, Some(Kind::Ambiguous)) {
         return false;
     }
     match grant.access {
         AccessLevel::All => true,
         AccessLevel::Read => matches!(kind, Some(Kind::Read)),
-        AccessLevel::Write => match kind {
-            Some(Kind::Write) => true,
-            Some(Kind::Ambiguous) => !strict,
-            _ => false,
-        },
+        AccessLevel::Write => matches!(kind, Some(Kind::Write) | Some(Kind::Ambiguous)),
+    }
+}
+
+/// Check if a deny grant's access level covers the tool's classified kind.
+/// Same expansion logic as allow, but ignores the `deny` flag guard.
+fn deny_covers_access(grant: &Grant, kind: Option<Kind>, strict: bool) -> bool {
+    if strict && matches!(kind, Some(Kind::Ambiguous)) {
+        return true; // strict mode: deny always catches ambiguous
+    }
+    match grant.access {
+        AccessLevel::All => true,
+        AccessLevel::Read => matches!(kind, Some(Kind::Read)),
+        AccessLevel::Write => matches!(kind, Some(Kind::Write) | Some(Kind::Ambiguous)),
     }
 }
 
@@ -736,6 +765,7 @@ mod tests {
     fn test_deserialize_subjects_only_schema() {
         let json = r#"{
             "default": "deny",
+            "roles": { "dev": [{ "server": "*", "access": "read" }] },
             "subjects": {
                 "bob": { "roles": ["dev"] }
             }
@@ -1099,10 +1129,10 @@ mod tests {
     }
 
     #[test]
-    fn test_all_access_allows_everything() {
+    fn test_all_access_allows_everything_non_strict() {
         let acl = RoleBasedAclConfig {
             default: AclPolicy::Deny,
-            strict_classification: true,
+            strict_classification: false,
             roles: HashMap::from([(
                 "admin".to_string(),
                 vec![Grant {
@@ -1127,9 +1157,56 @@ mod tests {
             };
             assert!(
                 is_tool_allowed_rbac(&identity, &ctx, &acl),
-                "access=* should allow Kind::{kind:?}"
+                "access=* non-strict should allow Kind::{kind:?}"
             );
         }
+    }
+
+    #[test]
+    fn test_all_access_blocks_ambiguous_in_strict_mode() {
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: true,
+            roles: HashMap::from([(
+                "admin".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::All,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("alice", vec!["admin".to_string()]);
+
+        // Read and Write still allowed
+        for kind in [Kind::Read, Kind::Write] {
+            let cls = make_classification(kind);
+            let ctx = ToolContext {
+                server_alias: "any",
+                tool_name: "any_tool",
+                classification: Some(&cls),
+            };
+            assert!(
+                is_tool_allowed_rbac(&identity, &ctx, &acl),
+                "access=* strict should allow Kind::{kind:?}"
+            );
+        }
+
+        // Ambiguous blocked in strict mode
+        let cls = make_classification(Kind::Ambiguous);
+        let ctx = ToolContext {
+            server_alias: "any",
+            tool_name: "any_tool",
+            classification: Some(&cls),
+        };
+        assert!(
+            !is_tool_allowed_rbac(&identity, &ctx, &acl),
+            "access=* strict should block Kind::Ambiguous"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1525,5 +1602,149 @@ mod tests {
             classification: Some(&read_cls),
         };
         assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    // -----------------------------------------------------------------------
+    // PR review fixes: deny access scoping, schema detection, role validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_deny_read_does_not_block_write() {
+        // A deny grant with access=read should only block read tools,
+        // not write tools on the same server/tool pattern.
+        let read_cls = make_classification(Kind::Read);
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::All,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::Read,
+                        tools: vec!["gh_secret_tool".to_string()],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: true,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("alice", vec!["dev".to_string()]);
+
+        // Read is denied by the deny grant
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_secret_tool",
+            classification: Some(&read_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+
+        // Write is NOT denied — the deny grant only covers read
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_secret_tool",
+            classification: Some(&write_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_deny_write_does_not_block_read() {
+        let read_cls = make_classification(Kind::Read);
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Single("*".to_string()),
+                        access: AccessLevel::All,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::Write,
+                        tools: vec!["gh_repo_delete".to_string()],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: true,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+
+        // Write is denied
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_repo_delete",
+            classification: Some(&write_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+
+        // Read is NOT denied — the deny grant only covers write
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_repo_delete",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_deserialize_roles_wrong_type_errors() {
+        // roles as array (not object) should trigger new schema detection
+        // and then fail deserialization, not silently fall to legacy.
+        let json = r#"{
+            "default": "deny",
+            "roles": ["admin"]
+        }"#;
+        let result: Result<AclConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_subjects_wrong_type_errors() {
+        let json = r#"{
+            "default": "deny",
+            "subjects": "alice"
+        }"#;
+        let result: Result<AclConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_unknown_role_reference_errors() {
+        // Subject references a role that doesn't exist in the roles map.
+        let json = r#"{
+            "default": "deny",
+            "roles": {
+                "admin": [{ "server": "*", "access": "*" }]
+            },
+            "subjects": {
+                "alice": { "roles": ["nonexistent"] }
+            }
+        }"#;
+        let result: Result<AclConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("unknown role"));
     }
 }

--- a/src/server_auth/acl.rs
+++ b/src/server_auth/acl.rs
@@ -1,6 +1,13 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 use super::AuthIdentity;
+use crate::classifier::{Kind, ToolClassification};
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -8,6 +15,14 @@ pub enum AclPolicy {
     Allow,
     Deny,
 }
+
+fn default_policy() -> AclPolicy {
+    AclPolicy::Allow
+}
+
+// ---------------------------------------------------------------------------
+// Legacy schema (first-match-wins, flat rules list)
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AclRule {
@@ -20,20 +35,156 @@ pub struct AclRule {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-pub struct AclConfig {
+pub struct LegacyAclConfig {
     #[serde(default = "default_policy")]
     pub default: AclPolicy,
     #[serde(default)]
     pub rules: Vec<AclRule>,
 }
 
-fn default_policy() -> AclPolicy {
-    AclPolicy::Allow
+// ---------------------------------------------------------------------------
+// New role-based schema
+// ---------------------------------------------------------------------------
+
+/// A single server string or array of server globs.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum ServerPattern {
+    Single(String),
+    Multiple(Vec<String>),
 }
 
-/// Check if a tool is allowed for the given identity against ACL rules.
-/// Rules are evaluated in order; first match wins.
-pub fn is_tool_allowed(identity: &AuthIdentity, tool_name: &str, acl: &AclConfig) -> bool {
+/// The access level for a grant.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AccessLevel {
+    Read,
+    Write,
+    #[serde(rename = "*")]
+    All,
+}
+
+/// A single grant entry within a role definition or a subject's `extra` list.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Grant {
+    pub server: ServerPattern,
+    pub access: AccessLevel,
+    #[serde(default)]
+    pub tools: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub resources: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub prompts: Vec<String>,
+    #[serde(default)]
+    pub deny: bool,
+}
+
+/// Per-subject configuration: assigned roles + optional extra grants.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubjectConfig {
+    #[serde(default)]
+    pub roles: Vec<String>,
+    #[serde(default)]
+    pub extra: Vec<Grant>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RoleBasedAclConfig {
+    #[serde(default = "default_policy")]
+    pub default: AclPolicy,
+    #[serde(default, rename = "strictClassification")]
+    pub strict_classification: bool,
+    #[serde(default)]
+    pub roles: HashMap<String, Vec<Grant>>,
+    #[serde(default)]
+    pub subjects: HashMap<String, SubjectConfig>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified AclConfig enum with custom deserializer
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub enum AclConfig {
+    Legacy(LegacyAclConfig),
+    RoleBased(RoleBasedAclConfig),
+}
+
+impl<'de> Deserialize<'de> for AclConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw: serde_json::Value = serde_json::Value::deserialize(deserializer)?;
+        let obj = raw
+            .as_object()
+            .ok_or_else(|| serde::de::Error::custom("ACL config must be a JSON object"))?;
+
+        let has_rules = obj.contains_key("rules");
+        let has_roles_map = obj.get("roles").is_some_and(|v| v.is_object());
+        let has_subjects_map = obj.get("subjects").is_some_and(|v| v.is_object());
+        let is_new = has_roles_map || has_subjects_map;
+
+        if has_rules && is_new {
+            return Err(serde::de::Error::custom(
+                "ACL config cannot have both 'rules' (legacy) and 'roles'/'subjects' (new schema)",
+            ));
+        }
+
+        if is_new {
+            let rbac: RoleBasedAclConfig =
+                serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
+            Ok(AclConfig::RoleBased(rbac))
+        } else {
+            let legacy: LegacyAclConfig =
+                serde_json::from_value(raw).map_err(serde::de::Error::custom)?;
+            Ok(AclConfig::Legacy(legacy))
+        }
+    }
+}
+
+#[cfg(test)]
+impl AclConfig {
+    pub fn legacy(default: AclPolicy, rules: Vec<AclRule>) -> Self {
+        AclConfig::Legacy(LegacyAclConfig { default, rules })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToolContext — coordinates for role-based evaluation
+// ---------------------------------------------------------------------------
+
+pub struct ToolContext<'a> {
+    pub server_alias: &'a str,
+    pub tool_name: &'a str,
+    pub classification: Option<&'a ToolClassification>,
+}
+
+// ---------------------------------------------------------------------------
+// Unified dispatcher
+// ---------------------------------------------------------------------------
+
+/// Check if a tool is allowed for the given identity.
+/// Legacy schema uses first-match-wins; role-based uses union evaluation.
+pub fn is_tool_allowed(
+    identity: &AuthIdentity,
+    tool_name: &str,
+    acl: &AclConfig,
+    ctx: Option<&ToolContext>,
+) -> bool {
+    match acl {
+        AclConfig::Legacy(legacy) => legacy_is_tool_allowed(identity, tool_name, legacy),
+        AclConfig::RoleBased(rbac) => match ctx {
+            Some(c) => is_tool_allowed_rbac(identity, c, rbac),
+            None => rbac.default == AclPolicy::Allow,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Legacy evaluator (first-match-wins, unchanged logic)
+// ---------------------------------------------------------------------------
+
+fn legacy_is_tool_allowed(identity: &AuthIdentity, tool_name: &str, acl: &LegacyAclConfig) -> bool {
     for rule in &acl.rules {
         if !matches_identity(identity, rule) {
             continue;
@@ -67,6 +218,106 @@ fn matches_tool(tool_name: &str, patterns: &[String]) -> bool {
         .iter()
         .any(|pattern| glob_match(pattern, tool_name))
 }
+
+// ---------------------------------------------------------------------------
+// Role-based evaluator (union semantics)
+// ---------------------------------------------------------------------------
+
+fn is_tool_allowed_rbac(
+    identity: &AuthIdentity,
+    ctx: &ToolContext,
+    acl: &RoleBasedAclConfig,
+) -> bool {
+    let (role_names, extra_grants) = resolve_subject(identity, acl);
+
+    // Collect all grants from matched roles + extra.
+    let mut all_grants: Vec<&Grant> = Vec::new();
+    for role_name in &role_names {
+        if let Some(grants) = acl.roles.get(role_name) {
+            all_grants.extend(grants.iter());
+        }
+    }
+    all_grants.extend(extra_grants);
+
+    // Filter to grants that match server + tool.
+    let matching: Vec<&Grant> = all_grants
+        .into_iter()
+        .filter(|g| matches_server(g, ctx.server_alias) && matches_tool_grant(g, ctx.tool_name))
+        .collect();
+
+    // Union evaluation: deny always wins.
+    if matching.iter().any(|g| g.deny) {
+        return false;
+    }
+
+    let kind = ctx.classification.map(|c| c.kind);
+
+    if matching
+        .iter()
+        .any(|g| grant_covers_access(g, kind, acl.strict_classification))
+    {
+        return true;
+    }
+
+    // No matching grant -> fall back to default.
+    acl.default == AclPolicy::Allow
+}
+
+/// Resolve roles and extra grants for an identity.
+fn resolve_subject<'a>(
+    identity: &AuthIdentity,
+    acl: &'a RoleBasedAclConfig,
+) -> (Vec<String>, Vec<&'a Grant>) {
+    let mut role_names: Vec<String> = identity.roles.clone();
+    let mut extra: Vec<&Grant> = Vec::new();
+
+    if let Some(subj_config) = acl.subjects.get(&identity.subject) {
+        for r in &subj_config.roles {
+            if !role_names.contains(r) {
+                role_names.push(r.clone());
+            }
+        }
+        extra.extend(subj_config.extra.iter());
+    }
+
+    (role_names, extra)
+}
+
+fn matches_server(grant: &Grant, server: &str) -> bool {
+    match &grant.server {
+        ServerPattern::Single(s) => glob_match(s, server),
+        ServerPattern::Multiple(list) => list.iter().any(|s| glob_match(s, server)),
+    }
+}
+
+fn matches_tool_grant(grant: &Grant, tool_name: &str) -> bool {
+    if grant.tools.is_empty() {
+        return true;
+    }
+    grant
+        .tools
+        .iter()
+        .any(|pattern| glob_match(pattern, tool_name))
+}
+
+fn grant_covers_access(grant: &Grant, kind: Option<Kind>, strict: bool) -> bool {
+    if grant.deny {
+        return false;
+    }
+    match grant.access {
+        AccessLevel::All => true,
+        AccessLevel::Read => matches!(kind, Some(Kind::Read)),
+        AccessLevel::Write => match kind {
+            Some(Kind::Write) => true,
+            Some(Kind::Ambiguous) => !strict,
+            _ => false,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Glob matching (shared by both schemas)
+// ---------------------------------------------------------------------------
 
 /// Glob matching: supports `*` as wildcard for any characters.
 /// Handles multiple wildcards (e.g., `*admin*`, `foo*bar*baz`).
@@ -152,9 +403,14 @@ fn match_middle_and_end(segments: &[&str], mut value: &str, ends_with_star: bool
     true
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::classifier::Source;
 
     fn alice() -> AuthIdentity {
         AuthIdentity::new("alice", vec!["admin".to_string()])
@@ -168,63 +424,80 @@ mod tests {
         AuthIdentity::anonymous()
     }
 
+    fn make_classification(kind: Kind) -> ToolClassification {
+        ToolClassification {
+            kind,
+            confidence: 1.0,
+            source: Source::Classifier,
+            reasons: vec![],
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Legacy tests (unchanged logic, wrapped in AclConfig::Legacy)
+    // -----------------------------------------------------------------------
+
     #[test]
     fn test_default_allow_no_rules() {
-        let acl = AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![],
-        };
-        assert!(is_tool_allowed(&alice(), "any_tool", &acl));
-        assert!(is_tool_allowed(&anon(), "any_tool", &acl));
+        let acl = AclConfig::legacy(AclPolicy::Allow, vec![]);
+        assert!(is_tool_allowed(&alice(), "any_tool", &acl, None));
+        assert!(is_tool_allowed(&anon(), "any_tool", &acl, None));
     }
 
     #[test]
     fn test_default_deny_no_rules() {
-        let acl = AclConfig {
-            default: AclPolicy::Deny,
-            rules: vec![],
-        };
-        assert!(!is_tool_allowed(&alice(), "any_tool", &acl));
+        let acl = AclConfig::legacy(AclPolicy::Deny, vec![]);
+        assert!(!is_tool_allowed(&alice(), "any_tool", &acl, None));
     }
 
     #[test]
     fn test_deny_specific_subject() {
-        let acl = AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![AclRule {
+        let acl = AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![AclRule {
                 subjects: vec!["bob".to_string()],
                 roles: vec![],
                 tools: vec!["sentry__*".to_string()],
                 policy: AclPolicy::Deny,
             }],
-        };
+        );
 
-        assert!(!is_tool_allowed(&bob(), "sentry__search_issues", &acl));
-        assert!(is_tool_allowed(&bob(), "slack__send_message", &acl));
-        assert!(is_tool_allowed(&alice(), "sentry__search_issues", &acl));
+        assert!(!is_tool_allowed(
+            &bob(),
+            "sentry__search_issues",
+            &acl,
+            None
+        ));
+        assert!(is_tool_allowed(&bob(), "slack__send_message", &acl, None));
+        assert!(is_tool_allowed(
+            &alice(),
+            "sentry__search_issues",
+            &acl,
+            None
+        ));
     }
 
     #[test]
     fn test_allow_specific_role() {
-        let acl = AclConfig {
-            default: AclPolicy::Deny,
-            rules: vec![AclRule {
+        let acl = AclConfig::legacy(
+            AclPolicy::Deny,
+            vec![AclRule {
                 subjects: vec![],
                 roles: vec!["admin".to_string()],
                 tools: vec!["*".to_string()],
                 policy: AclPolicy::Allow,
             }],
-        };
+        );
 
-        assert!(is_tool_allowed(&alice(), "anything", &acl));
-        assert!(!is_tool_allowed(&bob(), "anything", &acl));
+        assert!(is_tool_allowed(&alice(), "anything", &acl, None));
+        assert!(!is_tool_allowed(&bob(), "anything", &acl, None));
     }
 
     #[test]
     fn test_first_match_wins() {
-        let acl = AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![
+        let acl = AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![
                 AclRule {
                     subjects: vec!["bob".to_string()],
                     roles: vec![],
@@ -238,12 +511,15 @@ mod tests {
                     policy: AclPolicy::Deny,
                 },
             ],
-        };
+        );
 
-        // First rule matches — allow
-        assert!(is_tool_allowed(&bob(), "sentry__search_issues", &acl));
-        // Second rule matches — deny
-        assert!(!is_tool_allowed(&bob(), "sentry__delete_project", &acl));
+        assert!(is_tool_allowed(&bob(), "sentry__search_issues", &acl, None));
+        assert!(!is_tool_allowed(
+            &bob(),
+            "sentry__delete_project",
+            &acl,
+            None
+        ));
     }
 
     #[test]
@@ -272,40 +548,43 @@ mod tests {
 
     #[test]
     fn test_wildcard_subject() {
-        let acl = AclConfig {
-            default: AclPolicy::Deny,
-            rules: vec![AclRule {
+        let acl = AclConfig::legacy(
+            AclPolicy::Deny,
+            vec![AclRule {
                 subjects: vec!["*".to_string()],
                 roles: vec![],
                 tools: vec!["health__*".to_string()],
                 policy: AclPolicy::Allow,
             }],
-        };
+        );
 
-        assert!(is_tool_allowed(&alice(), "health__check", &acl));
-        assert!(is_tool_allowed(&bob(), "health__check", &acl));
-        assert!(is_tool_allowed(&anon(), "health__check", &acl));
-        assert!(!is_tool_allowed(&alice(), "sentry__search", &acl));
+        assert!(is_tool_allowed(&alice(), "health__check", &acl, None));
+        assert!(is_tool_allowed(&bob(), "health__check", &acl, None));
+        assert!(is_tool_allowed(&anon(), "health__check", &acl, None));
+        assert!(!is_tool_allowed(&alice(), "sentry__search", &acl, None));
     }
 
     #[test]
     fn test_combined_subject_and_role() {
-        let acl = AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![AclRule {
+        let acl = AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![AclRule {
                 subjects: vec!["bob".to_string()],
                 roles: vec!["admin".to_string()],
                 tools: vec!["dangerous__*".to_string()],
                 policy: AclPolicy::Deny,
             }],
-        };
+        );
 
-        // bob doesn't have admin role -> rule doesn't match -> falls to default (allow)
-        assert!(is_tool_allowed(&bob(), "dangerous__delete", &acl));
+        assert!(is_tool_allowed(&bob(), "dangerous__delete", &acl, None));
 
-        // identity with both bob + admin
         let bob_admin = AuthIdentity::new("bob", vec!["admin".to_string()]);
-        assert!(!is_tool_allowed(&bob_admin, "dangerous__delete", &acl));
+        assert!(!is_tool_allowed(
+            &bob_admin,
+            "dangerous__delete",
+            &acl,
+            None
+        ));
     }
 
     #[test]
@@ -371,20 +650,20 @@ mod tests {
 
     #[test]
     fn test_acl_with_contains_pattern() {
-        let acl = AclConfig {
-            default: AclPolicy::Allow,
-            rules: vec![AclRule {
+        let acl = AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![AclRule {
                 subjects: vec!["bob".to_string()],
                 roles: vec![],
                 tools: vec!["*admin*".to_string()],
                 policy: AclPolicy::Deny,
             }],
-        };
+        );
 
-        assert!(!is_tool_allowed(&bob(), "admin_panel", &acl));
-        assert!(!is_tool_allowed(&bob(), "user_admin_panel", &acl));
-        assert!(is_tool_allowed(&bob(), "user_panel", &acl));
-        assert!(is_tool_allowed(&alice(), "admin_panel", &acl));
+        assert!(!is_tool_allowed(&bob(), "admin_panel", &acl, None));
+        assert!(!is_tool_allowed(&bob(), "user_admin_panel", &acl, None));
+        assert!(is_tool_allowed(&bob(), "user_panel", &acl, None));
+        assert!(is_tool_allowed(&alice(), "admin_panel", &acl, None));
     }
 
     #[test]
@@ -405,17 +684,846 @@ mod tests {
             ]
         }"#;
         let acl: AclConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(acl.default, AclPolicy::Deny);
-        assert_eq!(acl.rules.len(), 2);
-        assert_eq!(acl.rules[0].subjects, vec!["alice"]);
-        assert!(acl.rules[0].roles.is_empty());
-        assert_eq!(acl.rules[1].roles, vec!["viewer"]);
+        match &acl {
+            AclConfig::Legacy(legacy) => {
+                assert_eq!(legacy.default, AclPolicy::Deny);
+                assert_eq!(legacy.rules.len(), 2);
+                assert_eq!(legacy.rules[0].subjects, vec!["alice"]);
+                assert!(legacy.rules[0].roles.is_empty());
+                assert_eq!(legacy.rules[1].roles, vec!["viewer"]);
+            }
+            AclConfig::RoleBased(_) => panic!("expected legacy schema"),
+        }
     }
 
     #[test]
     fn test_acl_default_deserialize() {
         let json = r#"{"rules": []}"#;
         let acl: AclConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(acl.default, AclPolicy::Allow);
+        match &acl {
+            AclConfig::Legacy(legacy) => assert_eq!(legacy.default, AclPolicy::Allow),
+            AclConfig::RoleBased(_) => panic!("expected legacy schema"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Schema detection tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_deserialize_rbac_schema() {
+        let json = r#"{
+            "default": "deny",
+            "roles": {
+                "admin": [{ "server": "*", "access": "*" }]
+            },
+            "subjects": {
+                "alice": { "roles": ["admin"] }
+            }
+        }"#;
+        let acl: AclConfig = serde_json::from_str(json).unwrap();
+        match &acl {
+            AclConfig::RoleBased(rbac) => {
+                assert_eq!(rbac.default, AclPolicy::Deny);
+                assert!(rbac.roles.contains_key("admin"));
+                assert!(rbac.subjects.contains_key("alice"));
+            }
+            AclConfig::Legacy(_) => panic!("expected role-based schema"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_subjects_only_schema() {
+        let json = r#"{
+            "default": "deny",
+            "subjects": {
+                "bob": { "roles": ["dev"] }
+            }
+        }"#;
+        let acl: AclConfig = serde_json::from_str(json).unwrap();
+        assert!(matches!(acl, AclConfig::RoleBased(_)));
+    }
+
+    #[test]
+    fn test_deserialize_both_schemas_error() {
+        let json = r#"{
+            "rules": [{"subjects": ["x"], "tools": ["*"], "policy": "allow"}],
+            "roles": { "admin": [{ "server": "*", "access": "*" }] }
+        }"#;
+        let result: Result<AclConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("cannot have both"));
+    }
+
+    #[test]
+    fn test_deserialize_empty_acl() {
+        let json = r#"{}"#;
+        let acl: AclConfig = serde_json::from_str(json).unwrap();
+        match &acl {
+            AclConfig::Legacy(legacy) => {
+                assert_eq!(legacy.default, AclPolicy::Allow);
+                assert!(legacy.rules.is_empty());
+            }
+            AclConfig::RoleBased(_) => panic!("expected legacy for empty config"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_rbac_strict_classification() {
+        let json = r#"{
+            "default": "deny",
+            "strictClassification": true,
+            "roles": {}
+        }"#;
+        let acl: AclConfig = serde_json::from_str(json).unwrap();
+        match &acl {
+            AclConfig::RoleBased(rbac) => assert!(rbac.strict_classification),
+            AclConfig::Legacy(_) => panic!("expected role-based schema"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_rbac_full_example() {
+        let json = r#"{
+            "default": "deny",
+            "strictClassification": false,
+            "roles": {
+                "admin":    [{ "server": "*", "access": "*" }],
+                "dev": [
+                    { "server": ["github", "grafana"], "access": "read" },
+                    { "server": "github", "access": "write", "tools": ["gh_pr", "gh_issue"] }
+                ],
+                "readonly": [{ "server": "*", "access": "read" }]
+            },
+            "subjects": {
+                "alice":   { "roles": ["admin"] },
+                "bob":     { "roles": ["dev"] },
+                "charlie": {
+                    "roles": ["readonly"],
+                    "extra": [{ "server": "sentry", "access": "read", "resources": ["issue://*"] }]
+                }
+            }
+        }"#;
+        let acl: AclConfig = serde_json::from_str(json).unwrap();
+        match &acl {
+            AclConfig::RoleBased(rbac) => {
+                assert_eq!(rbac.roles.len(), 3);
+                assert_eq!(rbac.subjects.len(), 3);
+                assert!(!rbac.strict_classification);
+                let dev_grants = &rbac.roles["dev"];
+                assert_eq!(dev_grants.len(), 2);
+                let charlie = &rbac.subjects["charlie"];
+                assert_eq!(charlie.extra.len(), 1);
+                assert_eq!(charlie.extra[0].resources, vec!["issue://*"]);
+            }
+            AclConfig::Legacy(_) => panic!("expected role-based schema"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Grant matching tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_server_pattern_single() {
+        let grant = Grant {
+            server: ServerPattern::Single("github".to_string()),
+            access: AccessLevel::All,
+            tools: vec![],
+            resources: vec![],
+            prompts: vec![],
+            deny: false,
+        };
+        assert!(matches_server(&grant, "github"));
+        assert!(!matches_server(&grant, "grafana"));
+    }
+
+    #[test]
+    fn test_server_pattern_wildcard() {
+        let grant = Grant {
+            server: ServerPattern::Single("*".to_string()),
+            access: AccessLevel::All,
+            tools: vec![],
+            resources: vec![],
+            prompts: vec![],
+            deny: false,
+        };
+        assert!(matches_server(&grant, "github"));
+        assert!(matches_server(&grant, "grafana"));
+        assert!(matches_server(&grant, "sentry"));
+    }
+
+    #[test]
+    fn test_server_pattern_multiple() {
+        let grant = Grant {
+            server: ServerPattern::Multiple(vec!["github".to_string(), "grafana".to_string()]),
+            access: AccessLevel::All,
+            tools: vec![],
+            resources: vec![],
+            prompts: vec![],
+            deny: false,
+        };
+        assert!(matches_server(&grant, "github"));
+        assert!(matches_server(&grant, "grafana"));
+        assert!(!matches_server(&grant, "sentry"));
+    }
+
+    #[test]
+    fn test_tool_glob_in_grant() {
+        let grant = Grant {
+            server: ServerPattern::Single("*".to_string()),
+            access: AccessLevel::All,
+            tools: vec!["gh_pr*".to_string()],
+            resources: vec![],
+            prompts: vec![],
+            deny: false,
+        };
+        assert!(matches_tool_grant(&grant, "gh_pr_create"));
+        assert!(matches_tool_grant(&grant, "gh_pr"));
+        assert!(!matches_tool_grant(&grant, "gh_issue"));
+    }
+
+    #[test]
+    fn test_grant_no_tools_means_all() {
+        let grant = Grant {
+            server: ServerPattern::Single("*".to_string()),
+            access: AccessLevel::All,
+            tools: vec![],
+            resources: vec![],
+            prompts: vec![],
+            deny: false,
+        };
+        assert!(matches_tool_grant(&grant, "anything"));
+        assert!(matches_tool_grant(&grant, "gh_pr"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Access expansion tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_read_access_allows_read_tools() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "viewer".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Read,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["viewer".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "query_prometheus",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_read_access_denies_write_tools() {
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "viewer".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Read,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["viewer".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "update_dashboard",
+            classification: Some(&write_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_read_access_denies_ambiguous_tools() {
+        let amb_cls = make_classification(Kind::Ambiguous);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "viewer".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Read,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["viewer".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "execute_sql",
+            classification: Some(&amb_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_write_access_allows_write_tools() {
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Write,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_pr",
+            classification: Some(&write_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_write_access_allows_ambiguous_nonstrict() {
+        let amb_cls = make_classification(Kind::Ambiguous);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Write,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "databricks",
+            tool_name: "execute_sql",
+            classification: Some(&amb_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_write_access_denies_ambiguous_strict() {
+        let amb_cls = make_classification(Kind::Ambiguous);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: true,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Write,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "databricks",
+            tool_name: "execute_sql",
+            classification: Some(&amb_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_write_access_denies_read_tools() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "writer".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::Write,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["writer".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_status",
+            classification: Some(&read_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_all_access_allows_everything() {
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: true,
+            roles: HashMap::from([(
+                "admin".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::All,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("alice", vec!["admin".to_string()]);
+
+        for kind in [Kind::Read, Kind::Write, Kind::Ambiguous] {
+            let cls = make_classification(kind);
+            let ctx = ToolContext {
+                server_alias: "any",
+                tool_name: "any_tool",
+                classification: Some(&cls),
+            };
+            assert!(
+                is_tool_allowed_rbac(&identity, &ctx, &acl),
+                "access=* should allow Kind::{kind:?}"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Union evaluation tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_multiple_roles_union() {
+        let read_cls = make_classification(Kind::Read);
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([
+                (
+                    "reader".to_string(),
+                    vec![Grant {
+                        server: ServerPattern::Single("*".to_string()),
+                        access: AccessLevel::Read,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    }],
+                ),
+                (
+                    "writer".to_string(),
+                    vec![Grant {
+                        server: ServerPattern::Single("*".to_string()),
+                        access: AccessLevel::Write,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    }],
+                ),
+            ]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["reader".to_string(), "writer".to_string()]);
+
+        let ctx_read = ToolContext {
+            server_alias: "github",
+            tool_name: "list_repos",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx_read, &acl));
+
+        let ctx_write = ToolContext {
+            server_alias: "github",
+            tool_name: "create_pr",
+            classification: Some(&write_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx_write, &acl));
+    }
+
+    #[test]
+    fn test_deny_overrides_allow() {
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::All,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::Write,
+                        tools: vec!["gh_repo_delete".to_string()],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: true,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+
+        let ctx_pr = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_pr",
+            classification: Some(&write_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx_pr, &acl));
+
+        let ctx_delete = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_repo_delete",
+            classification: Some(&write_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_delete, &acl));
+    }
+
+    #[test]
+    fn test_extra_grants_merge_with_roles() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "readonly".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("github".to_string()),
+                    access: AccessLevel::Read,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::from([(
+                "charlie".to_string(),
+                SubjectConfig {
+                    roles: vec!["readonly".to_string()],
+                    extra: vec![Grant {
+                        server: ServerPattern::Single("sentry".to_string()),
+                        access: AccessLevel::Read,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    }],
+                },
+            )]),
+        };
+        let identity = AuthIdentity::new("charlie", vec![]);
+
+        // Can read github via role
+        let ctx_gh = ToolContext {
+            server_alias: "github",
+            tool_name: "list_repos",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx_gh, &acl));
+
+        // Can read sentry via extra
+        let ctx_sentry = ToolContext {
+            server_alias: "sentry",
+            tool_name: "search_issues",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx_sentry, &acl));
+
+        // Cannot read grafana (no grant)
+        let ctx_grafana = ToolContext {
+            server_alias: "grafana",
+            tool_name: "query_prometheus",
+            classification: Some(&read_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_grafana, &acl));
+    }
+
+    #[test]
+    fn test_no_matching_grants_falls_to_default_allow() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Allow,
+            strict_classification: false,
+            roles: HashMap::new(),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("unknown", vec![]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "anything",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_no_matching_grants_falls_to_default_deny() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::new(),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("unknown", vec![]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "anything",
+            classification: Some(&read_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_subject_inherits_roles_from_config() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "admin".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("*".to_string()),
+                    access: AccessLevel::All,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::from([(
+                "alice".to_string(),
+                SubjectConfig {
+                    roles: vec!["admin".to_string()],
+                    extra: vec![],
+                },
+            )]),
+        };
+        // Token has NO roles, but subject config assigns "admin"
+        let identity = AuthIdentity::new("alice", vec![]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "anything",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+    }
+
+    #[test]
+    fn test_deny_glob_blocks_entire_server() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "restricted".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Single("*".to_string()),
+                        access: AccessLevel::Read,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("sentry".to_string()),
+                        access: AccessLevel::All,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: true,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["restricted".to_string()]);
+
+        // GitHub read works
+        let ctx_gh = ToolContext {
+            server_alias: "github",
+            tool_name: "list_repos",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx_gh, &acl));
+
+        // Sentry is fully blocked by deny
+        let ctx_sentry = ToolContext {
+            server_alias: "sentry",
+            tool_name: "search_issues",
+            classification: Some(&read_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_sentry, &acl));
+    }
+
+    #[test]
+    fn test_server_as_array_in_grant() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Multiple(vec![
+                        "github".to_string(),
+                        "grafana".to_string(),
+                    ]),
+                    access: AccessLevel::Read,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+
+        for server in ["github", "grafana"] {
+            let ctx = ToolContext {
+                server_alias: server,
+                tool_name: "some_tool",
+                classification: Some(&read_cls),
+            };
+            assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        }
+
+        let ctx_sentry = ToolContext {
+            server_alias: "sentry",
+            tool_name: "some_tool",
+            classification: Some(&read_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_sentry, &acl));
+    }
+
+    #[test]
+    fn test_dev_role_read_write_scoped() {
+        let read_cls = make_classification(Kind::Read);
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Multiple(vec![
+                            "github".to_string(),
+                            "grafana".to_string(),
+                        ]),
+                        access: AccessLevel::Read,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::Write,
+                        tools: vec!["gh_pr".to_string(), "gh_issue".to_string()],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+
+        // Can read grafana
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "query_prometheus",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+
+        // Cannot write grafana
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "update_dashboard",
+            classification: Some(&write_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+
+        // Can write gh_pr on github
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_pr",
+            classification: Some(&write_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+
+        // Cannot write gh_repo on github (not in tools list)
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_repo",
+            classification: Some(&write_cls),
+        };
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+
+        // Can read gh_repo on github (read grant covers all tools)
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_repo",
+            classification: Some(&read_cls),
+        };
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
     }
 }

--- a/src/server_auth/mod.rs
+++ b/src/server_auth/mod.rs
@@ -2,7 +2,7 @@ mod acl;
 mod providers;
 
 pub(crate) use acl::glob_match;
-pub use acl::AclConfig;
+pub use acl::{AclConfig, ToolContext};
 pub use providers::{BearerTokenAuth, ForwardedUserAuth, NoAuth};
 
 // Re-exported for tests in other modules (serve.rs)
@@ -134,9 +134,14 @@ pub fn build_auth_provider(config: &ServerAuthConfig) -> Result<Arc<dyn AuthProv
 }
 
 /// Check if a tool is allowed for the given identity.
-pub fn is_tool_allowed(identity: &AuthIdentity, tool_name: &str, acl: &Option<AclConfig>) -> bool {
+pub fn is_tool_allowed(
+    identity: &AuthIdentity,
+    tool_name: &str,
+    acl: &Option<AclConfig>,
+    ctx: Option<&acl::ToolContext>,
+) -> bool {
     match acl {
-        Some(acl) => acl::is_tool_allowed(identity, tool_name, acl),
+        Some(acl) => acl::is_tool_allowed(identity, tool_name, acl, ctx),
         None => true,
     }
 }
@@ -255,7 +260,10 @@ mod tests {
         assert_eq!(config.provider, "bearer");
         assert_eq!(config.bearer.unwrap().tokens.len(), 2);
         let acl = config.acl.unwrap();
-        assert_eq!(acl.rules.len(), 1);
+        match &acl {
+            AclConfig::Legacy(legacy) => assert_eq!(legacy.rules.len(), 1),
+            AclConfig::RoleBased(_) => panic!("expected legacy schema"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
The flat first-match-wins ACL had no notion of servers, no read/write dimension, and rule ordering was error-prone — a misplaced deny could silently flip the whole policy.

New schema lets users define reusable roles with server-aware grants (read/write/*), evaluated as a union where deny always wins. The evaluator consumes tool classifications from the classifier to gate read vs write access, with a strictClassification mode that blocks ambiguous tools entirely. Legacy schema is auto-detected and keeps its original first-match-wins semantics unchanged.

fixed: #55