### PR TITLE
Add multi-stage Dockerfile and built-in healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,25 @@
-FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY mcp /usr/local/bin/mcp
+# --- Build stage (Alpine = native musl, no cross-compile wrapper) ---
+FROM rust:alpine AS builder
+
+RUN apk add --no-cache musl-dev
+
+WORKDIR /app
+
+# Cache dependencies: copy manifests first, build a dummy project
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
+    cargo build --release && \
+    rm -rf src
+
+# Build the real binary
+COPY src/ src/
+RUN touch src/main.rs && cargo build --release
+
+# --- Runtime stage (scratch = only binary + CA certs) ---
+FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/target/release/mcp /usr/local/bin/mcp
+
+EXPOSE 8080
 ENTRYPOINT ["mcp"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   mcp-proxy:
     build:
       context: .
-      dockerfile: Dockerfile.dev
+      dockerfile: Dockerfile
     command: ["serve", "--http", "0.0.0.0:8080", "--insecure"]
     ports:
       - "8080:8080"
@@ -23,7 +23,7 @@ services:
       - ./servers.json:/root/.config/mcp/servers.json:ro
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "mcp", "serve", "--help"]
+      test: ["CMD", "mcp", "healthcheck"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ fn print_usage() {
     eprintln!("                                      Check ACL decision for a request");
     eprintln!("  mcp acl check --role <name> --server <alias> --all-tools");
     eprintln!("                                      Check all tools for a role");
+    eprintln!("  mcp healthcheck [url]               HTTP health probe (for containers)");
     eprintln!();
     eprintln!("Flags:");
     eprintln!("  --json                              Force JSON output");
@@ -88,6 +89,32 @@ async fn run() -> Result<()> {
     if args.is_empty() || args[0] == "--help" || args[0] == "-h" {
         print_usage();
         return Ok(());
+    }
+
+    // Built-in HTTP health probe for container health checks (scratch/distroless
+    // images have no curl/wget). Exits 0 if the endpoint returns 2xx, 1 otherwise.
+    if args[0] == "healthcheck" {
+        let url = args
+            .get(1)
+            .map(|s| s.as_str())
+            .unwrap_or("http://localhost:8080/health");
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()?;
+        let resp = client.get(url).send().await;
+        match resp {
+            Ok(r) if r.status().is_success() => {
+                std::process::exit(0);
+            }
+            Ok(r) => {
+                eprintln!("healthcheck failed: HTTP {}", r.status());
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("healthcheck failed: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 
     // `serve` manages its own db pool — handle it before creating the shared one.


### PR DESCRIPTION
The Dockerfile required a pre-built binary and the compose file referenced a nonexistent Dockerfile.dev. The health check ran `mcp serve --help` which always exits 0 regardless of server state.

Replace with a multi-stage build (rust:alpine to scratch) that compiles from source and produces an 11.8MB image. Add `mcp healthcheck [url]` subcommand so scratch images can probe /health without external tools.

Fixes: #65
Fixes: #66
Fixes: #73