### PR TITLE
Add Kubernetes reference manifests and deployment guide

### DIFF
--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mcp-config
+  namespace: mcp
+  labels:
+    app.kubernetes.io/name: mcp-proxy
+    app.kubernetes.io/component: config
+data:
+  # MCP proxy configuration. This is the same format as servers.json.
+  # Tokens should use ${ENV_VAR} placeholders — the proxy resolves them
+  # at startup from environment variables injected via the Secret below.
+  #
+  # See: https://github.com/avelino/mcp/blob/main/docs/reference/config-file.md
+  servers.json: |
+    {
+      "mcpServers": {
+        "sentry": {
+          "url": "https://mcp.sentry.dev/sse",
+          "headers": {
+            "Authorization": "Bearer ${SENTRY_TOKEN}"
+          }
+        }
+      }
+    }

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-proxy
+  namespace: mcp
+  labels:
+    app.kubernetes.io/name: mcp-proxy
+    app.kubernetes.io/component: proxy
+spec:
+  replicas: 1
+  # Each replica runs its own backend pool — there is no shared state or
+  # leader election. Scaling to N replicas means N independent instances
+  # of every configured MCP server. This is safe but multiplies backend
+  # connections and resource usage proportionally.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcp-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mcp-proxy
+        app.kubernetes.io/component: proxy
+    spec:
+      # The proxy handles SIGTERM with a graceful drain:
+      #   1. Stops accepting new connections
+      #   2. Finishes in-flight requests
+      #   3. Shuts down backend clients in parallel (5s timeout each)
+      #   4. Total cleanup bounded to ~10s internally
+      # 30s gives enough headroom for the internal shutdown to complete.
+      terminationGracePeriodSeconds: 30
+
+      containers:
+        - name: mcp
+          image: ghcr.io/avelino/mcp:latest
+          args: ["serve", "--http", "0.0.0.0:8080", "--insecure"]
+          # --insecure is required because the pod binds 0.0.0.0 (non-loopback).
+          # TLS termination should happen at the Ingress or load balancer.
+
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+
+          env:
+            # Inject config inline — no file mount needed.
+            # The proxy resolves ${VAR} placeholders in the config from
+            # environment variables, so tokens stay in the Secret.
+            - name: MCP_SERVERS_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: mcp-config
+                  key: servers.json
+
+            # Token injected as env var, referenced as ${SENTRY_TOKEN} in config.
+            - name: SENTRY_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: mcp-secrets
+                  key: sentry-token
+
+            # Audit logging. Set to "true" and mount a PVC at /data to persist
+            # logs across restarts. The scratch image has no writable filesystem
+            # by default, so this needs a volume.
+            - name: MCP_AUDIT_ENABLED
+              value: "false"
+            - name: MCP_AUDIT_PATH
+              value: "/data/audit/data"
+            - name: MCP_AUDIT_INDEX_PATH
+              value: "/data/audit/index"
+
+            # Classifier cache (ephemeral, rebuilt on startup).
+            - name: MCP_CLASSIFIER_CACHE
+              value: "/tmp/tool-classification.json"
+
+          # --- Probes ---
+          #
+          # GET /health returns JSON with backend connectivity status.
+          # The proxy lazy-connects to backends, so 0 connected backends at
+          # startup is normal — probes should NOT fail just because backends
+          # haven't been reached yet.
+
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            # Give 30s for the process to start and initial discovery.
+            failureThreshold: 6
+            periodSeconds: 5
+
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            # Only checks that the process responds to HTTP.
+            # Backend failures are degraded state, not liveness failure.
+            periodSeconds: 30
+            timeoutSeconds: 5
+
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            # Same endpoint. The proxy is ready to serve immediately since
+            # it lazy-connects backends on first request.
+            periodSeconds: 10
+            timeoutSeconds: 5
+
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: "1"
+              memory: 256Mi
+
+          securityContext:
+            # The scratch base image has no /etc/passwd, so the process runs
+            # as UID 0. This is a static binary with no shell — minimal
+            # attack surface regardless of UID.
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+
+          volumeMounts:
+            # Writable tmp for classifier cache and other ephemeral files.
+            - name: tmp
+              mountPath: /tmp
+            # Audit data (only needed if MCP_AUDIT_ENABLED=true).
+            # Swap emptyDir for a PVC reference to persist across restarts.
+            - name: data
+              mountPath: /data
+
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 10Mi
+        # For persistent audit logs, replace with:
+        #   persistentVolumeClaim:
+        #     claimName: mcp-audit-data
+        - name: data
+          emptyDir:
+            sizeLimit: 100Mi

