### PR TITLE
Add ACL check CLI and enriched audit logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 description = "CLI that turns MCP servers into terminal commands"
 authors = ["Thiago Avelino <avelinorun@gmail.com>"]

--- a/docs/guides/audit-logging.md
+++ b/docs/guides/audit-logging.md
@@ -25,6 +25,15 @@ Every entry records:
 | `duration_ms` | How long it took |
 | `success` | Whether it worked |
 | `error_message` | Error details when it failed |
+| `acl_decision` | `allow` or `deny` (proxy `tools/call` only) |
+| `acl_matched_rule` | Which rule decided: `dev[1]`, `alice.extra[0]`, `default`, `legacy[3]`, `no-acl` |
+| `acl_access_kind` | Effective access evaluated: `read`, `write`, or `*` |
+| `classification_kind` | Tool classification: `read`, `write`, or `ambiguous` |
+| `classification_source` | How it was classified: `override`, `annotation`, `classifier`, or `fallback` |
+| `classification_confidence` | Classifier confidence (0.00–1.00) |
+
+The ACL fields are only present on proxy `tools/call` entries. CLI commands
+and other methods omit them (the fields are absent, not null).
 
 ## What gets logged
 
@@ -102,6 +111,15 @@ mcp logs --errors --json | jq '.[].error_message'
 
 # Count calls per server
 mcp logs --json | jq 'group_by(.server_name) | map({server: .[0].server_name, count: length})'
