### PR TITLE
Add container-friendly config and env var overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ FROM alpine:latest AS certs
 FROM scratch AS release
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --chmod=755 mcp /usr/local/bin/mcp
+# Scratch has no writable filesystem — disable audit by default.
+# Override with -e MCP_AUDIT_ENABLED=true when a volume is mounted.
+ENV MCP_AUDIT_ENABLED=false
 EXPOSE 8080
 ENTRYPOINT ["mcp"]
 
@@ -29,5 +32,8 @@ ENTRYPOINT ["mcp"]
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/target/release/mcp /usr/local/bin/mcp
+# Scratch has no writable filesystem — disable audit by default.
+# Override with -e MCP_AUDIT_ENABLED=true when a volume is mounted.
+ENV MCP_AUDIT_ENABLED=false
 EXPOSE 8080
 ENTRYPOINT ["mcp"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
           "mcpServers": {
             "example": {
               "url": "https://example.com/mcp",
-              "headers": {"Authorization": "Bearer ${EXAMPLE_TOKEN}"}
+              "headers": {"Authorization": "Bearer $${EXAMPLE_TOKEN}"}
             }
           },
           "serverAuth": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,15 @@
 # MCP Proxy Server — Docker Compose example
 #
-# Usage:
-#   cp servers.example.json servers.json   # edit with your backends and tokens
+# Option A — Inline config (no file mount):
+#   Edit the MCP_SERVERS_CONFIG value below, then:
 #   docker compose up --build
+#
+#   Tip: load from file with shell substitution:
+#     MCP_SERVERS_CONFIG="$(cat servers.json)" docker compose up --build
+#
+# Option B — File mount (traditional):
+#   cp servers.example.json servers.json   # edit with your backends and tokens
+#   docker compose --profile file-mount up --build
 #
 # Test:
 #   curl http://localhost:8080/health
@@ -12,7 +19,39 @@
 #     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
 
 services:
+  # Option A: inline config via environment variable
   mcp-proxy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ["serve", "--http", "0.0.0.0:8080", "--insecure"]
+    ports:
+      - "8080:8080"
+    environment:
+      MCP_SERVERS_CONFIG: |
+        {
+          "mcpServers": {
+            "example": {
+              "url": "https://example.com/mcp",
+              "headers": {"Authorization": "Bearer ${EXAMPLE_TOKEN}"}
+            }
+          },
+          "serverAuth": {
+            "provider": "bearer",
+            "tokens": ["change-me-alice"]
+          }
+        }
+      # EXAMPLE_TOKEN: "your-token-here"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mcp", "healthcheck"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  # Option B: file-mounted config (activate with --profile file-mount)
+  mcp-proxy-file:
+    profiles: ["file-mount"]
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/guides/audit-logging.md
+++ b/docs/guides/audit-logging.md
@@ -198,6 +198,8 @@ Each entry is stored as a JSON document with key `audit:{timestamp_millis}-{uuid
 
 ## Disabling audit logging
 
+Via config file:
+
 ```json
 {
   "audit": {
@@ -206,4 +208,33 @@ Each entry is stored as a JSON document with key `audit:{timestamp_millis}-{uuid
 }
 ```
 
-When disabled, the logger is a no-op — zero overhead, no files created.
+Via environment variable (takes priority over config file):
+
+```bash
+MCP_AUDIT_ENABLED=false mcp serve --http 0.0.0.0:8080
+```
+
+When disabled, the logger is a no-op and the database is not initialized — zero overhead, no files created, no filesystem writes. This is the default in the Docker image.
+
+## Environment variable overrides
+
+All audit settings can be overridden via environment variables, which take priority over the config file. This is useful for container deployments where editing the config JSON is impractical.
+
+| Variable | Overrides | Description |
+|---|---|---|
+| `MCP_AUDIT_ENABLED` | `audit.enabled` | Set to `false` or `0` to disable |
+| `MCP_AUDIT_PATH` | `audit.path` | ChronDB data directory |
+| `MCP_AUDIT_INDEX_PATH` | `audit.index_path` | ChronDB index directory |
+
+Example: redirect audit to a mounted volume in Docker:
+
+```bash
+docker run -d \
+  -e MCP_AUDIT_ENABLED=true \
+  -e MCP_AUDIT_PATH=/data/audit/data \
+  -e MCP_AUDIT_INDEX_PATH=/data/audit/index \
+  -v audit-vol:/data/audit \
+  ghcr.io/avelino/mcp serve --http 0.0.0.0:8080
+```
+
+See the full list of variables in the [environment variables reference](../reference/environment-variables.md).

--- a/docs/howto/docker.md
+++ b/docs/howto/docker.md
@@ -27,6 +27,39 @@ docker run --rm ghcr.io/avelino/mcp search github
 
 ## Using your config
 
+There are two ways to provide configuration: **file mount** (traditional) or **inline JSON** (container-friendly).
+
+### Option A: Inline config (recommended for containers)
+
+Pass the entire config as an environment variable — no file mounts needed:
+
+```bash
+docker run --rm \
+  -e MCP_SERVERS_CONFIG='{
+    "mcpServers": {
+      "sentry": {
+        "url": "https://mcp.sentry.dev/sse",
+        "headers": {"Authorization": "Bearer ${SENTRY_TOKEN}"}
+      }
+    }
+  }' \
+  -e SENTRY_TOKEN \
+  ghcr.io/avelino/mcp sentry search_issues '{"query": "is:unresolved"}'
+```
+
+You can also read the JSON from an existing file with `$(cat ...)`:
+
+```bash
+docker run --rm \
+  -e MCP_SERVERS_CONFIG="$(cat servers.json)" \
+  -e SENTRY_TOKEN \
+  ghcr.io/avelino/mcp sentry search_issues '{"query": "is:unresolved"}'
+```
+
+This is ideal for Docker Compose, Kubernetes, and CI/CD — the config lives in the orchestrator, not the filesystem.
+
+### Option B: File mount
+
 Mount your local config directory so the container can access your server definitions:
 
 ```bash
@@ -41,9 +74,8 @@ Servers that need API tokens or other secrets require environment variables. Pas
 
 ```bash
 docker run --rm \
-  -v ~/.config/mcp:/root/.config/mcp \
+  -e MCP_SERVERS_CONFIG='{"mcpServers":{"github":{"url":"https://api.github.com/mcp","headers":{"Authorization":"Bearer ${GITHUB_TOKEN}"}}}}' \
   -e GITHUB_TOKEN \
-  -e SLACK_TOKEN \
   ghcr.io/avelino/mcp github list_repositories '{"query": "mcp"}'
 ```
 
@@ -53,13 +85,124 @@ You can also use an env file:
 # .env
 GITHUB_TOKEN=ghp_xxxx
 SLACK_TOKEN=xoxb-xxxx
+MCP_SERVERS_CONFIG={"mcpServers":{"github":{"url":"https://api.github.com/mcp","headers":{"Authorization":"Bearer ${GITHUB_TOKEN}"}}}}
 ```
 
 ```bash
 docker run --rm \
-  -v ~/.config/mcp:/root/.config/mcp \
   --env-file .env \
-  ghcr.io/avelino/mcp sentry search_issues '{"query": "is:unresolved"}'
+  ghcr.io/avelino/mcp github list_repositories '{"query": "mcp"}'
+```
+
+## Proxy mode (long-running)
+
+Run the MCP proxy as a long-running service:
+
+```bash
+docker run -d \
+  -e MCP_SERVERS_CONFIG='{
+    "mcpServers": {
+      "sentry": {"url": "https://mcp.sentry.dev/sse"}
+    },
+    "serverAuth": {
+      "provider": "bearer",
+      "tokens": ["my-secret-token"]
+    }
+  }' \
+  -p 8080:8080 \
+  ghcr.io/avelino/mcp serve --http 0.0.0.0:8080 --insecure
+```
+
+### With audit logging
+
+The default image disables audit logging (`MCP_AUDIT_ENABLED=false`) because `scratch` images have no writable filesystem. To enable it, mount a volume and override:
+
+```bash
+docker run -d \
+  -e MCP_SERVERS_CONFIG='{"mcpServers":{...}}' \
+  -e MCP_AUDIT_ENABLED=true \
+  -e MCP_AUDIT_PATH=/data/audit/data \
+  -e MCP_AUDIT_INDEX_PATH=/data/audit/index \
+  -v audit-data:/data/audit \
+  -p 8080:8080 \
+  ghcr.io/avelino/mcp serve --http 0.0.0.0:8080 --insecure
+```
+
+## Container environment variables
+
+These variables are especially useful for container deployments. See the full list in the [environment variables reference](../reference/environment-variables.md).
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MCP_SERVERS_CONFIG` | — | Inline JSON config, no file mount needed |
+| `MCP_CONFIG_DIR` | `~/.config/mcp` | Override config directory |
+| `MCP_AUDIT_ENABLED` | `false` (in Docker image) | Disable audit for read-only fs |
+| `MCP_AUDIT_PATH` | `~/.config/mcp/db/data` | Override audit data path |
+| `MCP_AUDIT_INDEX_PATH` | `~/.config/mcp/db/index` | Override audit index path |
+| `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override OAuth token storage |
+| `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Override classifier cache |
+
+## Kubernetes
+
+Use `MCP_SERVERS_CONFIG` to inject config via ConfigMap or Secret — no file mount needed:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-proxy
+  template:
+    metadata:
+      labels:
+        app: mcp-proxy
+    spec:
+      containers:
+        - name: mcp
+          image: ghcr.io/avelino/mcp:latest
+          args: ["serve", "--http", "0.0.0.0:8080", "--insecure"]
+          ports:
+            - containerPort: 8080
+          env:
+            - name: MCP_SERVERS_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: mcp-config
+                  key: servers.json
+            - name: SENTRY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-secrets
+                  key: sentry-token
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-config
+data:
+  servers.json: |
+    {
+      "mcpServers": {
+        "sentry": {
+          "url": "https://mcp.sentry.dev/sse",
+          "headers": {"Authorization": "Bearer ${SENTRY_TOKEN}"}
+        }
+      }
+    }
 ```
 
 ## Shell alias
@@ -88,7 +231,7 @@ Pipe input via stdin with `-i` (Docker's interactive flag):
 
 ```bash
 echo '{"query": "is:unresolved"}' | docker run --rm -i \
-  -v ~/.config/mcp:/root/.config/mcp \
+  -e MCP_SERVERS_CONFIG='{"mcpServers":{"sentry":{"url":"https://mcp.sentry.dev/sse"}}}' \
   ghcr.io/avelino/mcp sentry search_issues
 ```
 
@@ -103,4 +246,5 @@ docker run --rm ghcr.io/avelino/mcp:0.1.0 --help
 ## Limitations
 
 - **Stdio servers only work if the runtime is available inside the container.** The default image includes only the `mcp` binary and `ca-certificates`. Servers that require `npx`, `python`, or other runtimes won't work unless you build a custom image. HTTP servers (configured with `url`) work out of the box.
-- **OAuth browser flow doesn't work in Docker.** For HTTP servers that need OAuth, run `mcp add <server>` on your host first to complete authentication, then mount the config directory (which includes `auth.json`).
+- **OAuth browser flow doesn't work in Docker.** For HTTP servers that need OAuth, run `mcp add <server>` on your host first to complete authentication, then mount the config directory (which includes `auth.json`), or set `MCP_AUTH_PATH` to a mounted volume.
+- **Audit logging is disabled by default** in the Docker image because `scratch` images have no writable filesystem. Enable it with `MCP_AUDIT_ENABLED=true` and mount a volume for the data.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -6,11 +6,54 @@ These variables configure `mcp` behavior:
 
 | Variable | Default | Description |
 |---|---|---|
+| `MCP_SERVERS_CONFIG` | — | Inline JSON config (entire `servers.json` content). Highest priority — skips file read entirely. |
 | `MCP_CONFIG_PATH` | `~/.config/mcp/servers.json` | Path to the config file |
+| `MCP_CONFIG_DIR` | `~/.config/mcp` | Config directory. Falls back to `/tmp/mcp` when `HOME` is not set. |
 | `MCP_TIMEOUT` | `60` | Timeout in seconds for stdio server responses |
+| `MCP_MAX_OUTPUT` | `1048576` | Maximum output bytes from CLI server commands |
 | `MCP_PROXY_REQUEST_TIMEOUT` | `120` | (proxy mode) Hard upper bound, in seconds, that any single client request can spend inside `mcp serve` before the proxy returns a JSON-RPC error. Acts as a belt-and-suspenders boundary on top of the per-transport `MCP_TIMEOUT`. |
 | `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Path to the persistent tool read/write classification cache (see [`mcp acl classify`](./cli.md#mcp-acl-classify)). Override this in CI/containers that cannot write to `$HOME`. |
 | `MCP_DISCOVERY_CONCURRENCY` | `10` | Max parallel `--help` calls during CLI subcommand discovery (see [CLI as MCP](../guides/cli-as-mcp.md)) |
+| `MCP_AUDIT_ENABLED` | `true` | Set to `false` or `0` to disable audit logging and database initialization. Overrides `audit.enabled` in the config file. |
+| `MCP_AUDIT_PATH` | `~/.config/mcp/db/data` | Override the ChronDB data directory. Overrides `audit.path` in the config file. |
+| `MCP_AUDIT_INDEX_PATH` | `~/.config/mcp/db/index` | Override the ChronDB index directory. Overrides `audit.index_path` in the config file. |
+| `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override the OAuth token storage location |
+
+### Config loading priority
+
+`mcp` resolves its configuration in this order:
+
+1. **`MCP_SERVERS_CONFIG`** — inline JSON string, parsed directly (no file read)
+2. **`MCP_CONFIG_PATH`** — path to a config file
+3. **`MCP_CONFIG_DIR`/servers.json** — config directory override
+4. **`~/.config/mcp/servers.json`** — default file location
+5. **`/tmp/mcp/servers.json`** — last-resort fallback when `HOME` is not set
+
+Environment variable substitution (`${VAR_NAME}`) works in all cases, including inline config.
+
+### `MCP_SERVERS_CONFIG`
+
+Provide the entire config as a JSON string. This is the recommended approach for containers — no file mounts required:
+
+```bash
+export MCP_SERVERS_CONFIG='{
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/sse",
+      "headers": {"Authorization": "Bearer ${SENTRY_TOKEN}"}
+    }
+  }
+}'
+mcp serve --http 0.0.0.0:8080
+```
+
+Load from an existing file with `$(cat ...)`:
+
+```bash
+MCP_SERVERS_CONFIG="$(cat servers.json)" mcp serve --http 0.0.0.0:8080
+```
+
+`MCP_SERVERS_CONFIG` takes priority over `MCP_CONFIG_PATH`. If both are set, the inline config wins.
 
 ### `MCP_CONFIG_PATH`
 
@@ -19,6 +62,16 @@ Override the default config file location. Useful for maintaining multiple confi
 ```bash
 MCP_CONFIG_PATH=./test-servers.json mcp --list
 ```
+
+### `MCP_CONFIG_DIR`
+
+Override the base config directory (default `~/.config/mcp`). All default paths (`servers.json`, `auth.json`, `db/`, `tool-classification.json`) resolve relative to this directory.
+
+```bash
+MCP_CONFIG_DIR=/data/mcp mcp serve --http 0.0.0.0:8080
+```
+
+When `HOME` is not set (common in `scratch` and `distroless` containers), `mcp` falls back to `/tmp/mcp` with a warning.
 
 ### `MCP_TIMEOUT`
 
@@ -29,6 +82,14 @@ MCP_TIMEOUT=120 mcp slack --list
 ```
 
 Does not affect HTTP servers (they use reqwest's default timeouts).
+
+### `MCP_MAX_OUTPUT`
+
+Maximum number of bytes to capture from a CLI server's stdout. Commands that exceed this limit have their output truncated. Default is 1 MB.
+
+```bash
+MCP_MAX_OUTPUT=5242880 mcp my-cli some-tool '{"query": "large dataset"}'
+```
 
 ### `MCP_PROXY_REQUEST_TIMEOUT`
 
@@ -61,6 +122,37 @@ Only applies to CLI servers (`cli: true`). Limits how many `--help` calls run in
 
 ```bash
 MCP_DISCOVERY_CONCURRENCY=5 mcp kubectl --list
+```
+
+### `MCP_AUDIT_ENABLED`
+
+Disable audit logging entirely. When set to `false` or `0`, the database is not initialized and no filesystem writes occur. This overrides `"enabled": true` in the config file's `audit` section.
+
+The default Docker image sets `MCP_AUDIT_ENABLED=false` because `scratch` images have no writable filesystem. Override it when you mount a volume:
+
+```bash
+docker run --rm \
+  -e MCP_AUDIT_ENABLED=true \
+  -e MCP_AUDIT_PATH=/data/audit/data \
+  -e MCP_AUDIT_INDEX_PATH=/data/audit/index \
+  -v audit-data:/data/audit \
+  ghcr.io/avelino/mcp serve --http 0.0.0.0:8080
+```
+
+### `MCP_AUDIT_PATH` / `MCP_AUDIT_INDEX_PATH`
+
+Override the ChronDB data and index directories. These take priority over the `audit.path` and `audit.index_path` fields in the config file.
+
+```bash
+MCP_AUDIT_PATH=/var/lib/mcp/data MCP_AUDIT_INDEX_PATH=/var/lib/mcp/index mcp serve --http 0.0.0.0:8080
+```
+
+### `MCP_AUTH_PATH`
+
+Override the OAuth token storage location. Default is `~/.config/mcp/auth.json`. Useful in containers where `$HOME` doesn't exist or is read-only.
+
+```bash
+MCP_AUTH_PATH=/data/auth.json mcp add sentry --remote https://mcp.sentry.dev
 ```
 
 ## Config variables

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -30,6 +30,9 @@ pub struct AuthStore {
 }
 
 pub fn auth_store_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("MCP_AUTH_PATH") {
+        return Ok(PathBuf::from(path));
+    }
     Ok(config::config_dir()?.join("auth.json"))
 }
 

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -31,7 +31,10 @@ pub struct AuthStore {
 
 pub fn auth_store_path() -> Result<PathBuf> {
     if let Ok(path) = std::env::var("MCP_AUTH_PATH") {
-        return Ok(PathBuf::from(path));
+        let path = path.trim();
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
     }
     Ok(config::config_dir()?.join("auth.json"))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,9 +191,18 @@ pub struct Config {
     pub config_hashes: HashMap<String, String>,
 }
 
+/// Returns the MCP configuration directory.
+/// Uses `MCP_CONFIG_DIR` if set, then `$HOME/.config/mcp`, then `/tmp/mcp` as
+/// a last-resort fallback for containers without a home directory.
 pub fn config_dir() -> Result<PathBuf> {
-    let home = dirs::home_dir().context("could not determine home directory")?;
-    Ok(home.join(".config").join("mcp"))
+    if let Ok(dir) = std::env::var("MCP_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    if let Some(home) = dirs::home_dir() {
+        return Ok(home.join(".config").join("mcp"));
+    }
+    eprintln!("warning: HOME not set, using /tmp/mcp as config directory");
+    Ok(PathBuf::from("/tmp/mcp"))
 }
 
 /// Returns the data path for the shared ChronDB database.
@@ -289,6 +298,11 @@ fn strip_json_comments(input: &str) -> String {
 }
 
 pub fn load_config() -> Result<Config> {
+    // Priority 1: inline config via MCP_SERVERS_CONFIG (no file mount needed)
+    if let Ok(raw) = std::env::var("MCP_SERVERS_CONFIG") {
+        return parse_config_content(&raw, PathBuf::from("<env:MCP_SERVERS_CONFIG>"));
+    }
+    // Priority 2: file path (existing behavior)
     let path = config_path()?;
     load_config_from_path(&path)
 }
@@ -298,7 +312,7 @@ pub fn load_config_from_path(path: &PathBuf) -> Result<Config> {
         return Ok(Config {
             servers: HashMap::new(),
             server_auth: ServerAuthConfig::default(),
-            audit: AuditConfig::default(),
+            audit: apply_audit_env_overrides(AuditConfig::default()),
             path: path.clone(),
             config_hashes: HashMap::new(),
         });
@@ -307,11 +321,15 @@ pub fn load_config_from_path(path: &PathBuf) -> Result<Config> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read config file: {}", path.display()))?;
 
-    let content = substitute_env_vars(&content);
+    parse_config_content(&content, path.clone())
+}
+
+fn parse_config_content(content: &str, source: PathBuf) -> Result<Config> {
+    let content = substitute_env_vars(content);
     let content = strip_json_comments(&content);
 
     let raw: Value = serde_json::from_str(&content)
-        .with_context(|| format!("failed to parse config file: {}", path.display()))?;
+        .with_context(|| format!("failed to parse config from: {}", source.display()))?;
 
     let servers_value = raw
         .get("mcpServers")
@@ -363,13 +381,34 @@ pub fn load_config_from_path(path: &PathBuf) -> Result<Config> {
         .transpose()?
         .unwrap_or_default();
 
+    // Apply environment variable overrides for container-friendly deployment
+    let audit = apply_audit_env_overrides(audit);
+
     Ok(Config {
         servers,
         server_auth,
         audit,
-        path: path.clone(),
+        path: source,
         config_hashes,
     })
+}
+
+/// Applies environment variable overrides to `AuditConfig`.
+/// Container deployments can use these to disable audit or redirect paths
+/// without modifying the config JSON.
+fn apply_audit_env_overrides(mut audit: AuditConfig) -> AuditConfig {
+    if let Ok(v) = std::env::var("MCP_AUDIT_ENABLED") {
+        if v.eq_ignore_ascii_case("false") || v == "0" {
+            audit.enabled = false;
+        }
+    }
+    if let Ok(v) = std::env::var("MCP_AUDIT_PATH") {
+        audit.path = Some(v);
+    }
+    if let Ok(v) = std::env::var("MCP_AUDIT_INDEX_PATH") {
+        audit.index_path = Some(v);
+    }
+    audit
 }
 
 fn substitute_env_vars(input: &str) -> String {
@@ -813,5 +852,184 @@ mod tests {
         .unwrap();
         assert!(config.servers.contains_key("active"));
         assert!(!config.servers.contains_key("disabled"));
+    }
+
+    // --- Container-friendly config tests (issue #67) ---
+
+    /// Serialize env var access for tests that set/remove env vars.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn test_inline_config_via_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let json = r#"{"mcpServers":{"demo":{"url":"https://example.com/mcp"}}}"#;
+        std::env::set_var("MCP_SERVERS_CONFIG", json);
+        // Ensure MCP_CONFIG_PATH doesn't interfere
+        std::env::remove_var("MCP_CONFIG_PATH");
+        // Clear audit overrides
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let config = load_config().unwrap();
+        assert_eq!(config.servers.len(), 1);
+        assert!(config.servers.contains_key("demo"));
+        assert_eq!(config.path, PathBuf::from("<env:MCP_SERVERS_CONFIG>"));
+
+        std::env::remove_var("MCP_SERVERS_CONFIG");
+    }
+
+    #[test]
+    fn test_inline_config_env_var_substitution() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_INLINE_TEST_TOKEN", "tok_abc");
+        let json = r#"{"mcpServers":{"s":{"url":"https://ex.com","headers":{"Authorization":"Bearer ${MCP_INLINE_TEST_TOKEN}"}}}}"#;
+        std::env::set_var("MCP_SERVERS_CONFIG", json);
+        std::env::remove_var("MCP_CONFIG_PATH");
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let config = load_config().unwrap();
+        match &config.servers["s"] {
+            ServerConfig::Http { headers, .. } => {
+                assert_eq!(headers["Authorization"], "Bearer tok_abc");
+            }
+            _ => panic!("expected Http config"),
+        }
+
+        std::env::remove_var("MCP_SERVERS_CONFIG");
+        std::env::remove_var("MCP_INLINE_TEST_TOKEN");
+    }
+
+    #[test]
+    fn test_inline_config_invalid_json_errors() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_SERVERS_CONFIG", "not json {{{");
+        std::env::remove_var("MCP_CONFIG_PATH");
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let result = load_config();
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("MCP_SERVERS_CONFIG"),
+            "error should reference source: {err_msg}"
+        );
+
+        std::env::remove_var("MCP_SERVERS_CONFIG");
+    }
+
+    #[test]
+    fn test_inline_config_takes_precedence_over_file() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Point MCP_CONFIG_PATH to a file with different content
+        let mut file = NamedTempFile::new().unwrap();
+        write!(
+            file,
+            r#"{{"mcpServers":{{"file_server":{{"url":"https://file.com"}}}}}}"#
+        )
+        .unwrap();
+        std::env::set_var("MCP_CONFIG_PATH", file.path().to_str().unwrap());
+
+        // Inline config should win
+        std::env::set_var(
+            "MCP_SERVERS_CONFIG",
+            r#"{"mcpServers":{"inline_server":{"url":"https://inline.com"}}}"#,
+        );
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let config = load_config().unwrap();
+        assert!(config.servers.contains_key("inline_server"));
+        assert!(!config.servers.contains_key("file_server"));
+
+        std::env::remove_var("MCP_SERVERS_CONFIG");
+        std::env::remove_var("MCP_CONFIG_PATH");
+    }
+
+    #[test]
+    fn test_audit_disabled_via_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_AUDIT_ENABLED", "false");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        // Config JSON has audit enabled, but env override disables it
+        let config = config_from_json(
+            r#"{
+                "mcpServers": {},
+                "audit": {"enabled": true}
+            }"#,
+        )
+        .unwrap();
+        assert!(!config.audit.enabled);
+
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+    }
+
+    #[test]
+    fn test_audit_disabled_via_env_zero() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_AUDIT_ENABLED", "0");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let config = config_from_json(r#"{"mcpServers": {}}"#).unwrap();
+        assert!(!config.audit.enabled);
+
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+    }
+
+    #[test]
+    fn test_audit_enabled_not_overridden_when_env_unset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let config = config_from_json(r#"{"mcpServers": {}}"#).unwrap();
+        assert!(config.audit.enabled); // default is true
+    }
+
+    #[test]
+    fn test_audit_path_overrides_via_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::set_var("MCP_AUDIT_PATH", "/data/audit/data");
+        std::env::set_var("MCP_AUDIT_INDEX_PATH", "/data/audit/index");
+
+        let config = config_from_json(r#"{"mcpServers": {}}"#).unwrap();
+        assert_eq!(config.audit.path.as_deref(), Some("/data/audit/data"));
+        assert_eq!(
+            config.audit.index_path.as_deref(),
+            Some("/data/audit/index")
+        );
+
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+    }
+
+    #[test]
+    fn test_audit_env_overrides_json_path() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::set_var("MCP_AUDIT_PATH", "/env/data");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        // JSON sets one path, env overrides it
+        let config = config_from_json(
+            r#"{
+                "mcpServers": {},
+                "audit": {"path": "/json/data"}
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(config.audit.path.as_deref(), Some("/env/data"));
+
+        std::env::remove_var("MCP_AUDIT_PATH");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -393,19 +393,29 @@ fn parse_config_content(content: &str, source: PathBuf) -> Result<Config> {
     })
 }
 
+/// Returns the trimmed value of an env var, or `None` if unset or empty/whitespace.
+fn non_empty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_owned())
+        .filter(|v| !v.is_empty())
+}
+
 /// Applies environment variable overrides to `AuditConfig`.
 /// Container deployments can use these to disable audit or redirect paths
 /// without modifying the config JSON.
 fn apply_audit_env_overrides(mut audit: AuditConfig) -> AuditConfig {
     if let Ok(v) = std::env::var("MCP_AUDIT_ENABLED") {
-        if v.eq_ignore_ascii_case("false") || v == "0" {
-            audit.enabled = false;
+        match v.trim() {
+            s if s.eq_ignore_ascii_case("false") || s == "0" => audit.enabled = false,
+            s if s.eq_ignore_ascii_case("true") || s == "1" => audit.enabled = true,
+            _ => {}
         }
     }
-    if let Ok(v) = std::env::var("MCP_AUDIT_PATH") {
+    if let Some(v) = non_empty_env("MCP_AUDIT_PATH") {
         audit.path = Some(v);
     }
-    if let Ok(v) = std::env::var("MCP_AUDIT_INDEX_PATH") {
+    if let Some(v) = non_empty_env("MCP_AUDIT_INDEX_PATH") {
         audit.index_path = Some(v);
     }
     audit
@@ -754,6 +764,11 @@ mod tests {
 
     #[test]
     fn test_parse_audit_config() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
         let config = config_from_json(
             r#"{
                 "mcpServers": {},
@@ -773,6 +788,11 @@ mod tests {
 
     #[test]
     fn test_parse_config_without_audit() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
         let config = config_from_json(r#"{"mcpServers": {}}"#).unwrap();
         assert!(config.audit.enabled); // default
         assert!(!config.audit.log_arguments); // default
@@ -1031,5 +1051,59 @@ mod tests {
         assert_eq!(config.audit.path.as_deref(), Some("/env/data"));
 
         std::env::remove_var("MCP_AUDIT_PATH");
+    }
+
+    #[test]
+    fn test_audit_force_enabled_via_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_AUDIT_ENABLED", "true");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        // JSON disables audit, but env override force-enables it
+        let config = config_from_json(
+            r#"{
+                "mcpServers": {},
+                "audit": {"enabled": false}
+            }"#,
+        )
+        .unwrap();
+        assert!(config.audit.enabled);
+
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+    }
+
+    #[test]
+    fn test_audit_force_enabled_via_env_one() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MCP_AUDIT_ENABLED", "1");
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
+
+        let config = config_from_json(
+            r#"{
+                "mcpServers": {},
+                "audit": {"enabled": false}
+            }"#,
+        )
+        .unwrap();
+        assert!(config.audit.enabled);
+
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+    }
+
+    #[test]
+    fn test_empty_audit_path_env_ignored() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("MCP_AUDIT_ENABLED");
+        std::env::set_var("MCP_AUDIT_PATH", "");
+        std::env::set_var("MCP_AUDIT_INDEX_PATH", "  ");
+
+        let config = config_from_json(r#"{"mcpServers": {}}"#).unwrap();
+        assert!(config.audit.path.is_none());
+        assert!(config.audit.index_path.is_none());
+
+        std::env::remove_var("MCP_AUDIT_PATH");
+        std::env::remove_var("MCP_AUDIT_INDEX_PATH");
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -48,7 +48,13 @@ impl DbPool {
 
 /// Creates a shared DbPool using ChronDB's native idle timeout.
 /// Uses audit config path overrides if set, otherwise falls back to the shared db paths.
+/// Returns a disabled pool when audit is disabled (e.g. container with read-only fs).
 pub fn create_pool(audit_config: &AuditConfig) -> Result<Arc<DbPool>> {
+    if !audit_config.enabled {
+        eprintln!("[db] audit disabled, skipping database initialization");
+        return Ok(Arc::new(DbPool::disabled()));
+    }
+
     let data_path = match audit_config.data_path_override() {
         Some(p) => p.to_string(),
         None => config::db_data_path()?,


### PR DESCRIPTION
The proxy assumed a writable home directory and file-mounted config, which breaks in scratch/distroless containers and Kubernetes pods.

Introduce MCP_SERVERS_CONFIG for inline JSON config (no file mount), MCP_CONFIG_DIR with /tmp/mcp fallback when HOME is missing, MCP_AUDIT_ENABLED/PATH/INDEX_PATH to control audit without editing JSON, MCP_AUTH_PATH for token storage, and a create_pool guard that skips DB init on read-only filesystems. Dockerfile defaults to MCP_AUDIT_ENABLED=false for scratch images. Docs updated with full env var reference, Kubernetes manifest, and $(cat ...) examples.

Fixes: #67