--- a/deploy/kubernetes/deployment.yaml
+++ b/deploy/kubernetes/deployment.yaml
@@ -114,9 +114,11 @@ spec:
               memory: 256Mi
 
           securityContext:
-            # The scratch base image has no /etc/passwd, so the process runs
-            # as UID 0. This is a static binary with no shell — minimal
-            # attack surface regardless of UID.
+            # Runs as UID 0 by default (no USER in Dockerfile). The scratch
+            # base is a static binary with no shell — minimal attack surface.
+            # To satisfy runAsNonRoot policies, set runAsUser to a numeric UID
+            # and ensure mounted volumes (/tmp, /data) are writable for that UID
+            # (via fsGroup or an initContainer).
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mcp
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - deployment.yaml
+  - service.yaml
+  # Uncomment to enable persistent audit logging:
+  # - pvc.yaml
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: mcp
+
+images:
+  - name: ghcr.io/avelino/mcp
+    newTag: latest

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -6,16 +6,13 @@ namespace: mcp
 resources:
   - namespace.yaml
   - configmap.yaml
-  - secret.yaml
   - deployment.yaml
   - service.yaml
+  # Create the Secret separately before applying (see secret.yaml for template):
+  #   kubectl -n mcp create secret generic mcp-secrets --from-literal=sentry-token=sntrys_...
   # Uncomment to enable persistent audit logging:
   # - pvc.yaml
 
 labels:
   - pairs:
       app.kubernetes.io/part-of: mcp
-
-images:
-  - name: ghcr.io/avelino/mcp
-    newTag: latest

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp
+  labels:
+    app.kubernetes.io/name: mcp-proxy
+    app.kubernetes.io/part-of: mcp

--- a/deploy/kubernetes/pvc.yaml
+++ b/deploy/kubernetes/pvc.yaml
@@ -1,0 +1,19 @@
+# Optional: persistent audit log storage.
+# Only needed if you set MCP_AUDIT_ENABLED=true in the Deployment.
+#
+# To use: uncomment the persistentVolumeClaim reference in deployment.yaml
+# and replace the emptyDir volume for "data".
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mcp-audit-data
+  namespace: mcp
+  labels:
+    app.kubernetes.io/name: mcp-proxy
+    app.kubernetes.io/component: storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,3 +1,11 @@
+# Example Secret — DO NOT apply directly.
+# Create your Secret separately before applying the kustomization:
+#
+#   kubectl -n mcp create secret generic mcp-secrets \
+#     --from-literal=sentry-token=sntrys_... \
+#     --from-literal=grafana-token=glsa_...
+#
+# This file is a reference template, not included in kustomization.yaml.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,7 +15,5 @@ metadata:
     app.kubernetes.io/name: mcp-proxy
     app.kubernetes.io/component: config
 type: Opaque
-# Replace these placeholder values with real tokens.
-# Use: kubectl create secret generic mcp-secrets --from-literal=sentry-token=sntrys_...
 stringData:
   sentry-token: "REPLACE_ME"

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mcp-secrets
+  namespace: mcp
+  labels:
+    app.kubernetes.io/name: mcp-proxy
+    app.kubernetes.io/component: config
+type: Opaque
+# Replace these placeholder values with real tokens.
+# Use: kubectl create secret generic mcp-secrets --from-literal=sentry-token=sntrys_...
+stringData:
+  sentry-token: "REPLACE_ME"

--- a/deploy/kubernetes/service.yaml
+++ b/deploy/kubernetes/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-proxy
+  namespace: mcp
+  labels:
+    app.kubernetes.io/name: mcp-proxy
+    app.kubernetes.io/component: proxy
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mcp-proxy
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -24,6 +24,7 @@
 ## How-to
 
 * [Docker](howto/docker.md)
+* [Kubernetes](howto/kubernetes.md)
 * [Supported services](howto/services.md)
 * [Troubleshooting](howto/troubleshooting.md)
 

--- a/docs/howto/docker.md
+++ b/docs/howto/docker.md
@@ -144,65 +144,12 @@ These variables are especially useful for container deployments. See the full li
 
 ## Kubernetes
 