+
+# Denied write requests
+mcp logs --json | jq '.[] | select(.acl_decision=="deny" and .acl_access_kind=="write")'
+
+# Low-confidence classifications that were allowed
+mcp logs --json | jq '.[] | select(.classification_confidence < 0.5 and .acl_decision=="allow")'
+
+# Which rules are denying requests
+mcp logs --json | jq '[.[] | select(.acl_decision=="deny")] | group_by(.acl_matched_rule) | map({rule: .[0].acl_matched_rule, count: length})'
 ```
 
 ## Follow mode

--- a/docs/guides/audit-logging.md
+++ b/docs/guides/audit-logging.md
@@ -25,15 +25,16 @@ Every entry records:
 | `duration_ms` | How long it took |
 | `success` | Whether it worked |
 | `error_message` | Error details when it failed |
-| `acl_decision` | `allow` or `deny` (proxy `tools/call` only) |
-| `acl_matched_rule` | Which rule decided: `dev[1]`, `alice.extra[0]`, `default`, `legacy[3]`, `no-acl` |
+| `acl_decision` | `allow` or `deny` when ACL evaluation is performed |
+| `acl_matched_rule` | Which rule decided: `dev[1]`, `alice.extra[0]`, `default`, `legacy[3]`, `legacy:default`, `no-acl` |
 | `acl_access_kind` | Effective access evaluated: `read`, `write`, or `*` |
 | `classification_kind` | Tool classification: `read`, `write`, or `ambiguous` |
 | `classification_source` | How it was classified: `override`, `annotation`, `classifier`, or `fallback` |
 | `classification_confidence` | Classifier confidence (0.00–1.00) |
 
-The ACL fields are only present on proxy `tools/call` entries. CLI commands
-and other methods omit them (the fields are absent, not null).
+ACL/classification fields are present on entries that perform ACL checks:
+proxy `tools/call`, `tools/list:filtered`, and CLI `acl/check`. Other entries
+omit them (the fields are absent, not null).
 
 ## What gets logged
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -371,7 +371,7 @@ mcp acl check --subject alice --server github --all-tools --format json
 - `--subject <name>` — subject to check (looks up roles from `subjects` map in ACL config)
 - `--server <alias>` — backend server alias (required)
 - `--tool <name>` — single tool to check (required unless `--all-tools`)
-- `--access read|write` — override the tool classification for single-tool checks
+- `--access read|write` — override the tool classification (if omitted, the CLI connects to the backend to classify the tool automatically)
 - `--role <name>` — check a hypothetical role (creates a synthetic identity)
 - `--all-tools` — connect to the backend, list all tools, and check each one
 - `--format table|json` — override the auto-detected output format

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -354,3 +354,51 @@ mcp acl classify --server databricks --format json | jq '.[] | {tool, kind}'
 The JSON form is an array of `{server, tool, kind, confidence, source, reasons}` objects, suitable for scripting or diffing across config changes.
 
 See [Tool ACL overrides](./config-file.md#tool-acl-overrides) for how to pin tools manually, and [`docs/acl-redesign-plan.md`](../acl-redesign-plan.md) for the full redesign context.
+
+### `mcp acl check`
+
+Test an ACL decision without starting the proxy. Useful for validating
+policy changes before rolling them out.
+
+```bash
+mcp acl check --subject alice --server grafana --tool query_prometheus
+mcp acl check --subject bob --server databricks --tool execute_sql --access write
+mcp acl check --role dev --server github --all-tools
+mcp acl check --subject alice --server github --all-tools --format json
+```
+
+**Flags:**
+- `--subject <name>` — subject to check (looks up roles from `subjects` map in ACL config)
+- `--server <alias>` — backend server alias (required)
+- `--tool <name>` — single tool to check (required unless `--all-tools`)
+- `--access read|write` — override the tool classification for single-tool checks
+- `--role <name>` — check a hypothetical role (creates a synthetic identity)
+- `--all-tools` — connect to the backend, list all tools, and check each one
+- `--format table|json` — override the auto-detected output format
+
+**Single-tool output:**
+
+```
+ALLOW  via dev[0]  access=read  classification=classifier:read (confidence 0.72)
+```
+
+**Multi-tool output (`--all-tools`):**
+
+```
+TOOL                                     DECISION RULE                      ACCESS KIND       SOURCE      CONF
+query_prometheus                         ALLOW  dev[0]                    read   read       classifier  0.72
+update_dashboard                         DENY   default                   -      write      classifier  0.81
+```
+
+**Exit code:** `0` for allow, `1` for deny (single-tool mode only).
+`--all-tools` always exits `0` since mixed results are expected.
+
+**Examples:**
+
+```bash
+# CI pre-deploy check: ensure dev role can read grafana
+mcp acl check --role dev --server grafana --tool query_prometheus || echo "BLOCKED"
+
+# Audit what a role can reach on a server
+mcp acl check --role dev --server github --all-tools --format json | jq '.[] | select(.decision=="DENY")'
+```

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -56,6 +56,19 @@ pub struct AuditEntry {
     pub error_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Value>,
+    // -- ACL decision fields (added by issue #56) --
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acl_decision: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acl_matched_rule: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acl_access_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classification_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classification_source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classification_confidence: Option<f32>,
 }
 
 impl AuditEntry {
@@ -362,6 +375,12 @@ mod tests {
             success: true,
             error_message: None,
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         }
     }
 
@@ -377,6 +396,12 @@ mod tests {
             success: false,
             error_message: Some("connection timeout".to_string()),
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         }
     }
 
@@ -685,5 +710,63 @@ mod tests {
         let obj = Value::Object(map);
         let entries = parse_entries_from_list(&obj, 10).unwrap();
         assert_eq!(entries.len(), 1);
+    }
+
+    // --- ACL enrichment tests (issue #56) ---
+
+    #[test]
+    fn test_audit_acl_fields_serialized_when_set() {
+        let mut entry = sample_entry();
+        entry.acl_decision = Some("deny".to_string());
+        entry.acl_matched_rule = Some("dev[1]".to_string());
+        entry.acl_access_kind = Some("write".to_string());
+        entry.classification_kind = Some("write".to_string());
+        entry.classification_source = Some("classifier".to_string());
+        entry.classification_confidence = Some(0.81);
+
+        let json = serde_json::to_value(&entry).unwrap();
+        assert_eq!(json["acl_decision"], "deny");
+        assert_eq!(json["acl_matched_rule"], "dev[1]");
+        assert_eq!(json["acl_access_kind"], "write");
+        assert_eq!(json["classification_kind"], "write");
+        assert_eq!(json["classification_source"], "classifier");
+        assert!((json["classification_confidence"].as_f64().unwrap() - 0.81).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_audit_acl_fields_omitted_when_none() {
+        let entry = sample_entry();
+        let json = serde_json::to_value(&entry).unwrap();
+        let obj = json.as_object().unwrap();
+        // ACL fields should be absent (not null) when None
+        assert!(!obj.contains_key("acl_decision"));
+        assert!(!obj.contains_key("acl_matched_rule"));
+        assert!(!obj.contains_key("acl_access_kind"));
+        assert!(!obj.contains_key("classification_kind"));
+        assert!(!obj.contains_key("classification_source"));
+        assert!(!obj.contains_key("classification_confidence"));
+    }
+
+    #[test]
+    fn test_audit_backwards_compat_deser() {
+        // Old JSON without ACL fields should deserialize with None values
+        let old_json = json!({
+            "timestamp": "2026-03-16T18:30:00Z",
+            "source": "serve:http",
+            "method": "tools/call",
+            "tool_name": "sentry__search_issues",
+            "server_name": "sentry",
+            "identity": "alice",
+            "duration_ms": 142,
+            "success": true,
+            "error_message": null
+        });
+        let entry: AuditEntry = serde_json::from_value(old_json).unwrap();
+        assert!(entry.acl_decision.is_none());
+        assert!(entry.acl_matched_rule.is_none());
+        assert!(entry.acl_access_kind.is_none());
+        assert!(entry.classification_kind.is_none());
+        assert!(entry.classification_source.is_none());
+        assert!(entry.classification_confidence.is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -687,12 +687,17 @@ async fn handle_acl_check(
                 }
             };
 
+            // Legacy ACL matches namespaced tools (e.g. "sentry__search_issues"),
+            // while RBAC matches un-namespaced tool names. Pass the namespaced
+            // form to is_tool_allowed (legacy rules match on it; RBAC ToolContext
+            // uses the original tool_name field for grant matching).
+            let namespaced = format!("{server}__{}", tool.name);
             let ctx = ToolContext {
                 server_alias: &server,
                 tool_name: &tool.name,
                 classification: Some(&cls),
             };
-            let d = server_auth::is_tool_allowed(&identity, &tool.name, acl_config, Some(&ctx));
+            let d = server_auth::is_tool_allowed(&identity, &namespaced, acl_config, Some(&ctx));
             results.push(decision_to_result(&tool.name, &d));
         }
         cache.save();
@@ -700,24 +705,52 @@ async fn handle_acl_check(
     } else {
         // Single tool check.
         let tool = tool_name.unwrap();
-        let cls_kind = match access_override.as_deref() {
-            Some("read") => Some(classifier::Kind::Read),
-            Some("write") => Some(classifier::Kind::Write),
-            _ => None,
+        let cls = match access_override.as_deref() {
+            Some("read") => Some(classifier::ToolClassification {
+                kind: classifier::Kind::Read,
+                confidence: 1.0,
+                source: classifier::Source::Override,
+                reasons: vec!["--access flag".to_string()],
+            }),
+            Some("write") => Some(classifier::ToolClassification {
+                kind: classifier::Kind::Write,
+                confidence: 1.0,
+                source: classifier::Source::Override,
+                reasons: vec!["--access flag".to_string()],
+            }),
+            _ => {
+                // No --access given: connect to backend and classify the tool
+                // so grants with access=read/write can match correctly.
+                let server_config = &cfg.servers[&server];
+                if !use_json {
+                    eprintln!("[acl] connecting to {server} to classify {tool}...");
+                }
+                match client::McpClient::connect(server_config).await {
+                    Ok(mcp_client) => {
+                        let tools = mcp_client.list_tools().await.unwrap_or_default();
+                        let _ = mcp_client.shutdown().await;
+                        tools
+                            .iter()
+                            .find(|t| t.name == tool)
+                            .map(|t| classifier::classify(t, server_config.tool_acl()))
+                    }
+                    Err(e) => {
+                        if !use_json {
+                            eprintln!("[acl] warning: could not connect to classify tool: {e:#}");
+                        }
+                        None
+                    }
+                }
+            }
         };
-        let cls = cls_kind.map(|k| classifier::ToolClassification {
-            kind: k,
-            confidence: 1.0,
-            source: classifier::Source::Override,
-            reasons: vec!["--access flag".to_string()],
-        });
+        let namespaced = format!("{server}__{tool}");
         let ctx = ToolContext {
             server_alias: &server,
             tool_name: &tool,
             classification: cls.as_ref(),
         };
 
-        let d = server_auth::is_tool_allowed(&identity, &tool, acl_config, Some(&ctx));
+        let d = server_auth::is_tool_allowed(&identity, &namespaced, acl_config, Some(&ctx));
         results.push(decision_to_result(&tool, &d));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,10 @@ fn print_usage() {
     eprintln!("  mcp acl classify                    Classify tools as read/write");
     eprintln!("  mcp acl classify --server <alias>   Classify tools for one backend");
     eprintln!("  mcp acl classify --format json      Emit classification as JSON");
+    eprintln!("  mcp acl check --subject <name> --server <alias> --tool <name>");
+    eprintln!("                                      Check ACL decision for a request");
+    eprintln!("  mcp acl check --role <name> --server <alias> --all-tools");
+    eprintln!("                                      Check all tools for a role");
     eprintln!();
     eprintln!("Flags:");
     eprintln!("  --json                              Force JSON output");
@@ -129,6 +133,12 @@ async fn run() -> Result<()> {
             success: result.is_ok(),
             error_message: result.as_ref().err().map(|e| format!("{e:#}")),
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         });
         return result;
     }
@@ -162,6 +172,12 @@ async fn run() -> Result<()> {
                 success,
                 error_message,
                 arguments: Some(serde_json::json!({"query": query})),
+                acl_decision: None,
+                acl_matched_rule: None,
+                acl_access_kind: None,
+                classification_kind: None,
+                classification_source: None,
+                classification_confidence: None,
             });
 
             output::print_search_results(&result?, fmt)?;
@@ -188,6 +204,12 @@ async fn run() -> Result<()> {
                 success: result.is_ok(),
                 error_message: result.as_ref().err().map(|e| format!("{e:#}")),
                 arguments: None,
+                acl_decision: None,
+                acl_matched_rule: None,
+                acl_access_kind: None,
+                classification_kind: None,
+                classification_source: None,
+                classification_confidence: None,
             });
 
             return result;
@@ -210,6 +232,12 @@ async fn run() -> Result<()> {
                 success: result.is_ok(),
                 error_message: result.as_ref().err().map(|e| format!("{e:#}")),
                 arguments: None,
+                acl_decision: None,
+                acl_matched_rule: None,
+                acl_access_kind: None,
+                classification_kind: None,
+                classification_source: None,
+                classification_confidence: None,
             });
 
             return result;
@@ -218,7 +246,7 @@ async fn run() -> Result<()> {
             return handle_logs_command(&args[1..], &cfg, fmt, db_pool.clone()).await;
         }
         "acl" => {
-            return handle_acl_command(&args[1..], &cfg, fmt).await;
+            return handle_acl_command(&args[1..], &cfg, fmt, &audit).await;
         }
         _ => {}
     }
@@ -301,12 +329,17 @@ async fn handle_acl_command(
     args: &[String],
     cfg: &config::Config,
     fmt: OutputFormat,
+    audit: &Arc<audit::AuditLogger>,
 ) -> Result<()> {
     let sub = args.first().map(String::as_str).ok_or_else(|| {
-        anyhow::anyhow!("usage: mcp acl classify [--server <alias>] [--format table|json]")
+        anyhow::anyhow!(
+            "usage: mcp acl <classify|check> [flags]\n  mcp acl classify [--server <alias>]\n  mcp acl check --subject <name> --server <alias> --tool <name>"
+        )
     })?;
-    if sub != "classify" {
-        bail!("unknown acl subcommand: {sub} (did you mean 'classify'?)");
+    match sub {
+        "classify" => {}
+        "check" => return handle_acl_check(&args[1..], cfg, fmt, audit).await,
+        _ => bail!("unknown acl subcommand: {sub} (available: classify, check)"),
     }
 
     // Parse flags
@@ -453,6 +486,310 @@ async fn handle_acl_command(
     Ok(())
 }
 
+/// `mcp acl check --subject <name> --server <alias> --tool <name> [flags]`
+///
+/// Pure policy check: loads config, synthesizes an identity, and evaluates the
+/// ACL without starting the proxy. Useful for validating rule changes before
+/// rolling them out.
+async fn handle_acl_check(
+    args: &[String],
+    cfg: &config::Config,
+    fmt: OutputFormat,
+    audit: &Arc<audit::AuditLogger>,
+) -> Result<()> {
+    use server_auth::{AclConfig, Decision, ToolContext};
+
+    let usage = "usage: mcp acl check --subject <name> --server <alias> --tool <name> \
+                 [--access read|write] [--role <name>] [--all-tools] [--format json|table]";
+
+    let mut subject: Option<String> = None;
+    let mut server_alias: Option<String> = None;
+    let mut tool_name: Option<String> = None;
+    let mut access_override: Option<String> = None;
+    let mut role_override: Option<String> = None;
+    let mut all_tools = false;
+    let mut format_override: Option<String> = None;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--subject" => {
+                subject = Some(
+                    args.get(i + 1)
+                        .filter(|v| !v.starts_with("--"))
+                        .ok_or_else(|| anyhow::anyhow!("{usage}"))?
+                        .clone(),
+                );
+                i += 2;
+            }
+            "--server" => {
+                server_alias = Some(
+                    args.get(i + 1)
+                        .filter(|v| !v.starts_with("--"))
+                        .ok_or_else(|| anyhow::anyhow!("{usage}"))?
+                        .clone(),
+                );
+                i += 2;
+            }
+            "--tool" => {
+                tool_name = Some(
+                    args.get(i + 1)
+                        .filter(|v| !v.starts_with("--"))
+                        .ok_or_else(|| anyhow::anyhow!("{usage}"))?
+                        .clone(),
+                );
+                i += 2;
+            }
+            "--access" => {
+                let val = args
+                    .get(i + 1)
+                    .filter(|v| !v.starts_with("--"))
+                    .ok_or_else(|| anyhow::anyhow!("{usage}"))?
+                    .clone();
+                if val != "read" && val != "write" {
+                    bail!("--access must be 'read' or 'write', got '{val}'");
+                }
+                access_override = Some(val);
+                i += 2;
+            }
+            "--role" => {
+                role_override = Some(
+                    args.get(i + 1)
+                        .filter(|v| !v.starts_with("--"))
+                        .ok_or_else(|| anyhow::anyhow!("{usage}"))?
+                        .clone(),
+                );
+                i += 2;
+            }
+            "--all-tools" => {
+                all_tools = true;
+                i += 1;
+            }
+            "--format" => {
+                format_override = Some(
+                    args.get(i + 1)
+                        .filter(|v| !v.starts_with("--"))
+                        .ok_or_else(|| anyhow::anyhow!("{usage}"))?
+                        .clone(),
+                );
+                i += 2;
+            }
+            other => bail!("unknown flag: {other}\n{usage}"),
+        }
+    }
+
+    let use_json = match format_override.as_deref() {
+        Some("json") => true,
+        Some("table") => false,
+        Some(other) => bail!("unknown --format: {other} (expected 'table' or 'json')"),
+        None => matches!(fmt, OutputFormat::Json),
+    };
+
+    let server = server_alias.ok_or_else(|| anyhow::anyhow!("--server is required\n{usage}"))?;
+    if subject.is_none() && role_override.is_none() {
+        bail!("--subject or --role is required\n{usage}");
+    }
+    if tool_name.is_none() && !all_tools {
+        bail!("--tool or --all-tools is required\n{usage}");
+    }
+
+    // Verify server exists in config.
+    if !cfg.servers.contains_key(&server) {
+        bail!("server \"{server}\" not found in config");
+    }
+
+    let acl_config = &cfg.server_auth.acl;
+
+    // Synthesize identity.
+    let identity = match (&subject, &role_override) {
+        (Some(subj), Some(role)) => {
+            // Subject with a specific role override
+            server_auth::AuthIdentity::new(subj.clone(), vec![role.clone()])
+        }
+        (Some(subj), None) => {
+            // Look up roles from subjects map in ACL config
+            let roles = match acl_config {
+                Some(AclConfig::RoleBased(rbac)) => rbac
+                    .subjects
+                    .get(subj.as_str())
+                    .map(|sc| sc.roles.clone())
+                    .unwrap_or_default(),
+                _ => vec![],
+            };
+            server_auth::AuthIdentity::new(subj.clone(), roles)
+        }
+        (None, Some(role)) => {
+            // Hypothetical role check
+            server_auth::AuthIdentity::new("__check__", vec![role.clone()])
+        }
+        (None, None) => unreachable!(), // validated above
+    };
+
+    // Build the classification for tool(s).
+    #[derive(serde::Serialize)]
+    struct CheckResult {
+        tool: String,
+        decision: &'static str,
+        matched_rule: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        access_evaluated: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        classification_kind: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        classification_source: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        classification_confidence: Option<f32>,
+    }
+
+    fn decision_to_result(tool_name: &str, d: &Decision) -> CheckResult {
+        CheckResult {
+            tool: tool_name.to_string(),
+            decision: if d.allowed { "ALLOW" } else { "DENY" },
+            matched_rule: d.matched_rule.to_string(),
+            access_evaluated: d.access_evaluated.as_ref().map(|a| a.as_str().to_string()),
+            classification_kind: d.classification_kind.map(|k| k.as_str().to_string()),
+            classification_source: d.classification_source.map(|s| s.as_str().to_string()),
+            classification_confidence: d.classification_confidence,
+        }
+    }
+
+    let mut results: Vec<CheckResult> = Vec::new();
+
+    if all_tools {
+        // Connect to backend, list tools, classify, and check each.
+        let server_config = &cfg.servers[&server];
+        if !use_json {
+            eprintln!("[acl] listing tools from {server}...");
+        }
+        let mcp_client = client::McpClient::connect(server_config).await?;
+        let tools = mcp_client.list_tools().await?;
+        let overrides = server_config.tool_acl();
+        let mut cache = classifier_cache::ClassifierCache::load();
+
+        let has_overrides = overrides.is_some_and(|o| !o.read.is_empty() || !o.write.is_empty());
+
+        for tool in &tools {
+            let cls = if has_overrides {
+                classifier::classify(tool, overrides)
+            } else {
+                let key = classifier_cache::cache_key(
+                    &server,
+                    &tool.name,
+                    tool.description.as_deref(),
+                    tool.annotations.as_ref(),
+                );
+                if let Some(cached) = cache.get(&key).cloned() {
+                    cached
+                } else {
+                    let c = classifier::classify(tool, None);
+                    cache.put(key, c.clone());
+                    c
+                }
+            };
+
+            let ctx = ToolContext {
+                server_alias: &server,
+                tool_name: &tool.name,
+                classification: Some(&cls),
+            };
+            let d = server_auth::is_tool_allowed(&identity, &tool.name, acl_config, Some(&ctx));
+            results.push(decision_to_result(&tool.name, &d));
+        }
+        cache.save();
+        let _ = mcp_client.shutdown().await;
+    } else {
+        // Single tool check.
+        let tool = tool_name.unwrap();
+        let cls_kind = match access_override.as_deref() {
+            Some("read") => Some(classifier::Kind::Read),
+            Some("write") => Some(classifier::Kind::Write),
+            _ => None,
+        };
+        let cls = cls_kind.map(|k| classifier::ToolClassification {
+            kind: k,
+            confidence: 1.0,
+            source: classifier::Source::Override,
+            reasons: vec!["--access flag".to_string()],
+        });
+        let ctx = ToolContext {
+            server_alias: &server,
+            tool_name: &tool,
+            classification: cls.as_ref(),
+        };
+
+        let d = server_auth::is_tool_allowed(&identity, &tool, acl_config, Some(&ctx));
+        results.push(decision_to_result(&tool, &d));
+    }
+
+    // Sort results for stable output.
+    results.sort_by(|a, b| a.tool.cmp(&b.tool));
+
+    if use_json {
+        println!("{}", serde_json::to_string_pretty(&results)?);
+    } else {
+        if all_tools {
+            println!(
+                "{:<40} {:<6} {:<25} {:<6} {:<10} {:<11} CONF",
+                "TOOL", "DECISION", "RULE", "ACCESS", "KIND", "SOURCE"
+            );
+        }
+        for r in &results {
+            let access = r.access_evaluated.as_deref().unwrap_or("-");
+            let kind = r.classification_kind.as_deref().unwrap_or("-");
+            let source = r.classification_source.as_deref().unwrap_or("-");
+            let conf = r
+                .classification_confidence
+                .map(|c| format!("{c:.2}"))
+                .unwrap_or_else(|| "-".to_string());
+
+            if all_tools {
+                println!(
+                    "{:<40} {:<6} {:<25} {:<6} {:<10} {:<11} {}",
+                    r.tool, r.decision, r.matched_rule, access, kind, source, conf
+                );
+            } else {
+                println!(
+                    "{:<6} via {}  access={}  classification={}:{} (confidence {})",
+                    r.decision, r.matched_rule, access, source, kind, conf
+                );
+            }
+        }
+    }
+
+    // Log the check to audit.
+    let identity_str = subject
+        .as_deref()
+        .or(role_override.as_deref())
+        .unwrap_or("unknown");
+    for r in &results {
+        audit.log(audit::AuditEntry {
+            timestamp: chrono::Local::now().to_rfc3339(),
+            source: "cli".to_string(),
+            method: "acl/check".to_string(),
+            tool_name: Some(r.tool.clone()),
+            server_name: Some(server.clone()),
+            identity: identity_str.to_string(),
+            duration_ms: 0,
+            success: true,
+            error_message: None,
+            arguments: None,
+            acl_decision: Some(r.decision.to_lowercase()),
+            acl_matched_rule: Some(r.matched_rule.clone()),
+            acl_access_kind: r.access_evaluated.clone(),
+            classification_kind: r.classification_kind.clone(),
+            classification_source: r.classification_source.clone(),
+            classification_confidence: r.classification_confidence,
+        });
+    }
+
+    // Exit code: for single tool, 1 = deny.
+    if !all_tools && results.first().is_some_and(|r| r.decision == "DENY") {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
 async fn handle_server_command(
     args: &[String],
     cfg: &config::Config,
@@ -491,6 +828,12 @@ async fn handle_server_command(
             success,
             error_message,
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         });
 
         if let Some(tools) = tools {
@@ -516,6 +859,12 @@ async fn handle_server_command(
             success: true,
             error_message: None,
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         });
 
         client.shutdown().await?;
@@ -556,6 +905,12 @@ async fn handle_server_command(
             success,
             error_message,
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         });
 
         if let Some(tools) = tools {
@@ -609,6 +964,12 @@ async fn handle_server_command(
         success,
         error_message,
         arguments: log_arguments,
+        acl_decision: None,
+        acl_matched_rule: None,
+        acl_access_kind: None,
+        classification_kind: None,
+        classification_source: None,
+        classification_confidence: None,
     });
 
     if let Some(r) = call_result {
@@ -647,6 +1008,12 @@ async fn handle_add(args: &[String], audit: &Arc<audit::AuditLogger>) -> Result<
             success: result.is_ok(),
             error_message: result.as_ref().err().map(|e| format!("{e:#}")),
             arguments: Some(serde_json::json!({"url": url})),
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         });
 
         return result;
@@ -666,6 +1033,12 @@ async fn handle_add(args: &[String], audit: &Arc<audit::AuditLogger>) -> Result<
         success: result.is_ok(),
         error_message: result.as_ref().err().map(|e| format!("{e:#}")),
         arguments: Some(serde_json::json!({"from": "registry"})),
+        acl_decision: None,
+        acl_matched_rule: None,
+        acl_access_kind: None,
+        classification_kind: None,
+        classification_source: None,
+        classification_confidence: None,
     });
 
     result

--- a/src/output.rs
+++ b/src/output.rs
@@ -989,6 +989,12 @@ mod tests {
                 Some("connection timeout".to_string())
             },
             arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
         }
     }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -133,6 +133,11 @@ type ResolvedCall = (
     Option<Arc<McpClient>>,
     server_auth::Decision,
 );
+/// Ok: (server, tool, args, decision). Err: (optional decision for audit, error response).
+type ResolveResult = std::result::Result<
+    (String, String, Value, server_auth::Decision),
+    (Option<server_auth::Decision>, JsonRpcResponse),
+>;
 
 struct ProxyServer {
     configs: HashMap<String, ServerConfig>,
@@ -526,14 +531,13 @@ impl ProxyServer {
         params: Option<Value>,
         identity: &AuthIdentity,
         acl: &Option<AclConfig>,
-    ) -> std::result::Result<(String, String, Value, server_auth::Decision), JsonRpcResponse> {
+    ) -> ResolveResult {
         let params = match params {
             Some(p) => p,
             None => {
-                return Err(JsonRpcResponse::error(
-                    id.clone(),
-                    -32602,
-                    "missing params for tools/call",
+                return Err((
+                    None,
+                    JsonRpcResponse::error(id.clone(), -32602, "missing params for tools/call"),
                 ));
             }
         };
@@ -541,10 +545,13 @@ impl ProxyServer {
         let tool_name = match params.get("name").and_then(|n| n.as_str()) {
             Some(n) => n.to_string(),
             None => {
-                return Err(JsonRpcResponse::error(
-                    id.clone(),
-                    -32602,
-                    "missing 'name' in tools/call params",
+                return Err((
+                    None,
+                    JsonRpcResponse::error(
+                        id.clone(),
+                        -32602,
+                        "missing 'name' in tools/call params",
+                    ),
                 ));
             }
         };
@@ -554,10 +561,13 @@ impl ProxyServer {
         let (server_name, original_name) = match self.tool_map.get(&tool_name) {
             Some(mapping) => mapping.clone(),
             None => {
-                return Err(JsonRpcResponse::error(
-                    id.clone(),
-                    -32602,
-                    &format!("unknown tool: {tool_name}"),
+                return Err((
+                    None,
+                    JsonRpcResponse::error(
+                        id.clone(),
+                        -32602,
+                        &format!("unknown tool: {tool_name}"),
+                    ),
                 ));
             }
         };
@@ -571,12 +581,15 @@ impl ProxyServer {
 
         let decision = server_auth::is_tool_allowed(identity, &tool_name, acl, Some(&ctx));
         if !decision.allowed {
-            return Err(JsonRpcResponse::error(
-                id.clone(),
-                -32603,
-                &format!(
-                    "access denied: '{}' cannot use tool '{tool_name}'",
-                    identity.subject
+            return Err((
+                Some(decision),
+                JsonRpcResponse::error(
+                    id.clone(),
+                    -32603,
+                    &format!(
+                        "access denied: '{}' cannot use tool '{tool_name}'",
+                        identity.subject
+                    ),
                 ),
             ));
         }
@@ -824,59 +837,60 @@ async fn dispatch_request(
             if needs_discovery {
                 discover_pending_backends(proxy).await;
             }
-            let tools_snapshot: Vec<Value> = {
+            // Snapshot tools + metadata under a brief lock, then release
+            // before ACL evaluation/serialization/logging.
+            let (tools_snap, tool_map_snap, cls_snap, list_audit) = {
                 let p = proxy.lock().await;
-                let mut allowed = Vec::new();
-                for t in &p.tools {
-                    let ctx =
-                        p.tool_map
-                            .get(&t.name)
-                            .map(|(server, orig)| server_auth::ToolContext {
-                                server_alias: server.as_str(),
-                                tool_name: orig.as_str(),
-                                classification: p.classifications.get(&t.name),
-                            });
-                    let decision =
-                        server_auth::is_tool_allowed(identity, &t.name, acl, ctx.as_ref());
-                    if decision.allowed {
-                        allowed.push(serde_json::to_value(t).unwrap());
-                    } else {
-                        // Log each filtered-out tool so operators can see
-                        // what was hidden from a given identity.
-                        let (server_name, _) = p
-                            .tool_map
-                            .get(&t.name)
-                            .map(|(s, _)| (Some(s.clone()), ()))
-                            .unwrap_or((None, ()));
-                        p.audit.log(AuditEntry {
-                            timestamp: chrono::Utc::now().to_rfc3339(),
-                            source: source.to_string(),
-                            method: "tools/list:filtered".to_string(),
-                            tool_name: Some(t.name.clone()),
-                            server_name,
-                            identity: identity.subject.clone(),
-                            duration_ms: 0,
-                            success: true,
-                            error_message: None,
-                            arguments: None,
-                            acl_decision: Some("deny".to_string()),
-                            acl_matched_rule: Some(decision.matched_rule.to_string()),
-                            acl_access_kind: decision
-                                .access_evaluated
-                                .as_ref()
-                                .map(|a| a.as_str().to_string()),
-                            classification_kind: decision
-                                .classification_kind
-                                .map(|k| k.as_str().to_string()),
-                            classification_source: decision
-                                .classification_source
-                                .map(|s| s.as_str().to_string()),
-                            classification_confidence: decision.classification_confidence,
-                        });
-                    }
-                }
-                allowed
+                (
+                    p.tools.clone(),
+                    p.tool_map.clone(),
+                    p.classifications.clone(),
+                    Arc::clone(&p.audit),
+                )
             };
+            let mut tools_allowed: Vec<Value> = Vec::new();
+            for t in &tools_snap {
+                let ctx =
+                    tool_map_snap
+                        .get(&t.name)
+                        .map(|(server, orig)| server_auth::ToolContext {
+                            server_alias: server.as_str(),
+                            tool_name: orig.as_str(),
+                            classification: cls_snap.get(&t.name),
+                        });
+                let decision = server_auth::is_tool_allowed(identity, &t.name, acl, ctx.as_ref());
+                if decision.allowed {
+                    tools_allowed.push(serde_json::to_value(t).unwrap());
+                } else {
+                    let srv = tool_map_snap.get(&t.name).map(|(s, _)| s.clone());
+                    list_audit.log(AuditEntry {
+                        timestamp: chrono::Utc::now().to_rfc3339(),
+                        source: source.to_string(),
+                        method: "tools/list:filtered".to_string(),
+                        tool_name: Some(t.name.clone()),
+                        server_name: srv,
+                        identity: identity.subject.clone(),
+                        duration_ms: 0,
+                        success: true,
+                        error_message: None,
+                        arguments: None,
+                        acl_decision: Some("deny".to_string()),
+                        acl_matched_rule: Some(decision.matched_rule.to_string()),
+                        acl_access_kind: decision
+                            .access_evaluated
+                            .as_ref()
+                            .map(|a| a.as_str().to_string()),
+                        classification_kind: decision
+                            .classification_kind
+                            .map(|k| k.as_str().to_string()),
+                        classification_source: decision
+                            .classification_source
+                            .map(|s| s.as_str().to_string()),
+                        classification_confidence: decision.classification_confidence,
+                    });
+                }
+            }
+            let tools_snapshot = tools_allowed;
             JsonRpcResponse::success(id, json!({ "tools": tools_snapshot }))
         }
         "tools/call" => {
@@ -915,7 +929,10 @@ async fn dispatch_request(
                         server_name_for_audit = Some(server.clone());
                         Ok((server, orig, args, client, decision))
                     }
-                    Err(resp) => Err(resp),
+                    Err((maybe_decision, resp)) => {
+                        decision_for_audit = maybe_decision;
+                        Err(resp)
+                    }
                 }
             };
 
@@ -1219,33 +1236,34 @@ async fn authenticate_request(
     source: &str,
 ) -> Result<AuthIdentity, (StatusCode, Json<Value>)> {
     let creds = extract_credentials(headers);
-    state.auth_provider.authenticate(&creds).await.map_err(|e| {
-        // Log the authentication failure to audit.
-        // Use blocking_lock since we're inside a sync closure (map_err).
-        // This is safe — the proxy lock is never held long enough to cause issues.
-        let audit = Arc::clone(&state.proxy.blocking_lock().audit);
-        audit.log(AuditEntry {
-            timestamp: chrono::Utc::now().to_rfc3339(),
-            source: source.to_string(),
-            method: "auth/failure".to_string(),
-            tool_name: None,
-            server_name: None,
-            identity: "anonymous".to_string(),
-            duration_ms: 0,
-            success: false,
-            error_message: Some(format!("authentication failed: {e}")),
-            arguments: None,
-            acl_decision: None,
-            acl_matched_rule: None,
-            acl_access_kind: None,
-            classification_kind: None,
-            classification_source: None,
-            classification_confidence: None,
-        });
-        let err =
-            JsonRpcResponse::error(Value::Null, -32000, &format!("authentication failed: {e}"));
-        (StatusCode::UNAUTHORIZED, Json(json!(err)))
-    })
+    match state.auth_provider.authenticate(&creds).await {
+        Ok(identity) => Ok(identity),
+        Err(e) => {
+            // Log auth failure using async lock (safe in async context).
+            let audit = Arc::clone(&state.proxy.lock().await.audit);
+            audit.log(AuditEntry {
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                source: source.to_string(),
+                method: "auth/failure".to_string(),
+                tool_name: None,
+                server_name: None,
+                identity: "anonymous".to_string(),
+                duration_ms: 0,
+                success: false,
+                error_message: Some(format!("authentication failed: {e}")),
+                arguments: None,
+                acl_decision: None,
+                acl_matched_rule: None,
+                acl_access_kind: None,
+                classification_kind: None,
+                classification_source: None,
+                classification_confidence: None,
+            });
+            let err =
+                JsonRpcResponse::error(Value::Null, -32000, &format!("authentication failed: {e}"));
+            Err((StatusCode::UNAUTHORIZED, Json(json!(err))))
+        }
+    }
 }
 
 /// Bind a TCP listener with TCP keepalive enabled. Short keepalive intervals

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -126,7 +126,13 @@ type SharedProxy = Arc<Mutex<ProxyServer>>;
 
 /// Result of resolving a `tools/call` request: server name, original tool
 /// name, arguments, and (optionally) an already-connected client.
-type ResolvedCall = (String, String, Value, Option<Arc<McpClient>>);
+type ResolvedCall = (
+    String,
+    String,
+    Value,
+    Option<Arc<McpClient>>,
+    server_auth::Decision,
+);
 
 struct ProxyServer {
     configs: HashMap<String, ServerConfig>,
@@ -520,7 +526,7 @@ impl ProxyServer {
         params: Option<Value>,
         identity: &AuthIdentity,
         acl: &Option<AclConfig>,
-    ) -> std::result::Result<(String, String, Value), JsonRpcResponse> {
+    ) -> std::result::Result<(String, String, Value, server_auth::Decision), JsonRpcResponse> {
         let params = match params {
             Some(p) => p,
             None => {
@@ -563,7 +569,8 @@ impl ProxyServer {
             classification,
         };
 
-        if !server_auth::is_tool_allowed(identity, &tool_name, acl, Some(&ctx)) {
+        let decision = server_auth::is_tool_allowed(identity, &tool_name, acl, Some(&ctx));
+        if !decision.allowed {
             return Err(JsonRpcResponse::error(
                 id.clone(),
                 -32603,
@@ -574,7 +581,7 @@ impl ProxyServer {
             ));
         }
 
-        Ok((server_name, original_name, arguments))
+        Ok((server_name, original_name, arguments, decision))
     }
 
     /// Drain all connected backends and return them so they can be shut down
@@ -696,7 +703,26 @@ async fn discover_pending_backends(proxy: &SharedProxy) {
             }
             Ok(Err(e)) => {
                 let mut p = proxy.lock().await;
-                eprintln!("[serve] {name}: failed to discover: {e:#}");
+                let msg = format!("failed to discover: {e:#}");
+                eprintln!("[serve] {name}: {msg}");
+                p.audit.log(AuditEntry {
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    source: "serve:discovery".to_string(),
+                    method: "discovery/failure".to_string(),
+                    tool_name: None,
+                    server_name: Some(name.clone()),
+                    identity: "system".to_string(),
+                    duration_ms: 0,
+                    success: false,
+                    error_message: Some(msg),
+                    arguments: None,
+                    acl_decision: None,
+                    acl_matched_rule: None,
+                    acl_access_kind: None,
+                    classification_kind: None,
+                    classification_source: None,
+                    classification_confidence: None,
+                });
                 p.discovery_failures
                     .entry(name)
                     .or_insert_with(DiscoveryFailure::new)
@@ -704,10 +730,26 @@ async fn discover_pending_backends(proxy: &SharedProxy) {
             }
             Err(_) => {
                 let mut p = proxy.lock().await;
-                eprintln!(
-                    "[serve] {name}: discovery timed out ({}s)",
-                    discovery_timeout.as_secs()
-                );
+                let msg = format!("discovery timed out ({}s)", discovery_timeout.as_secs());
+                eprintln!("[serve] {name}: {msg}");
+                p.audit.log(AuditEntry {
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                    source: "serve:discovery".to_string(),
+                    method: "discovery/timeout".to_string(),
+                    tool_name: None,
+                    server_name: Some(name.clone()),
+                    identity: "system".to_string(),
+                    duration_ms: discovery_timeout.as_millis() as u64,
+                    success: false,
+                    error_message: Some(msg),
+                    arguments: None,
+                    acl_decision: None,
+                    acl_matched_rule: None,
+                    acl_access_kind: None,
+                    classification_kind: None,
+                    classification_source: None,
+                    classification_confidence: None,
+                });
                 p.discovery_failures
                     .entry(name)
                     .or_insert_with(DiscoveryFailure::new)
@@ -762,6 +804,7 @@ async fn dispatch_request(
     let audit_logger: Arc<AuditLogger>;
     let mut tool_name_for_audit: Option<String> = None;
     let mut server_name_for_audit: Option<String> = None;
+    let mut decision_for_audit: Option<server_auth::Decision> = None;
 
     let response = match req.method.as_str() {
         "initialize" => {
@@ -783,20 +826,56 @@ async fn dispatch_request(
             }
             let tools_snapshot: Vec<Value> = {
                 let p = proxy.lock().await;
-                p.tools
-                    .iter()
-                    .filter(|t| {
-                        let ctx = p.tool_map.get(&t.name).map(|(server, orig)| {
-                            server_auth::ToolContext {
+                let mut allowed = Vec::new();
+                for t in &p.tools {
+                    let ctx =
+                        p.tool_map
+                            .get(&t.name)
+                            .map(|(server, orig)| server_auth::ToolContext {
                                 server_alias: server.as_str(),
                                 tool_name: orig.as_str(),
                                 classification: p.classifications.get(&t.name),
-                            }
+                            });
+                    let decision =
+                        server_auth::is_tool_allowed(identity, &t.name, acl, ctx.as_ref());
+                    if decision.allowed {
+                        allowed.push(serde_json::to_value(t).unwrap());
+                    } else {
+                        // Log each filtered-out tool so operators can see
+                        // what was hidden from a given identity.
+                        let (server_name, _) = p
+                            .tool_map
+                            .get(&t.name)
+                            .map(|(s, _)| (Some(s.clone()), ()))
+                            .unwrap_or((None, ()));
+                        p.audit.log(AuditEntry {
+                            timestamp: chrono::Utc::now().to_rfc3339(),
+                            source: source.to_string(),
+                            method: "tools/list:filtered".to_string(),
+                            tool_name: Some(t.name.clone()),
+                            server_name,
+                            identity: identity.subject.clone(),
+                            duration_ms: 0,
+                            success: true,
+                            error_message: None,
+                            arguments: None,
+                            acl_decision: Some("deny".to_string()),
+                            acl_matched_rule: Some(decision.matched_rule.to_string()),
+                            acl_access_kind: decision
+                                .access_evaluated
+                                .as_ref()
+                                .map(|a| a.as_str().to_string()),
+                            classification_kind: decision
+                                .classification_kind
+                                .map(|k| k.as_str().to_string()),
+                            classification_source: decision
+                                .classification_source
+                                .map(|s| s.as_str().to_string()),
+                            classification_confidence: decision.classification_confidence,
                         });
-                        server_auth::is_tool_allowed(identity, &t.name, acl, ctx.as_ref())
-                    })
-                    .map(|t| serde_json::to_value(t).unwrap())
-                    .collect()
+                    }
+                }
+                allowed
             };
             JsonRpcResponse::success(id, json!({ "tools": tools_snapshot }))
         }
@@ -828,13 +907,13 @@ async fn dispatch_request(
             let resolved: std::result::Result<ResolvedCall, JsonRpcResponse> = {
                 let mut p = proxy.lock().await;
                 match p.resolve_tool_call(&id, req.params.clone(), identity, acl) {
-                    Ok((server, orig, args)) => {
+                    Ok((server, orig, args, decision)) => {
                         let client = p.try_get_client(&server);
                         // Refine the audit entry now that we know the
                         // namespaced tool resolves to a real backend.
                         tool_name_for_audit = Some(format!("{server}{SEPARATOR}{orig}"));
                         server_name_for_audit = Some(server.clone());
-                        Ok((server, orig, args, client))
+                        Ok((server, orig, args, client, decision))
                     }
                     Err(resp) => Err(resp),
                 }
@@ -842,7 +921,8 @@ async fn dispatch_request(
 
             match resolved {
                 Err(resp) => resp,
-                Ok((server, original, args, maybe_client)) => {
+                Ok((server, original, args, maybe_client, acl_decision)) => {
+                    decision_for_audit = Some(acl_decision);
                     // Phase 2: ensure connected (without holding the proxy
                     // lock during the connect itself).
                     let client_result: Result<Arc<McpClient>> = match maybe_client {
@@ -888,6 +968,7 @@ async fn dispatch_request(
             server_name: server_name_for_audit,
             identity,
             start,
+            decision: decision_for_audit,
         },
         response,
     )
@@ -901,9 +982,23 @@ struct AuditCtx<'a> {
     server_name: Option<String>,
     identity: &'a AuthIdentity,
     start: std::time::Instant,
+    decision: Option<server_auth::Decision>,
 }
 
 fn finish_audit(ctx: AuditCtx<'_>, response: JsonRpcResponse) -> JsonRpcResponse {
+    let (acl_decision, acl_matched_rule, acl_access_kind, cls_kind, cls_source, cls_conf) =
+        match &ctx.decision {
+            Some(d) => (
+                Some(if d.allowed { "allow" } else { "deny" }.to_string()),
+                Some(d.matched_rule.to_string()),
+                d.access_evaluated.as_ref().map(|a| a.as_str().to_string()),
+                d.classification_kind.map(|k| k.as_str().to_string()),
+                d.classification_source.map(|s| s.as_str().to_string()),
+                d.classification_confidence,
+            ),
+            None => (None, None, None, None, None, None),
+        };
+
     ctx.audit.log(AuditEntry {
         timestamp: chrono::Utc::now().to_rfc3339(),
         source: ctx.source.to_string(),
@@ -915,6 +1010,12 @@ fn finish_audit(ctx: AuditCtx<'_>, response: JsonRpcResponse) -> JsonRpcResponse
         success: response.error.is_none(),
         error_message: response.error.as_ref().map(|e| e.message.clone()),
         arguments: None,
+        acl_decision,
+        acl_matched_rule,
+        acl_access_kind,
+        classification_kind: cls_kind,
+        classification_source: cls_source,
+        classification_confidence: cls_conf,
     });
     response
 }
@@ -1111,12 +1212,36 @@ fn extract_credentials(headers: &HeaderMap) -> Credentials {
 }
 
 /// Authenticate an HTTP request. Returns identity on success, or a 401 response.
+/// Logs authentication failures to the audit log.
 async fn authenticate_request(
     state: &AppState,
     headers: &HeaderMap,
+    source: &str,
 ) -> Result<AuthIdentity, (StatusCode, Json<Value>)> {
     let creds = extract_credentials(headers);
     state.auth_provider.authenticate(&creds).await.map_err(|e| {
+        // Log the authentication failure to audit.
+        // Use blocking_lock since we're inside a sync closure (map_err).
+        // This is safe — the proxy lock is never held long enough to cause issues.
+        let audit = Arc::clone(&state.proxy.blocking_lock().audit);
+        audit.log(AuditEntry {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            source: source.to_string(),
+            method: "auth/failure".to_string(),
+            tool_name: None,
+            server_name: None,
+            identity: "anonymous".to_string(),
+            duration_ms: 0,
+            success: false,
+            error_message: Some(format!("authentication failed: {e}")),
+            arguments: None,
+            acl_decision: None,
+            acl_matched_rule: None,
+            acl_access_kind: None,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
+        });
         let err =
             JsonRpcResponse::error(Value::Null, -32000, &format!("authentication failed: {e}"));
         (StatusCode::UNAUTHORIZED, Json(json!(err)))
@@ -1376,7 +1501,7 @@ async fn mcp_handler(
     }
 
     // Authenticate
-    let identity = match authenticate_request(&state, &headers).await {
+    let identity = match authenticate_request(&state, &headers, "serve:http").await {
         Ok(id) => id,
         Err(resp) => return resp,
     };
@@ -1476,7 +1601,7 @@ async fn mcp_handler(
 // and receives JSON-RPC responses as SSE `message` events.
 async fn mcp_sse_handler(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     // Authenticate
-    if let Err(resp) = authenticate_request(&state, &headers).await {
+    if let Err(resp) = authenticate_request(&state, &headers, "serve:http").await {
         return resp.into_response();
     }
 

--- a/src/server_auth/acl.rs
+++ b/src/server_auth/acl.rs
@@ -1,9 +1,10 @@
 use std::collections::HashMap;
+use std::fmt;
 
 use serde::Deserialize;
 
 use super::AuthIdentity;
-use crate::classifier::{Kind, ToolClassification};
+use crate::classifier::{Kind, Source, ToolClassification};
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -62,6 +63,16 @@ pub enum AccessLevel {
     Write,
     #[serde(rename = "*")]
     All,
+}
+
+impl AccessLevel {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AccessLevel::Read => "read",
+            AccessLevel::Write => "write",
+            AccessLevel::All => "*",
+        }
+    }
 }
 
 /// A single grant entry within a role definition or a subject's `extra` list.
@@ -171,22 +182,91 @@ pub struct ToolContext<'a> {
 }
 
 // ---------------------------------------------------------------------------
+// Decision — structured result from ACL evaluation
+// ---------------------------------------------------------------------------
+
+/// Stable identifier for the rule that determined the access decision.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatchedRule {
+    /// Legacy schema: rule at index N matched.
+    Legacy(usize),
+    /// Legacy schema default policy.
+    LegacyDefault,
+    /// RBAC: grant from role at grant-index within that role.
+    RoleGrant { role: String, index: usize },
+    /// RBAC: extra grant on a subject.
+    SubjectExtra { subject: String, index: usize },
+    /// RBAC default policy.
+    RbacDefault,
+    /// No ACL configured.
+    NoAcl,
+}
+
+impl fmt::Display for MatchedRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MatchedRule::Legacy(i) => write!(f, "legacy[{i}]"),
+            MatchedRule::LegacyDefault => write!(f, "legacy:default"),
+            MatchedRule::RoleGrant { role, index } => write!(f, "{role}[{index}]"),
+            MatchedRule::SubjectExtra { subject, index } => {
+                write!(f, "{subject}.extra[{index}]")
+            }
+            MatchedRule::RbacDefault => write!(f, "default"),
+            MatchedRule::NoAcl => write!(f, "no-acl"),
+        }
+    }
+}
+
+/// Structured result from ACL evaluation, carrying the decision and its provenance.
+#[derive(Debug, Clone)]
+pub struct Decision {
+    pub allowed: bool,
+    pub matched_rule: MatchedRule,
+    pub classification_kind: Option<Kind>,
+    pub classification_source: Option<Source>,
+    pub classification_confidence: Option<f32>,
+    pub access_evaluated: Option<AccessLevel>,
+}
+
+impl Decision {
+    fn from_ctx(allowed: bool, matched_rule: MatchedRule, ctx: Option<&ToolContext>) -> Self {
+        let (kind, source, confidence) = match ctx.and_then(|c| c.classification) {
+            Some(cls) => (Some(cls.kind), Some(cls.source), Some(cls.confidence)),
+            None => (None, None, None),
+        };
+        Self {
+            allowed,
+            matched_rule,
+            classification_kind: kind,
+            classification_source: source,
+            classification_confidence: confidence,
+            access_evaluated: None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Unified dispatcher
 // ---------------------------------------------------------------------------
 
 /// Check if a tool is allowed for the given identity.
 /// Legacy schema uses first-match-wins; role-based uses union evaluation.
+/// Returns a structured `Decision` with provenance information.
 pub fn is_tool_allowed(
     identity: &AuthIdentity,
     tool_name: &str,
     acl: &AclConfig,
     ctx: Option<&ToolContext>,
-) -> bool {
+) -> Decision {
     match acl {
-        AclConfig::Legacy(legacy) => legacy_is_tool_allowed(identity, tool_name, legacy),
+        AclConfig::Legacy(legacy) => legacy_is_tool_allowed(identity, tool_name, legacy, ctx),
         AclConfig::RoleBased(rbac) => match ctx {
             Some(c) => is_tool_allowed_rbac(identity, c, rbac),
-            None => rbac.default == AclPolicy::Allow,
+            None => Decision::from_ctx(
+                rbac.default == AclPolicy::Allow,
+                MatchedRule::RbacDefault,
+                None,
+            ),
         },
     }
 }
@@ -195,17 +275,26 @@ pub fn is_tool_allowed(
 // Legacy evaluator (first-match-wins, unchanged logic)
 // ---------------------------------------------------------------------------
 
-fn legacy_is_tool_allowed(identity: &AuthIdentity, tool_name: &str, acl: &LegacyAclConfig) -> bool {
-    for rule in &acl.rules {
+fn legacy_is_tool_allowed(
+    identity: &AuthIdentity,
+    tool_name: &str,
+    acl: &LegacyAclConfig,
+    ctx: Option<&ToolContext>,
+) -> Decision {
+    for (i, rule) in acl.rules.iter().enumerate() {
         if !matches_identity(identity, rule) {
             continue;
         }
         if !matches_tool(tool_name, &rule.tools) {
             continue;
         }
-        return rule.policy == AclPolicy::Allow;
+        return Decision::from_ctx(rule.policy == AclPolicy::Allow, MatchedRule::Legacy(i), ctx);
     }
-    acl.default == AclPolicy::Allow
+    Decision::from_ctx(
+        acl.default == AclPolicy::Allow,
+        MatchedRule::LegacyDefault,
+        ctx,
+    )
 }
 
 fn matches_identity(identity: &AuthIdentity, rule: &AclRule) -> bool {
@@ -234,48 +323,99 @@ fn matches_tool(tool_name: &str, patterns: &[String]) -> bool {
 // Role-based evaluator (union semantics)
 // ---------------------------------------------------------------------------
 
+/// A grant tagged with its provenance (which role/subject it came from).
+struct TaggedGrant<'a> {
+    grant: &'a Grant,
+    origin: MatchedRule,
+}
+
 fn is_tool_allowed_rbac(
     identity: &AuthIdentity,
     ctx: &ToolContext,
     acl: &RoleBasedAclConfig,
-) -> bool {
+) -> Decision {
     let (role_names, extra_grants) = resolve_subject(identity, acl);
 
-    // Collect all grants from matched roles + extra.
-    let mut all_grants: Vec<&Grant> = Vec::new();
+    let (cls_kind, cls_source, cls_confidence) = match ctx.classification {
+        Some(cls) => (Some(cls.kind), Some(cls.source), Some(cls.confidence)),
+        None => (None, None, None),
+    };
+
+    // Collect all grants tagged with provenance.
+    let mut all_grants: Vec<TaggedGrant> = Vec::new();
     for role_name in &role_names {
         if let Some(grants) = acl.roles.get(role_name) {
-            all_grants.extend(grants.iter());
+            for (i, grant) in grants.iter().enumerate() {
+                all_grants.push(TaggedGrant {
+                    grant,
+                    origin: MatchedRule::RoleGrant {
+                        role: role_name.clone(),
+                        index: i,
+                    },
+                });
+            }
         }
     }
-    all_grants.extend(extra_grants);
+    for (i, grant) in extra_grants.iter().enumerate() {
+        all_grants.push(TaggedGrant {
+            grant,
+            origin: MatchedRule::SubjectExtra {
+                subject: identity.subject.clone(),
+                index: i,
+            },
+        });
+    }
 
     // Filter to grants that match server + tool.
-    let matching: Vec<&Grant> = all_grants
-        .into_iter()
-        .filter(|g| matches_server(g, ctx.server_alias) && matches_tool_grant(g, ctx.tool_name))
+    let matching: Vec<&TaggedGrant> = all_grants
+        .iter()
+        .filter(|tg| {
+            matches_server(tg.grant, ctx.server_alias)
+                && matches_tool_grant(tg.grant, ctx.tool_name)
+        })
         .collect();
 
     let kind = ctx.classification.map(|c| c.kind);
 
     // Union evaluation: deny always wins, but only for grants that also
     // cover the current access classification.
-    if matching
+    if let Some(tg) = matching
         .iter()
-        .any(|g| g.deny && deny_covers_access(g, kind, acl.strict_classification))
+        .find(|tg| tg.grant.deny && deny_covers_access(tg.grant, kind, acl.strict_classification))
     {
-        return false;
+        return Decision {
+            allowed: false,
+            matched_rule: tg.origin.clone(),
+            classification_kind: cls_kind,
+            classification_source: cls_source,
+            classification_confidence: cls_confidence,
+            access_evaluated: Some(tg.grant.access.clone()),
+        };
     }
 
-    if matching
+    if let Some(tg) = matching
         .iter()
-        .any(|g| grant_covers_access(g, kind, acl.strict_classification))
+        .find(|tg| grant_covers_access(tg.grant, kind, acl.strict_classification))
     {
-        return true;
+        return Decision {
+            allowed: true,
+            matched_rule: tg.origin.clone(),
+            classification_kind: cls_kind,
+            classification_source: cls_source,
+            classification_confidence: cls_confidence,
+            access_evaluated: Some(tg.grant.access.clone()),
+        };
     }
 
     // No matching grant -> fall back to default.
-    acl.default == AclPolicy::Allow
+    Decision {
+        allowed: acl.default == AclPolicy::Allow,
+        matched_rule: MatchedRule::RbacDefault,
+        classification_kind: cls_kind,
+        classification_source: cls_source,
+        classification_confidence: cls_confidence,
+        access_evaluated: None,
+    }
 }
 
 /// Resolve roles and extra grants for an identity.
@@ -453,6 +593,16 @@ mod tests {
         AuthIdentity::anonymous()
     }
 
+    /// Shorthand: call is_tool_allowed and return just the bool.
+    fn is_tool_allowed_bool(
+        identity: &AuthIdentity,
+        tool_name: &str,
+        acl: &AclConfig,
+        ctx: Option<&ToolContext>,
+    ) -> bool {
+        is_tool_allowed(identity, tool_name, acl, ctx).allowed
+    }
+
     fn make_classification(kind: Kind) -> ToolClassification {
         ToolClassification {
             kind,
@@ -469,14 +619,14 @@ mod tests {
     #[test]
     fn test_default_allow_no_rules() {
         let acl = AclConfig::legacy(AclPolicy::Allow, vec![]);
-        assert!(is_tool_allowed(&alice(), "any_tool", &acl, None));
-        assert!(is_tool_allowed(&anon(), "any_tool", &acl, None));
+        assert!(is_tool_allowed_bool(&alice(), "any_tool", &acl, None));
+        assert!(is_tool_allowed_bool(&anon(), "any_tool", &acl, None));
     }
 
     #[test]
     fn test_default_deny_no_rules() {
         let acl = AclConfig::legacy(AclPolicy::Deny, vec![]);
-        assert!(!is_tool_allowed(&alice(), "any_tool", &acl, None));
+        assert!(!is_tool_allowed_bool(&alice(), "any_tool", &acl, None));
     }
 
     #[test]
@@ -491,14 +641,19 @@ mod tests {
             }],
         );
 
-        assert!(!is_tool_allowed(
+        assert!(!is_tool_allowed_bool(
             &bob(),
             "sentry__search_issues",
             &acl,
             None
         ));
-        assert!(is_tool_allowed(&bob(), "slack__send_message", &acl, None));
-        assert!(is_tool_allowed(
+        assert!(is_tool_allowed_bool(
+            &bob(),
+            "slack__send_message",
+            &acl,
+            None
+        ));
+        assert!(is_tool_allowed_bool(
             &alice(),
             "sentry__search_issues",
             &acl,
@@ -518,8 +673,8 @@ mod tests {
             }],
         );
 
-        assert!(is_tool_allowed(&alice(), "anything", &acl, None));
-        assert!(!is_tool_allowed(&bob(), "anything", &acl, None));
+        assert!(is_tool_allowed_bool(&alice(), "anything", &acl, None));
+        assert!(!is_tool_allowed_bool(&bob(), "anything", &acl, None));
     }
 
     #[test]
@@ -542,8 +697,13 @@ mod tests {
             ],
         );
 
-        assert!(is_tool_allowed(&bob(), "sentry__search_issues", &acl, None));
-        assert!(!is_tool_allowed(
+        assert!(is_tool_allowed_bool(
+            &bob(),
+            "sentry__search_issues",
+            &acl,
+            None
+        ));
+        assert!(!is_tool_allowed_bool(
             &bob(),
             "sentry__delete_project",
             &acl,
@@ -587,10 +747,15 @@ mod tests {
             }],
         );
 
-        assert!(is_tool_allowed(&alice(), "health__check", &acl, None));
-        assert!(is_tool_allowed(&bob(), "health__check", &acl, None));
-        assert!(is_tool_allowed(&anon(), "health__check", &acl, None));
-        assert!(!is_tool_allowed(&alice(), "sentry__search", &acl, None));
+        assert!(is_tool_allowed_bool(&alice(), "health__check", &acl, None));
+        assert!(is_tool_allowed_bool(&bob(), "health__check", &acl, None));
+        assert!(is_tool_allowed_bool(&anon(), "health__check", &acl, None));
+        assert!(!is_tool_allowed_bool(
+            &alice(),
+            "sentry__search",
+            &acl,
+            None
+        ));
     }
 
     #[test]
@@ -605,10 +770,15 @@ mod tests {
             }],
         );
 
-        assert!(is_tool_allowed(&bob(), "dangerous__delete", &acl, None));
+        assert!(is_tool_allowed_bool(
+            &bob(),
+            "dangerous__delete",
+            &acl,
+            None
+        ));
 
         let bob_admin = AuthIdentity::new("bob", vec!["admin".to_string()]);
-        assert!(!is_tool_allowed(
+        assert!(!is_tool_allowed_bool(
             &bob_admin,
             "dangerous__delete",
             &acl,
@@ -689,10 +859,15 @@ mod tests {
             }],
         );
 
-        assert!(!is_tool_allowed(&bob(), "admin_panel", &acl, None));
-        assert!(!is_tool_allowed(&bob(), "user_admin_panel", &acl, None));
-        assert!(is_tool_allowed(&bob(), "user_panel", &acl, None));
-        assert!(is_tool_allowed(&alice(), "admin_panel", &acl, None));
+        assert!(!is_tool_allowed_bool(&bob(), "admin_panel", &acl, None));
+        assert!(!is_tool_allowed_bool(
+            &bob(),
+            "user_admin_panel",
+            &acl,
+            None
+        ));
+        assert!(is_tool_allowed_bool(&bob(), "user_panel", &acl, None));
+        assert!(is_tool_allowed_bool(&alice(), "admin_panel", &acl, None));
     }
 
     #[test]
@@ -957,7 +1132,7 @@ mod tests {
             tool_name: "query_prometheus",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -985,7 +1160,7 @@ mod tests {
             tool_name: "update_dashboard",
             classification: Some(&write_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1013,7 +1188,7 @@ mod tests {
             tool_name: "execute_sql",
             classification: Some(&amb_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1041,7 +1216,7 @@ mod tests {
             tool_name: "gh_pr",
             classification: Some(&write_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1069,7 +1244,7 @@ mod tests {
             tool_name: "execute_sql",
             classification: Some(&amb_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1097,7 +1272,7 @@ mod tests {
             tool_name: "execute_sql",
             classification: Some(&amb_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1125,7 +1300,7 @@ mod tests {
             tool_name: "gh_status",
             classification: Some(&read_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1156,7 +1331,7 @@ mod tests {
                 classification: Some(&cls),
             };
             assert!(
-                is_tool_allowed_rbac(&identity, &ctx, &acl),
+                is_tool_allowed_rbac(&identity, &ctx, &acl).allowed,
                 "access=* non-strict should allow Kind::{kind:?}"
             );
         }
@@ -1191,7 +1366,7 @@ mod tests {
                 classification: Some(&cls),
             };
             assert!(
-                is_tool_allowed_rbac(&identity, &ctx, &acl),
+                is_tool_allowed_rbac(&identity, &ctx, &acl).allowed,
                 "access=* strict should allow Kind::{kind:?}"
             );
         }
@@ -1204,7 +1379,7 @@ mod tests {
             classification: Some(&cls),
         };
         assert!(
-            !is_tool_allowed_rbac(&identity, &ctx, &acl),
+            !is_tool_allowed_rbac(&identity, &ctx, &acl).allowed,
             "access=* strict should block Kind::Ambiguous"
         );
     }
@@ -1253,14 +1428,14 @@ mod tests {
             tool_name: "list_repos",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx_read, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx_read, &acl).allowed);
 
         let ctx_write = ToolContext {
             server_alias: "github",
             tool_name: "create_pr",
             classification: Some(&write_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx_write, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx_write, &acl).allowed);
     }
 
     #[test]
@@ -1299,14 +1474,14 @@ mod tests {
             tool_name: "gh_pr",
             classification: Some(&write_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx_pr, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx_pr, &acl).allowed);
 
         let ctx_delete = ToolContext {
             server_alias: "github",
             tool_name: "gh_repo_delete",
             classification: Some(&write_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx_delete, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_delete, &acl).allowed);
     }
 
     #[test]
@@ -1349,7 +1524,7 @@ mod tests {
             tool_name: "list_repos",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx_gh, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx_gh, &acl).allowed);
 
         // Can read sentry via extra
         let ctx_sentry = ToolContext {
@@ -1357,7 +1532,7 @@ mod tests {
             tool_name: "search_issues",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx_sentry, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx_sentry, &acl).allowed);
 
         // Cannot read grafana (no grant)
         let ctx_grafana = ToolContext {
@@ -1365,7 +1540,7 @@ mod tests {
             tool_name: "query_prometheus",
             classification: Some(&read_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx_grafana, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_grafana, &acl).allowed);
     }
 
     #[test]
@@ -1383,7 +1558,7 @@ mod tests {
             tool_name: "anything",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1401,7 +1576,7 @@ mod tests {
             tool_name: "anything",
             classification: Some(&read_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1436,7 +1611,7 @@ mod tests {
             tool_name: "anything",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1476,7 +1651,7 @@ mod tests {
             tool_name: "list_repos",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx_gh, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx_gh, &acl).allowed);
 
         // Sentry is fully blocked by deny
         let ctx_sentry = ToolContext {
@@ -1484,7 +1659,7 @@ mod tests {
             tool_name: "search_issues",
             classification: Some(&read_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx_sentry, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_sentry, &acl).allowed);
     }
 
     #[test]
@@ -1517,7 +1692,7 @@ mod tests {
                 tool_name: "some_tool",
                 classification: Some(&read_cls),
             };
-            assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+            assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
         }
 
         let ctx_sentry = ToolContext {
@@ -1525,7 +1700,7 @@ mod tests {
             tool_name: "some_tool",
             classification: Some(&read_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx_sentry, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx_sentry, &acl).allowed);
     }
 
     #[test]
@@ -1569,7 +1744,7 @@ mod tests {
             tool_name: "query_prometheus",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
 
         // Cannot write grafana
         let ctx = ToolContext {
@@ -1577,7 +1752,7 @@ mod tests {
             tool_name: "update_dashboard",
             classification: Some(&write_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
 
         // Can write gh_pr on github
         let ctx = ToolContext {
@@ -1585,7 +1760,7 @@ mod tests {
             tool_name: "gh_pr",
             classification: Some(&write_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
 
         // Cannot write gh_repo on github (not in tools list)
         let ctx = ToolContext {
@@ -1593,7 +1768,7 @@ mod tests {
             tool_name: "gh_repo",
             classification: Some(&write_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
 
         // Can read gh_repo on github (read grant covers all tools)
         let ctx = ToolContext {
@@ -1601,7 +1776,7 @@ mod tests {
             tool_name: "gh_repo",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     // -----------------------------------------------------------------------
@@ -1648,7 +1823,7 @@ mod tests {
             tool_name: "gh_secret_tool",
             classification: Some(&read_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
 
         // Write is NOT denied — the deny grant only covers read
         let ctx = ToolContext {
@@ -1656,7 +1831,7 @@ mod tests {
             tool_name: "gh_secret_tool",
             classification: Some(&write_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1697,7 +1872,7 @@ mod tests {
             tool_name: "gh_repo_delete",
             classification: Some(&write_cls),
         };
-        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(!is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
 
         // Read is NOT denied — the deny grant only covers write
         let ctx = ToolContext {
@@ -1705,7 +1880,7 @@ mod tests {
             tool_name: "gh_repo_delete",
             classification: Some(&read_cls),
         };
-        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl));
+        assert!(is_tool_allowed_rbac(&identity, &ctx, &acl).allowed);
     }
 
     #[test]
@@ -1746,5 +1921,285 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("unknown role"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Decision provenance tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_matched_rule_display() {
+        assert_eq!(MatchedRule::Legacy(0).to_string(), "legacy[0]");
+        assert_eq!(MatchedRule::Legacy(3).to_string(), "legacy[3]");
+        assert_eq!(MatchedRule::LegacyDefault.to_string(), "legacy:default");
+        assert_eq!(
+            MatchedRule::RoleGrant {
+                role: "dev".to_string(),
+                index: 1
+            }
+            .to_string(),
+            "dev[1]"
+        );
+        assert_eq!(
+            MatchedRule::SubjectExtra {
+                subject: "alice".to_string(),
+                index: 0
+            }
+            .to_string(),
+            "alice.extra[0]"
+        );
+        assert_eq!(MatchedRule::RbacDefault.to_string(), "default");
+        assert_eq!(MatchedRule::NoAcl.to_string(), "no-acl");
+    }
+
+    #[test]
+    fn test_decision_legacy_first_rule_match() {
+        let acl = AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![AclRule {
+                subjects: vec!["bob".to_string()],
+                roles: vec![],
+                tools: vec!["sentry__*".to_string()],
+                policy: AclPolicy::Deny,
+            }],
+        );
+        let d = is_tool_allowed(&bob(), "sentry__search_issues", &acl, None);
+        assert!(!d.allowed);
+        assert_eq!(d.matched_rule, MatchedRule::Legacy(0));
+    }
+
+    #[test]
+    fn test_decision_legacy_second_rule_match() {
+        let acl = AclConfig::legacy(
+            AclPolicy::Allow,
+            vec![
+                AclRule {
+                    subjects: vec!["alice".to_string()],
+                    roles: vec![],
+                    tools: vec!["*".to_string()],
+                    policy: AclPolicy::Allow,
+                },
+                AclRule {
+                    subjects: vec!["bob".to_string()],
+                    roles: vec![],
+                    tools: vec!["sentry__*".to_string()],
+                    policy: AclPolicy::Deny,
+                },
+            ],
+        );
+        let d = is_tool_allowed(&bob(), "sentry__delete", &acl, None);
+        assert!(!d.allowed);
+        assert_eq!(d.matched_rule, MatchedRule::Legacy(1));
+    }
+
+    #[test]
+    fn test_decision_legacy_default_fallback() {
+        let acl = AclConfig::legacy(
+            AclPolicy::Deny,
+            vec![AclRule {
+                subjects: vec!["alice".to_string()],
+                roles: vec![],
+                tools: vec!["*".to_string()],
+                policy: AclPolicy::Allow,
+            }],
+        );
+        let d = is_tool_allowed(&bob(), "anything", &acl, None);
+        assert!(!d.allowed);
+        assert_eq!(d.matched_rule, MatchedRule::LegacyDefault);
+    }
+
+    #[test]
+    fn test_decision_rbac_role_grant_index() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::Write,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("grafana".to_string()),
+                        access: AccessLevel::Read,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "query_prometheus",
+            classification: Some(&read_cls),
+        };
+        let d = is_tool_allowed_rbac(&identity, &ctx, &acl);
+        assert!(d.allowed);
+        assert_eq!(
+            d.matched_rule,
+            MatchedRule::RoleGrant {
+                role: "dev".to_string(),
+                index: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_decision_rbac_subject_extra() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "readonly".to_string(),
+                vec![Grant {
+                    server: ServerPattern::Single("github".to_string()),
+                    access: AccessLevel::Read,
+                    tools: vec![],
+                    resources: vec![],
+                    prompts: vec![],
+                    deny: false,
+                }],
+            )]),
+            subjects: HashMap::from([(
+                "charlie".to_string(),
+                SubjectConfig {
+                    roles: vec!["readonly".to_string()],
+                    extra: vec![Grant {
+                        server: ServerPattern::Single("sentry".to_string()),
+                        access: AccessLevel::Read,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    }],
+                },
+            )]),
+        };
+        let identity = AuthIdentity::new("charlie", vec![]);
+        let ctx = ToolContext {
+            server_alias: "sentry",
+            tool_name: "search_issues",
+            classification: Some(&read_cls),
+        };
+        let d = is_tool_allowed_rbac(&identity, &ctx, &acl);
+        assert!(d.allowed);
+        assert_eq!(
+            d.matched_rule,
+            MatchedRule::SubjectExtra {
+                subject: "charlie".to_string(),
+                index: 0
+            }
+        );
+    }
+
+    #[test]
+    fn test_decision_rbac_deny_provenance() {
+        let write_cls = make_classification(Kind::Write);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::from([(
+                "dev".to_string(),
+                vec![
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::All,
+                        tools: vec![],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: false,
+                    },
+                    Grant {
+                        server: ServerPattern::Single("github".to_string()),
+                        access: AccessLevel::Write,
+                        tools: vec!["gh_repo_delete".to_string()],
+                        resources: vec![],
+                        prompts: vec![],
+                        deny: true,
+                    },
+                ],
+            )]),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec!["dev".to_string()]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "gh_repo_delete",
+            classification: Some(&write_cls),
+        };
+        let d = is_tool_allowed_rbac(&identity, &ctx, &acl);
+        assert!(!d.allowed);
+        assert_eq!(
+            d.matched_rule,
+            MatchedRule::RoleGrant {
+                role: "dev".to_string(),
+                index: 1
+            }
+        );
+    }
+
+    #[test]
+    fn test_decision_rbac_default() {
+        let read_cls = make_classification(Kind::Read);
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Deny,
+            strict_classification: false,
+            roles: HashMap::new(),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("unknown", vec![]);
+        let ctx = ToolContext {
+            server_alias: "github",
+            tool_name: "anything",
+            classification: Some(&read_cls),
+        };
+        let d = is_tool_allowed_rbac(&identity, &ctx, &acl);
+        assert!(!d.allowed);
+        assert_eq!(d.matched_rule, MatchedRule::RbacDefault);
+    }
+
+    #[test]
+    fn test_decision_classification_populated() {
+        let cls = ToolClassification {
+            kind: Kind::Read,
+            confidence: 0.72,
+            source: Source::Classifier,
+            reasons: vec!["test".to_string()],
+        };
+        let acl = RoleBasedAclConfig {
+            default: AclPolicy::Allow,
+            strict_classification: false,
+            roles: HashMap::new(),
+            subjects: HashMap::new(),
+        };
+        let identity = AuthIdentity::new("bob", vec![]);
+        let ctx = ToolContext {
+            server_alias: "grafana",
+            tool_name: "query_prometheus",
+            classification: Some(&cls),
+        };
+        let d = is_tool_allowed_rbac(&identity, &ctx, &acl);
+        assert!(d.allowed);
+        assert_eq!(d.classification_kind, Some(Kind::Read));
+        assert_eq!(d.classification_source, Some(Source::Classifier));
+        assert!((d.classification_confidence.unwrap() - 0.72).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_decision_access_level_as_str() {
+        assert_eq!(AccessLevel::Read.as_str(), "read");
+        assert_eq!(AccessLevel::Write.as_str(), "write");
+        assert_eq!(AccessLevel::All.as_str(), "*");
     }
 }

--- a/src/server_auth/mod.rs
+++ b/src/server_auth/mod.rs
@@ -2,7 +2,7 @@ mod acl;
 mod providers;
 
 pub(crate) use acl::glob_match;
-pub use acl::{AclConfig, ToolContext};
+pub use acl::{AclConfig, Decision, MatchedRule, ToolContext};
 pub use providers::{BearerTokenAuth, ForwardedUserAuth, NoAuth};
 
 // Re-exported for tests in other modules (serve.rs)
@@ -139,10 +139,17 @@ pub fn is_tool_allowed(
     tool_name: &str,
     acl: &Option<AclConfig>,
     ctx: Option<&acl::ToolContext>,
-) -> bool {
+) -> Decision {
     match acl {
         Some(acl) => acl::is_tool_allowed(identity, tool_name, acl, ctx),
-        None => true,
+        None => Decision {
+            allowed: true,
+            matched_rule: MatchedRule::NoAcl,
+            classification_kind: None,
+            classification_source: None,
+            classification_confidence: None,
+            access_evaluated: None,
+        },
     }
 }
 


### PR DESCRIPTION
The ACL evaluator returned a bare bool — no way to know which rule matched, what the classification was, or why a request was denied. Operators had to start the proxy and hit it to test rule changes

Replace the bool with a structured Decision type that carries provenance (matched rule, classification context, access level). Wire it through serve.rs into AuditEntry with 6 new fields. Add `mcp acl check` CLI for offline policy checks without running the proxy. Close audit gaps for auth failures, tools/list filtering, and discovery errors

fixed: #56