-Use `MCP_SERVERS_CONFIG` to inject config via ConfigMap or Secret — no file mount needed:
+See the dedicated [Kubernetes deployment guide](./kubernetes.md) for complete manifests with probes, security context, audit logging, and operational guidance.
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: mcp-proxy
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: mcp-proxy
-  template:
-    metadata:
-      labels:
-        app: mcp-proxy
-    spec:
-      containers:
-        - name: mcp
-          image: ghcr.io/avelino/mcp:latest
-          args: ["serve", "--http", "0.0.0.0:8080", "--insecure"]
-          ports:
-            - containerPort: 8080
-          env:
-            - name: MCP_SERVERS_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: mcp-config
-                  key: servers.json
-            - name: SENTRY_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: mcp-secrets
-                  key: sentry-token
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            periodSeconds: 30
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8080
-            periodSeconds: 10
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: mcp-config
-data:
-  servers.json: |
-    {
-      "mcpServers": {
-        "sentry": {
-          "url": "https://mcp.sentry.dev/sse",
-          "headers": {"Authorization": "Bearer ${SENTRY_TOKEN}"}
-        }
-      }
-    }
+Quick start:
+
+```bash
+kubectl apply -k deploy/kubernetes/
 ```
 
 ## Shell alias

--- a/docs/howto/kubernetes.md
+++ b/docs/howto/kubernetes.md
@@ -5,10 +5,15 @@ Reference manifests for running the MCP proxy in a Kubernetes cluster.
 ## Quick start
 
 ```bash
-# Review and customize the manifests
-ls deploy/kubernetes/
+# 1. Edit the ConfigMap with your server configuration
+vim deploy/kubernetes/configmap.yaml
 
-# Apply everything
+# 2. Create the Secret with your API tokens (not included in kustomize)
+kubectl create namespace mcp
+kubectl -n mcp create secret generic mcp-secrets \
+  --from-literal=sentry-token=sntrys_...
+
+# 3. Apply the manifests
 kubectl apply -k deploy/kubernetes/
 ```
 
@@ -18,7 +23,8 @@ This creates:
 - `mcp-proxy` Deployment (1 replica)
 - `mcp-proxy` ClusterIP Service on port 8080
 - `mcp-config` ConfigMap with your server configuration
-- `mcp-secrets` Secret for API tokens
+
+The Secret must be created separately (step 2) to avoid committing real tokens to the repo.
 
 ## Configuration
 
@@ -159,9 +165,17 @@ securityContext:
     drop: ["ALL"]
 ```
 
-The image is based on `scratch` — a static binary with no shell, no package manager, no libc. The process runs as UID 0 because scratch has no `/etc/passwd` to define other users. Despite running as root, the attack surface is minimal: no shell to exec into, no tools to exploit, read-only filesystem.
+The image is based on `scratch` — a static binary with no shell, no package manager, no libc. The process runs as UID 0 by default (the Dockerfile doesn't set `USER`), but `scratch` itself does not require root. The attack surface is minimal regardless of UID: no shell to exec into, no tools to exploit, read-only filesystem.
 
-If your cluster policy requires `runAsNonRoot: true`, you'd need a non-scratch base image with a dedicated user.
+If your cluster policy requires `runAsNonRoot: true`, set a numeric `runAsUser` and ensure mounted volumes (`/tmp`, `/data`) are writable for that UID — either via `fsGroup` or an initContainer:
+
+```yaml
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+  fsGroup: 65534
+```
 
 ## Scaling
 
@@ -188,14 +202,14 @@ When Kubernetes sends `SIGTERM` (during rolling updates or scale-down):
 
 ## Environment variables reference
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `MCP_SERVERS_CONFIG` | — | Inline JSON config (highest priority) |
-| `MCP_PROXY_REQUEST_TIMEOUT` | `120` | Max seconds per JSON-RPC request |
-| `MCP_AUDIT_ENABLED` | `false` (in Docker) | Enable audit logging |
-| `MCP_AUDIT_PATH` | `/data/audit/data` | Audit data directory |
-| `MCP_AUDIT_INDEX_PATH` | `/data/audit/index` | Audit index directory |
-| `MCP_CLASSIFIER_CACHE` | `/tmp/tool-classification.json` | Tool classification cache |
+| Variable | Manifest value | Description |
+|----------|----------------|-------------|
+| `MCP_SERVERS_CONFIG` | (from ConfigMap) | Inline JSON config (highest priority) |
+| `MCP_PROXY_REQUEST_TIMEOUT` | `120` (app default) | Max seconds per JSON-RPC request |
+| `MCP_AUDIT_ENABLED` | `false` | Enable audit logging |
+| `MCP_AUDIT_PATH` | `/data/audit/data` | Audit data directory (app default: `~/.config/mcp/db/data`) |
+| `MCP_AUDIT_INDEX_PATH` | `/data/audit/index` | Audit index directory (app default: `~/.config/mcp/db/index`) |
+| `MCP_CLASSIFIER_CACHE` | `/tmp/tool-classification.json` | Tool classification cache (app default: `~/.config/mcp/tool-classification.json`) |
 
 Full reference: [Environment variables](../reference/environment-variables.md)
 
@@ -259,7 +273,7 @@ startupProbe:
 
 ### Token not resolving
 
-Ensure the Secret key matches what the Deployment env references, and that the `${VAR_NAME}` in the ConfigMap matches the env var name exactly. The proxy logs a warning if a placeholder can't be resolved.
+Ensure the Secret key matches what the Deployment env references, and that the `${VAR_NAME}` in the ConfigMap matches the env var name exactly. If a referenced env var is missing, the placeholder is replaced with an empty string silently — verify the resolved config by checking the proxy logs for authentication failures on backend connections.
 
 ### Read-only filesystem errors
 

--- a/docs/howto/kubernetes.md
+++ b/docs/howto/kubernetes.md
@@ -1,0 +1,266 @@
+# Deploying on Kubernetes
+
+Reference manifests for running the MCP proxy in a Kubernetes cluster.
+
+## Quick start
+
+```bash
+# Review and customize the manifests
+ls deploy/kubernetes/
+
+# Apply everything
+kubectl apply -k deploy/kubernetes/
+```
+
+This creates:
+
+- `mcp` namespace
+- `mcp-proxy` Deployment (1 replica)
+- `mcp-proxy` ClusterIP Service on port 8080
+- `mcp-config` ConfigMap with your server configuration
+- `mcp-secrets` Secret for API tokens
+
+## Configuration
+
+### Server config via ConfigMap
+
+Edit `deploy/kubernetes/configmap.yaml` with your MCP servers:
+
+```yaml
+data:
+  servers.json: |
+    {
+      "mcpServers": {
+        "sentry": {
+          "url": "https://mcp.sentry.dev/sse",
+          "headers": {
+            "Authorization": "Bearer ${SENTRY_TOKEN}"
+          }
+        },
+        "grafana": {
+          "url": "https://grafana.internal/api/mcp/sse",
+          "headers": {
+            "Authorization": "Bearer ${GRAFANA_TOKEN}"
+          }
+        }
+      }
+    }
+```
+
+The proxy resolves `${VAR}` placeholders from environment variables at startup. This keeps tokens out of the ConfigMap.
+
+### Secrets for tokens
+
+Create the secret with your real tokens:
+
+```bash
+kubectl -n mcp create secret generic mcp-secrets \
+  --from-literal=sentry-token=sntrys_abc123 \
+  --from-literal=grafana-token=glsa_xyz789
+```
+
+Then reference each token in the Deployment env:
+
+```yaml
+env:
+  - name: SENTRY_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: mcp-secrets
+        key: sentry-token
+  - name: GRAFANA_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: mcp-secrets
+        key: grafana-token
+```
+
+### Pinning the image version
+
+Edit `deploy/kubernetes/kustomization.yaml`:
+
+```yaml
+images:
+  - name: ghcr.io/avelino/mcp
+    newTag: "0.5.0"  # pin to a specific version
+```
+
+## Why `--insecure`?
+
+The proxy refuses to bind non-loopback addresses without `--insecure`. In Kubernetes, the pod needs `0.0.0.0:8080` so the Service can route traffic to it. TLS termination happens at the Ingress or load balancer level, not at the proxy.
+
+## Health probes
+
+The proxy exposes `GET /health` returning:
+
+```json
+{
+  "status": "ok",
+  "backends_configured": 3,
+  "backends_connected": 2,
+  "active_clients": 5,
+  "tools": 42,
+  "version": "0.5.0"
+}
+```
+
+### Why the probes are configured this way
+
+**Startup probe** — gives 30s (`failureThreshold: 6 * periodSeconds: 5`) for the process to start and begin backend discovery. Discovery is async, so the proxy serves immediately but backends connect in the background.
+
+**Liveness probe** — checks every 30s that the process responds to HTTP. Backend failures are **degraded state**, not a reason to restart the pod. If sentry is down, the proxy still serves grafana tools fine.
+
+**Readiness probe** — checks every 10s. The proxy is ready to serve as soon as it starts because it lazy-connects backends on first request. A probe failure here means the process itself is unhealthy.
+
+> **Do not** use `backends_connected > 0` as a readiness condition. The proxy is designed to start with zero connections and connect on demand.
+
+## Audit logging
+
+By default, audit logging is disabled (`MCP_AUDIT_ENABLED=false`) because the scratch-based image has no writable filesystem.
+
+To enable:
+
+1. Set `MCP_AUDIT_ENABLED=true` in the Deployment env
+2. Mount persistent storage at `/data`:
+
+```yaml
+# In deployment.yaml, replace the emptyDir volume:
+volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: mcp-audit-data
+```
+
+3. Uncomment `pvc.yaml` in `kustomization.yaml`:
+
+```yaml
+resources:
+  # ...
+  - pvc.yaml
+```
+
+4. Apply:
+
+```bash
+kubectl apply -k deploy/kubernetes/
+```
+
+Audit logs are written to `/data/audit/data` and indexed at `/data/audit/index` (controlled by `MCP_AUDIT_PATH` and `MCP_AUDIT_INDEX_PATH`).
+
+## Security context
+
+The manifests include a hardened security context:
+
+```yaml
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+```
+
+The image is based on `scratch` — a static binary with no shell, no package manager, no libc. The process runs as UID 0 because scratch has no `/etc/passwd` to define other users. Despite running as root, the attack surface is minimal: no shell to exec into, no tools to exploit, read-only filesystem.
+
+If your cluster policy requires `runAsNonRoot: true`, you'd need a non-scratch base image with a dedicated user.
+
+## Scaling
+
+Each replica is fully independent — own backend pool, own tool cache, own connections. There's no shared state, no leader election, no coordination needed.
+
+Scaling to N replicas means:
+
+- N independent connections to each backend
+- N copies of the tool/resource/prompt cache in memory
+- Clients are load-balanced across replicas by the Service
+
+This is fine for most deployments. Be aware that stdio-based backends (which spawn child processes) will have N copies of each process running across the cluster.
+
+## Graceful shutdown
+
+When Kubernetes sends `SIGTERM` (during rolling updates or scale-down):
+
+1. The proxy stops accepting new connections
+2. In-flight requests finish normally
+3. Backend clients are shut down in parallel (5s timeout each)
+4. Total internal cleanup is bounded to ~10s
+
+`terminationGracePeriodSeconds: 30` in the Deployment gives enough headroom. After 30s, Kubernetes sends `SIGKILL`.
+
+## Environment variables reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_SERVERS_CONFIG` | — | Inline JSON config (highest priority) |
+| `MCP_PROXY_REQUEST_TIMEOUT` | `120` | Max seconds per JSON-RPC request |
+| `MCP_AUDIT_ENABLED` | `false` (in Docker) | Enable audit logging |
+| `MCP_AUDIT_PATH` | `/data/audit/data` | Audit data directory |
+| `MCP_AUDIT_INDEX_PATH` | `/data/audit/index` | Audit index directory |
+| `MCP_CLASSIFIER_CACHE` | `/tmp/tool-classification.json` | Tool classification cache |
+
+Full reference: [Environment variables](../reference/environment-variables.md)
+
+## Exposing outside the cluster
+
+The Service is `ClusterIP` by default. To expose externally, add an Ingress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-proxy
+  namespace: mcp
+  annotations:
+    # TLS termination at the ingress
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  tls:
+    - hosts: ["mcp.example.com"]
+      secretName: mcp-tls
+  rules:
+    - host: mcp.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mcp-proxy
+                port:
+                  name: http
+```
+
+## Troubleshooting
+
+### Pod starts but backends never connect
+
+Check the ConfigMap config is valid JSON:
+
+```bash
+kubectl -n mcp get configmap mcp-config -o jsonpath='{.data.servers\.json}' | jq .
+```
+
+Check the proxy logs:
+
+```bash
+kubectl -n mcp logs deploy/mcp-proxy
+```
+
+Look for `[serve] discovering tools from ...` lines. If you see `failed to discover`, the backend URL or token is wrong.
+
+### Health probe fails on startup
+
+Increase the startup probe threshold:
+
+```yaml
+startupProbe:
+  failureThreshold: 12  # 60s instead of 30s
+  periodSeconds: 5
+```
+
+### Token not resolving
+
+Ensure the Secret key matches what the Deployment env references, and that the `${VAR_NAME}` in the ConfigMap matches the env var name exactly. The proxy logs a warning if a placeholder can't be resolved.
+
+### Read-only filesystem errors
+
+If you see permission errors, make sure the `tmp` and `data` volumes are mounted. The scratch image has no writable paths without explicit volume mounts.


### PR DESCRIPTION
Teams deploying the proxy on Kubernetes had to reverse-engineer port binding, probe semantics, shutdown timing, and security context from source code.

Add deploy/kubernetes/ with production-ready manifests (Deployment, Service, ConfigMap, Secret, optional PVC) using kustomize, plus a comprehensive docs/howto/kubernetes.md covering probes, graceful shutdown, audit logging, scaling, and troubleshooting. Replace the inline K8s snippet in docker.md with a link to the new guide.

Closes #68