### PR TITLE
Add timeout/logging/audit/CLI features for 0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +939,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +979,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -998,6 +1015,15 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1521,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,7 +1862,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1828,6 +1884,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1916,6 +2015,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ chrondb = "0.2.3-dev.12298e3"
 chrono = { version = "0.4", features = ["serde"] }
 shell-words = "1"
 socket2 = { version = "0.6", features = ["all"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/guides/audit-logging.md
+++ b/docs/guides/audit-logging.md
@@ -157,6 +157,7 @@ Add an `audit` section to `~/.config/mcp/servers.json`:
 | Field | Default | Description |
 |---|---|---|
 | `enabled` | `true` | Enable/disable audit logging |
+| `output` | `file` | Output destination: `file` (ChronDB, queryable), `stdout`, `stderr` (JSON lines), or `none` |
 | `log_arguments` | `false` | Log tool call arguments (may contain PII) |
 | `path` | `~/.config/mcp/audit/data` | ChronDB data directory |
 | `index_path` | `~/.config/mcp/audit/index` | ChronDB index directory |
@@ -216,6 +217,36 @@ MCP_AUDIT_ENABLED=false mcp serve --http 0.0.0.0:8080
 
 When disabled, the logger is a no-op and the database is not initialized — zero overhead, no files created, no filesystem writes. This is the default in the Docker image.
 
+## Streaming to stdout/stderr (containers)
+
+In containers, writing audit to ChronDB is often impractical — the filesystem may be read-only, ephemeral, or you want logs flowing to your container log driver (CloudWatch, Datadog, etc.).
+
+Set `output` to `stdout` or `stderr` to emit audit entries as newline-delimited JSON (one JSON object per line):
+
+```bash
+MCP_AUDIT_OUTPUT=stdout mcp serve --http 0.0.0.0:8080
+```
+
+Or in the config file:
+
+```json
+{
+  "audit": {
+    "output": "stdout"
+  }
+}
+```
+
+Each line is a complete `AuditEntry` JSON object:
+
+```json
+{"timestamp":"2026-04-14T12:00:00-03:00","source":"serve:http","method":"tools/call","tool_name":"search_issues","server_name":"sentry","identity":"alice","duration_ms":142,"success":true}
+```
+
+When using `stdout` or `stderr` mode, `mcp logs` queries are not available (no database to query). Use your log aggregation pipeline instead.
+
+Set `output` to `none` to disable audit entirely without touching the `enabled` flag.
+
 ## Environment variable overrides
 
 All audit settings can be overridden via environment variables, which take priority over the config file. This is useful for container deployments where editing the config JSON is impractical.
@@ -223,6 +254,7 @@ All audit settings can be overridden via environment variables, which take prior
 | Variable | Overrides | Description |
 |---|---|---|
 | `MCP_AUDIT_ENABLED` | `audit.enabled` | Set to `false` or `0` to disable |
+| `MCP_AUDIT_OUTPUT` | `audit.output` | `file`, `stdout`, `stderr`, or `none` |
 | `MCP_AUDIT_PATH` | `audit.path` | ChronDB data directory |
 | `MCP_AUDIT_INDEX_PATH` | `audit.index_path` | ChronDB index directory |
 
@@ -234,6 +266,14 @@ docker run -d \
   -e MCP_AUDIT_PATH=/data/audit/data \
   -e MCP_AUDIT_INDEX_PATH=/data/audit/index \
   -v audit-vol:/data/audit \
+  ghcr.io/avelino/mcp serve --http 0.0.0.0:8080
+```
+
+Example: stream audit to container stdout (no volume needed):
+
+```bash
+docker run -d \
+  -e MCP_AUDIT_OUTPUT=stdout \
   ghcr.io/avelino/mcp serve --http 0.0.0.0:8080
 ```
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -36,7 +36,7 @@ Your browser opens, you authorize the app, and the token is saved. Next time, it
 3. Registers as a client using [Dynamic Client Registration](https://datatracker.ietf.org/doc/rfc7591/) if supported
 4. Generates a PKCE challenge (S256) for security
 5. Opens your browser to the authorization URL
-6. Listens on a local port (`localhost:8085-8099`) for the callback
+6. Listens on a local port for the callback (default range `localhost:8085-8099`, configurable via `MCP_OAUTH_CALLBACK_PORT`)
 7. Exchanges the authorization code for tokens
 8. Saves tokens to `~/.config/mcp/auth.json`
 

--- a/docs/howto/docker.md
+++ b/docs/howto/docker.md
@@ -115,7 +115,21 @@ docker run -d \
 
 ### With audit logging
 
-The default image disables audit logging (`MCP_AUDIT_ENABLED=false`) because `scratch` images have no writable filesystem. To enable it, mount a volume and override:
+The default image disables audit logging (`MCP_AUDIT_ENABLED=false`) because `scratch` images have no writable filesystem. You have two options:
+
+**Option A: Stream to stdout (no volume needed)**
+
+```bash
+docker run -d \
+  -e MCP_SERVERS_CONFIG='{"mcpServers":{...}}' \
+  -e MCP_AUDIT_OUTPUT=stdout \
+  -p 8080:8080 \
+  ghcr.io/avelino/mcp serve --http 0.0.0.0:8080 --insecure
+```
+
+Audit entries are emitted as JSON lines to stdout, captured by your container log driver (CloudWatch, Datadog, etc.).
+
+**Option B: Persist to a volume**
 
 ```bash
 docker run -d \
@@ -136,7 +150,10 @@ These variables are especially useful for container deployments. See the full li
 |---|---|---|
 | `MCP_SERVERS_CONFIG` | — | Inline JSON config, no file mount needed |
 | `MCP_CONFIG_DIR` | `~/.config/mcp` | Override config directory |
+| `MCP_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
+| `MCP_LOG_FORMAT` | `text` | Log format: `text` or `json` (structured, for log drivers) |
 | `MCP_AUDIT_ENABLED` | `false` (in Docker image) | Disable audit for read-only fs |
+| `MCP_AUDIT_OUTPUT` | `file` | `stdout`/`stderr` for container log drivers, `none` to disable |
 | `MCP_AUDIT_PATH` | `~/.config/mcp/db/data` | Override audit data path |
 | `MCP_AUDIT_INDEX_PATH` | `~/.config/mcp/db/index` | Override audit index path |
 | `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override OAuth token storage |
@@ -194,4 +211,4 @@ docker run --rm ghcr.io/avelino/mcp:0.1.0 --help
 
 - **Stdio servers only work if the runtime is available inside the container.** The default image includes only the `mcp` binary and `ca-certificates`. Servers that require `npx`, `python`, or other runtimes won't work unless you build a custom image. HTTP servers (configured with `url`) work out of the box.
 - **OAuth browser flow doesn't work in Docker.** For HTTP servers that need OAuth, run `mcp add <server>` on your host first to complete authentication, then mount the config directory (which includes `auth.json`), or set `MCP_AUTH_PATH` to a mounted volume.
-- **Audit logging is disabled by default** in the Docker image because `scratch` images have no writable filesystem. Enable it with `MCP_AUDIT_ENABLED=true` and mount a volume for the data.
+- **Audit logging is disabled by default** in the Docker image because `scratch` images have no writable filesystem. Use `MCP_AUDIT_OUTPUT=stdout` to stream to the container log driver, or mount a volume and set `MCP_AUDIT_ENABLED=true`.

--- a/docs/howto/kubernetes.md
+++ b/docs/howto/kubernetes.md
@@ -124,7 +124,11 @@ The proxy exposes `GET /health` returning:
 
 By default, audit logging is disabled (`MCP_AUDIT_ENABLED=false`) because the scratch-based image has no writable filesystem.
 
-To enable:
+**Option A: Stream to stdout (no PVC needed)**
+
+Set `MCP_AUDIT_OUTPUT=stdout` in the Deployment env. Audit entries are emitted as JSON lines to stdout and captured by your cluster's log pipeline (Fluentd, Loki, CloudWatch, etc.). No persistent storage required.
+
+**Option B: Persist to a PVC**
 
 1. Set `MCP_AUDIT_ENABLED=true` in the Deployment env
 2. Mount persistent storage at `/data`:
@@ -207,6 +211,7 @@ When Kubernetes sends `SIGTERM` (during rolling updates or scale-down):
 | `MCP_SERVERS_CONFIG` | (from ConfigMap) | Inline JSON config (highest priority) |
 | `MCP_PROXY_REQUEST_TIMEOUT` | `120` (app default) | Max seconds per JSON-RPC request |
 | `MCP_AUDIT_ENABLED` | `false` | Enable audit logging |
+| `MCP_AUDIT_OUTPUT` | `file` | `stdout` for cluster log pipeline, `file` for PVC, `none` to disable |
 | `MCP_AUDIT_PATH` | `/data/audit/data` | Audit data directory (app default: `~/.config/mcp/db/data`) |
 | `MCP_AUDIT_INDEX_PATH` | `/data/audit/index` | Audit index directory (app default: `~/.config/mcp/db/index`) |
 | `MCP_CLASSIFIER_CACHE` | `/tmp/tool-classification.json` | Tool classification cache (app default: `~/.config/mcp/tool-classification.json`) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -262,7 +262,7 @@ mcp add filesystem
 Fails if:
 - Server not found in registry
 - Server already exists in config
-- Name is reserved (`search`, `add`, `remove`, `list`, `help`, `version`, `serve`, `logs`, `config`, `completions`)
+- Name is reserved (`search`, `add`, `remove`, `update`, `list`, `help`, `version`, `serve`, `logs`, `acl`, `config`, `completions`, `healthcheck`)
 
 ### `mcp add --url <url> <name>`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -262,7 +262,7 @@ mcp add filesystem
 Fails if:
 - Server not found in registry
 - Server already exists in config
-- Name is reserved (`search`, `add`, `remove`, `list`, `help`, `version`)
+- Name is reserved (`search`, `add`, `remove`, `list`, `help`, `version`, `serve`, `logs`, `config`, `completions`)
 
 ### `mcp add --url <url> <name>`
 
@@ -310,6 +310,61 @@ Fails if:
 - Server is not in the registry
 
 > If the server changed type in the registry (stdio ↔ http), `mcp update` warns and drops type-specific fields that no longer apply.
+
+## Config commands
+
+### `mcp config path`
+
+Print the resolved path to the config file (`servers.json`).
+
+```bash
+mcp config path
+# /Users/you/.config/mcp/servers.json
+```
+
+With `--json`, includes metadata:
+
+```json
+{
+  "path": "/Users/you/.config/mcp/servers.json",
+  "exists": true,
+  "dir": "/Users/you/.config/mcp"
+}
+```
+
+### `mcp config edit`
+
+Open the config file in your editor. Uses `$EDITOR`, falls back to `$VISUAL`, then `vi` (or `notepad` on Windows).
+
+```bash
+mcp config edit
+```
+
+If the config file doesn't exist, it's created with `{}` before opening.
+
+## Shell completions
+
+### `mcp completions <shell>`
+
+Generate shell completion scripts. Supported shells: `bash`, `zsh`, `fish`.
+
+```bash
+# Fish (recommended for the current session)
+mcp completions fish | source
+
+# Fish (persistent)
+mcp completions fish > ~/.config/fish/completions/mcp.fish
+
+# Bash
+mcp completions bash >> ~/.bashrc
+source ~/.bashrc
+
+# Zsh
+mcp completions zsh > "${fpath[1]}/_mcp"
+autoload -Uz compinit && compinit
+```
+
+Completions cover all subcommands, flags, and nested subcommands (`config path|edit`, `acl classify|check`, `logs` flags, etc.).
 
 ## ACL commands
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -9,14 +9,18 @@ These variables configure `mcp` behavior:
 | `MCP_SERVERS_CONFIG` | — | Inline JSON config (entire `servers.json` content). Highest priority — skips file read entirely. |
 | `MCP_CONFIG_PATH` | `~/.config/mcp/servers.json` | Path to the config file |
 | `MCP_CONFIG_DIR` | `~/.config/mcp` | Config directory. Falls back to `/tmp/mcp` when `HOME` is not set. |
-| `MCP_TIMEOUT` | `60` | Timeout in seconds for stdio server responses |
+| `MCP_TIMEOUT` | `60` | Timeout in seconds for server responses (stdio, CLI, and HTTP transports) |
 | `MCP_MAX_OUTPUT` | `1048576` | Maximum output bytes from CLI server commands |
 | `MCP_PROXY_REQUEST_TIMEOUT` | `120` | (proxy mode) Hard upper bound, in seconds, that any single client request can spend inside `mcp serve` before the proxy returns a JSON-RPC error. Acts as a belt-and-suspenders boundary on top of the per-transport `MCP_TIMEOUT`. |
 | `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Path to the persistent tool read/write classification cache (see [`mcp acl classify`](./cli.md#mcp-acl-classify)). Override this in CI/containers that cannot write to `$HOME`. |
 | `MCP_DISCOVERY_CONCURRENCY` | `10` | Max parallel `--help` calls during CLI subcommand discovery (see [CLI as MCP](../guides/cli-as-mcp.md)) |
+| `MCP_AUDIT_OUTPUT` | `file` | Audit output destination: `file` (ChronDB, queryable via `mcp logs`), `stdout`, `stderr` (JSON lines for container log drivers), or `none` (disable). |
 | `MCP_AUDIT_ENABLED` | `true` | Set to `false` or `0` to disable audit logging and database initialization. Overrides `audit.enabled` in the config file. |
 | `MCP_AUDIT_PATH` | `~/.config/mcp/db/data` | Override the ChronDB data directory. Overrides `audit.path` in the config file. |
 | `MCP_AUDIT_INDEX_PATH` | `~/.config/mcp/db/index` | Override the ChronDB index directory. Overrides `audit.index_path` in the config file. |
+| `MCP_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error`. Uses `tracing` `EnvFilter` syntax — you can also set per-module levels like `mcp=debug,hyper=warn`. |
+| `MCP_LOG_FORMAT` | `text` | Log output format: `text` (human-readable) or `json` (structured, for container log drivers). |
+| `MCP_OAUTH_CALLBACK_PORT` | `8085-8099` | Port or range for the OAuth callback listener. Single port (`9000`), range (`9000-9010`), or `0` for OS-assigned. |
 | `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override the OAuth token storage location |
 
 ### Config loading priority
@@ -75,13 +79,11 @@ When `HOME` is not set (common in `scratch` and `distroless` containers), `mcp` 
 
 ### `MCP_TIMEOUT`
 
-How long to wait for a stdio server to respond, in seconds. Increase this for servers that take a long time to initialize (like some npm packages on first run).
+How long to wait for a server to respond, in seconds. Applies to all transports: stdio, CLI, and HTTP. Increase this for servers that take a long time to initialize (like some npm packages on first run) or slow HTTP backends.
 
 ```bash
 MCP_TIMEOUT=120 mcp slack --list
 ```
-
-Does not affect HTTP servers (they use reqwest's default timeouts).
 
 ### `MCP_MAX_OUTPUT`
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -251,9 +251,22 @@ impl AuditLogger {
                             Utc::now().timestamp_millis(),
                             uuid::Uuid::new_v4()
                         );
-                        if let Ok(doc) = serde_json::to_value(&entry) {
-                            if let Ok(db) = writer_pool.acquire() {
-                                let _ = db.put(&key, &doc, None);
+                        match serde_json::to_value(&entry) {
+                            Ok(doc) => match writer_pool.acquire() {
+                                Ok(db) => {
+                                    if let Err(e) = db.put(&key, &doc, None) {
+                                        tracing::warn!(error = ?e, "failed to write audit entry");
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = format!("{e:#}"),
+                                        "failed to acquire db for audit"
+                                    );
+                                }
+                            },
+                            Err(e) => {
+                                tracing::warn!(error = %e, "failed to serialize audit entry");
                             }
                         }
                     }

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -10,6 +10,19 @@ fn default_true() -> bool {
     true
 }
 
+fn default_output() -> AuditOutput {
+    AuditOutput::File
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuditOutput {
+    File,
+    Stdout,
+    Stderr,
+    None,
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct AuditConfig {
     #[serde(default = "default_true")]
@@ -18,6 +31,8 @@ pub struct AuditConfig {
     pub index_path: Option<String>,
     #[serde(default)]
     pub log_arguments: bool,
+    #[serde(default = "default_output")]
+    pub output: AuditOutput,
 }
 
 impl Default for AuditConfig {
@@ -27,6 +42,7 @@ impl Default for AuditConfig {
             path: None,
             index_path: None,
             log_arguments: false,
+            output: AuditOutput::File,
         }
     }
 }
@@ -183,6 +199,9 @@ pub enum AuditLogger {
         sender: tokio::sync::mpsc::UnboundedSender<AuditEntry>,
         pool: Arc<DbPool>,
     },
+    Stream {
+        sender: tokio::sync::mpsc::UnboundedSender<AuditEntry>,
+    },
     Disabled,
 }
 
@@ -192,36 +211,70 @@ impl AuditLogger {
             return Ok(AuditLogger::Disabled);
         }
 
-        // Writer thread: receives entries via channel, writes to ChronDB on demand.
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AuditEntry>();
-        let writer_pool = pool.clone();
-        tokio::task::spawn_blocking(move || {
-            while let Some(entry) = rx.blocking_recv() {
-                let key = format!(
-                    "audit:{}-{}",
-                    Utc::now().timestamp_millis(),
-                    uuid::Uuid::new_v4()
-                );
-                if let Ok(doc) = serde_json::to_value(&entry) {
-                    if let Ok(db) = writer_pool.acquire() {
-                        let _ = db.put(&key, &doc, None);
-                    }
-                }
-            }
-        });
+        // Check effective output mode (env var overrides config)
+        let output = match std::env::var("MCP_AUDIT_OUTPUT") {
+            Ok(v) => match v.trim().to_lowercase().as_str() {
+                "stdout" => AuditOutput::Stdout,
+                "stderr" => AuditOutput::Stderr,
+                "none" => AuditOutput::None,
+                "file" => AuditOutput::File,
+                _ => config.output.clone(),
+            },
+            Err(_) => config.output.clone(),
+        };
 
-        Ok(AuditLogger::Active { sender: tx, pool })
+        match output {
+            AuditOutput::None => Ok(AuditLogger::Disabled),
+            AuditOutput::Stdout | AuditOutput::Stderr => {
+                let use_stderr = output == AuditOutput::Stderr;
+                let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AuditEntry>();
+                tokio::task::spawn_blocking(move || {
+                    while let Some(entry) = rx.blocking_recv() {
+                        if let Ok(line) = serde_json::to_string(&entry) {
+                            if use_stderr {
+                                eprintln!("{line}");
+                            } else {
+                                println!("{line}");
+                            }
+                        }
+                    }
+                });
+                Ok(AuditLogger::Stream { sender: tx })
+            }
+            AuditOutput::File => {
+                let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AuditEntry>();
+                let writer_pool = pool.clone();
+                tokio::task::spawn_blocking(move || {
+                    while let Some(entry) = rx.blocking_recv() {
+                        let key = format!(
+                            "audit:{}-{}",
+                            Utc::now().timestamp_millis(),
+                            uuid::Uuid::new_v4()
+                        );
+                        if let Ok(doc) = serde_json::to_value(&entry) {
+                            if let Ok(db) = writer_pool.acquire() {
+                                let _ = db.put(&key, &doc, None);
+                            }
+                        }
+                    }
+                });
+                Ok(AuditLogger::Active { sender: tx, pool })
+            }
+        }
     }
 
     pub fn log(&self, entry: AuditEntry) {
-        if let AuditLogger::Active { sender, .. } = self {
-            let _ = sender.send(entry);
+        match self {
+            AuditLogger::Active { sender, .. } | AuditLogger::Stream { sender } => {
+                let _ = sender.send(entry);
+            }
+            AuditLogger::Disabled => {}
         }
     }
 
     pub fn query_recent(&self, limit: usize) -> Result<Vec<AuditEntry>> {
         match self {
-            AuditLogger::Disabled => Ok(vec![]),
+            AuditLogger::Disabled | AuditLogger::Stream { .. } => Ok(vec![]),
             AuditLogger::Active { pool, .. } => {
                 let db = pool.acquire()?;
                 let raw = db
@@ -234,7 +287,7 @@ impl AuditLogger {
 
     pub fn query_filtered(&self, filter: &AuditFilter) -> Result<Vec<AuditEntry>> {
         match self {
-            AuditLogger::Disabled => Ok(vec![]),
+            AuditLogger::Disabled | AuditLogger::Stream { .. } => Ok(vec![]),
             AuditLogger::Active { pool, .. } => {
                 let db = pool.acquire()?;
                 let raw = db
@@ -506,6 +559,7 @@ mod tests {
         assert!(config.path.is_none());
         assert!(config.index_path.is_none());
         assert!(!config.log_arguments);
+        assert_eq!(config.output, AuditOutput::File);
     }
 
     #[test]
@@ -521,6 +575,40 @@ mod tests {
         assert_eq!(config.path.unwrap(), "/tmp/audit/data");
         assert_eq!(config.index_path.unwrap(), "/tmp/audit/index");
         assert!(config.log_arguments);
+        // Backward compat: missing output field defaults to File
+        assert_eq!(config.output, AuditOutput::File);
+    }
+
+    #[test]
+    fn test_audit_config_output_stdout() {
+        let json = json!({
+            "enabled": true,
+            "output": "stdout"
+        });
+        let config: AuditConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.output, AuditOutput::Stdout);
+    }
+
+    #[test]
+    fn test_audit_config_output_none() {
+        let json = json!({
+            "enabled": true,
+            "output": "none"
+        });
+        let config: AuditConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(config.output, AuditOutput::None);
+    }
+
+    #[test]
+    fn test_audit_output_serialization() {
+        assert_eq!(
+            serde_json::to_string(&AuditOutput::Stdout).unwrap(),
+            "\"stdout\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AuditOutput::File).unwrap(),
+            "\"file\""
+        );
     }
 
     // --- Disabled logger ---

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -12,8 +12,32 @@ use url::Url;
 use super::hints;
 use super::store::{self, to_stored_tokens};
 
-const CALLBACK_PORT_START: u16 = 8085;
-const CALLBACK_PORT_END: u16 = 8099;
+const DEFAULT_CALLBACK_PORT_START: u16 = 8085;
+const DEFAULT_CALLBACK_PORT_END: u16 = 8099;
+
+fn parse_port_spec(val: &str) -> (u16, u16) {
+    if val == "0" {
+        return (0, 0);
+    }
+    if let Some((start, end)) = val.split_once('-') {
+        if let (Ok(s), Ok(e)) = (start.parse::<u16>(), end.parse::<u16>()) {
+            if s <= e {
+                return (s, e);
+            }
+        }
+    }
+    if let Ok(port) = val.parse::<u16>() {
+        return (port, port);
+    }
+    (DEFAULT_CALLBACK_PORT_START, DEFAULT_CALLBACK_PORT_END)
+}
+
+fn callback_port_range() -> (u16, u16) {
+    match std::env::var("MCP_OAUTH_CALLBACK_PORT") {
+        Ok(val) => parse_port_spec(&val),
+        Err(_) => (DEFAULT_CALLBACK_PORT_START, DEFAULT_CALLBACK_PORT_END),
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct ProtectedResourceMetadata {
@@ -44,14 +68,14 @@ pub struct TokenResponse {
 pub async fn run_oauth_flow(server_url: &str) -> Result<String> {
     let key = store::server_key(server_url);
 
-    eprintln!("Authenticating with {}...", key);
+    tracing::info!(server = %key, "authenticating");
 
     let metadata = discover_auth_server(&key).await?;
 
     let client_id = match get_or_register_client(&key, &metadata).await {
         Ok(id) => id,
         Err(e) => {
-            eprintln!("OAuth registration not available: {e:#}");
+            tracing::warn!(error = format!("{e:#}"), "OAuth registration not available");
             return hints::prompt_for_token(server_url);
         }
     };
@@ -76,13 +100,13 @@ pub async fn run_oauth_flow(server_url: &str) -> Result<String> {
         auth_url.query_pairs_mut().append_pair("scope", &scopes);
     }
 
-    eprintln!("Opening browser for authorization...");
-    eprintln!("If it doesn't open, visit: {auth_url}");
+    tracing::info!("opening browser for authorization");
+    tracing::info!(url = %auth_url, "if browser doesn't open, visit this URL");
     let _ = open::that(auth_url.as_str());
 
     let code = wait_for_callback(listener, &state).await?;
 
-    eprintln!("Exchanging authorization code for tokens...");
+    tracing::info!("exchanging authorization code for tokens");
     let http = reqwest::Client::new();
     let resp = http
         .post(&metadata.token_endpoint)
@@ -113,7 +137,7 @@ pub async fn run_oauth_flow(server_url: &str) -> Result<String> {
     auth_store.tokens.insert(key.clone(), tokens);
     store::save_auth_store(&auth_store)?;
 
-    eprintln!("Authenticated successfully.");
+    tracing::info!("authenticated successfully");
     Ok(access_token)
 }
 
@@ -289,12 +313,18 @@ fn generate_random_string(len: usize) -> String {
 // --- Callback server ---
 
 async fn bind_callback_listener() -> Result<(TcpListener, u16)> {
-    for port in CALLBACK_PORT_START..=CALLBACK_PORT_END {
+    let (start, end) = callback_port_range();
+    if start == 0 {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let port = listener.local_addr()?.port();
+        return Ok((listener, port));
+    }
+    for port in start..=end {
         if let Ok(listener) = TcpListener::bind(format!("127.0.0.1:{port}")).await {
             return Ok((listener, port));
         }
     }
-    bail!("could not bind to any port in range {CALLBACK_PORT_START}-{CALLBACK_PORT_END}");
+    bail!("could not bind to any port in range {start}-{end}");
 }
 
 async fn wait_for_callback(listener: TcpListener, expected_state: &str) -> Result<String> {
@@ -388,6 +418,38 @@ mod tests {
         assert!(s
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || "-._~".contains(c)));
+    }
+
+    #[test]
+    fn test_parse_port_spec_single_port() {
+        assert_eq!(parse_port_spec("9000"), (9000, 9000));
+    }
+
+    #[test]
+    fn test_parse_port_spec_range() {
+        assert_eq!(parse_port_spec("9000-9010"), (9000, 9010));
+    }
+
+    #[test]
+    fn test_parse_port_spec_os_assigned() {
+        assert_eq!(parse_port_spec("0"), (0, 0));
+    }
+
+    #[test]
+    fn test_parse_port_spec_invalid_fallback() {
+        assert_eq!(
+            parse_port_spec("not-a-port"),
+            (DEFAULT_CALLBACK_PORT_START, DEFAULT_CALLBACK_PORT_END)
+        );
+    }
+
+    #[test]
+    fn test_parse_port_spec_inverted_range_fallback() {
+        // end < start should fall back to defaults
+        assert_eq!(
+            parse_port_spec("9010-9000"),
+            (DEFAULT_CALLBACK_PORT_START, DEFAULT_CALLBACK_PORT_END)
+        );
     }
 
     #[test]

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -72,7 +72,12 @@ pub async fn run_oauth_flow(server_url: &str) -> Result<String> {
 
     let metadata = discover_auth_server(&key).await?;
 
-    let client_id = match get_or_register_client(&key, &metadata).await {
+    // Bind callback listener BEFORE client registration so the redirect_uri
+    // in the registration request matches the actual port we're listening on.
+    let (listener, port) = bind_callback_listener().await?;
+    let redirect_uri = format!("http://localhost:{port}/callback");
+
+    let client_id = match get_or_register_client(&key, &metadata, &redirect_uri).await {
         Ok(id) => id,
         Err(e) => {
             tracing::warn!(error = format!("{e:#}"), "OAuth registration not available");
@@ -82,9 +87,6 @@ pub async fn run_oauth_flow(server_url: &str) -> Result<String> {
 
     let (code_verifier, code_challenge) = generate_pkce();
     let state = generate_random_string(32);
-
-    let (listener, port) = bind_callback_listener().await?;
-    let redirect_uri = format!("http://localhost:{port}/callback");
 
     let scopes = metadata.scopes_supported.join(" ");
     let mut auth_url = Url::parse(&metadata.authorization_endpoint)?;
@@ -235,6 +237,7 @@ async fn discover_auth_server(server_url: &str) -> Result<AuthServerMetadata> {
 async fn get_or_register_client(
     server_key_str: &str,
     metadata: &AuthServerMetadata,
+    redirect_uri: &str,
 ) -> Result<String> {
     let auth_store = store::load_auth_store()?;
     if let Some(reg) = auth_store.clients.get(server_key_str) {
@@ -249,7 +252,7 @@ async fn get_or_register_client(
     let http = reqwest::Client::new();
     let body = serde_json::json!({
         "client_name": "mcp",
-        "redirect_uris": ["http://localhost:8085/callback"],
+        "redirect_uris": [redirect_uri],
         "grant_types": ["authorization_code", "refresh_token"],
         "response_types": ["code"],
         "token_endpoint_auth_method": "none"

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -176,7 +176,7 @@ _mcp() {{
             _describe 'subcommand' subcommands
             ;;
         args)
-            case $words[1] in
+            case $words[2] in
                 config)
                     _values 'config subcommand' 'path[Show config file path]' 'edit[Open config in editor]'
                     ;;

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -1,0 +1,271 @@
+use anyhow::{bail, Result};
+
+const SUBCOMMANDS: &[&str] = &[
+    "search",
+    "add",
+    "remove",
+    "update",
+    "serve",
+    "logs",
+    "acl",
+    "config",
+    "completions",
+    "healthcheck",
+];
+
+pub fn handle_completions_command(args: &[String]) -> Result<()> {
+    if args.is_empty() {
+        bail!("usage: mcp completions <bash|zsh|fish>");
+    }
+    match args[0].as_str() {
+        "bash" => print!("{}", bash_completions()),
+        "zsh" => print!("{}", zsh_completions()),
+        "fish" => print!("{}", fish_completions()),
+        other => bail!("unsupported shell: {other} (use bash, zsh, or fish)"),
+    }
+    Ok(())
+}
+
+fn fish_completions() -> String {
+    let mut out = String::from("# mcp fish completions\n");
+    out.push_str("# Install: mcp completions fish > ~/.config/fish/completions/mcp.fish\n\n");
+
+    // Disable file completions by default
+    out.push_str("complete -c mcp -f\n\n");
+
+    // Global flags
+    out.push_str("complete -c mcp -l json -d 'Force JSON output'\n");
+    out.push_str("complete -c mcp -l insecure -d 'Allow HTTP on non-loopback interfaces'\n");
+    out.push_str("complete -c mcp -l list -d 'List configured servers'\n");
+    out.push_str("complete -c mcp -l help -s h -d 'Show help'\n\n");
+
+    // Subcommands (only when no subcommand is selected yet)
+    for cmd in SUBCOMMANDS {
+        let desc = subcommand_description(cmd);
+        out.push_str(&format!(
+            "complete -c mcp -n '__fish_use_subcommand' -a '{cmd}' -d '{desc}'\n"
+        ));
+    }
+    out.push('\n');
+
+    // config subcommands
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from config' -a 'path' -d 'Show config file path'\n",
+    );
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from config' -a 'edit' -d 'Open config in editor'\n",
+    );
+    out.push('\n');
+
+    // completions subcommands
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from completions' -a 'bash zsh fish' -d 'Shell type'\n",
+    );
+    out.push('\n');
+
+    // acl subcommands
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from acl' -a 'classify' -d 'Classify tools as read/write'\n",
+    );
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from acl' -a 'check' -d 'Check ACL decision'\n",
+    );
+    out.push('\n');
+
+    // logs flags
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from logs' -l limit -d 'Max entries' -r\n",
+    );
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from logs' -l server -d 'Filter by server' -r\n",
+    );
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from logs' -l tool -d 'Filter by tool prefix' -r\n",
+    );
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from logs' -l errors -d 'Show only failures'\n",
+    );
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from logs' -l since -d 'Time filter (5m, 1h, 24h, 7d)' -r\n",
+    );
+    out.push_str("complete -c mcp -n '__fish_seen_subcommand_from logs' -s f -d 'Follow mode'\n");
+    out.push('\n');
+
+    // serve flags
+    out.push_str(
+        "complete -c mcp -n '__fish_seen_subcommand_from serve' -l http -d 'HTTP mode with optional bind address' -r\n",
+    );
+
+    out
+}
+
+fn bash_completions() -> String {
+    let cmds = SUBCOMMANDS.join(" ");
+    format!(
+        r#"# mcp bash completions
+# Install: eval "$(mcp completions bash)" or add to ~/.bashrc
+
+_mcp() {{
+    local cur prev words cword
+    _init_completion || return
+
+    local subcommands="{cmds}"
+    local global_flags="--list --json --insecure --help -h"
+
+    case "${{words[1]}}" in
+        config)
+            COMPREPLY=( $(compgen -W "path edit" -- "$cur") )
+            return
+            ;;
+        completions)
+            COMPREPLY=( $(compgen -W "bash zsh fish" -- "$cur") )
+            return
+            ;;
+        acl)
+            COMPREPLY=( $(compgen -W "classify check" -- "$cur") )
+            return
+            ;;
+        logs)
+            COMPREPLY=( $(compgen -W "--limit --server --tool --errors --since -f" -- "$cur") )
+            return
+            ;;
+        serve)
+            COMPREPLY=( $(compgen -W "--http --insecure" -- "$cur") )
+            return
+            ;;
+    esac
+
+    if [[ $cword -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$subcommands $global_flags" -- "$cur") )
+    fi
+}}
+
+complete -F _mcp mcp
+"#
+    )
+}
+
+fn zsh_completions() -> String {
+    let cmds_list: String = SUBCOMMANDS
+        .iter()
+        .map(|c| format!("            '{c}:{}'", subcommand_description(c)))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"#compdef mcp
+# mcp zsh completions
+# Install: mcp completions zsh > ${{fpath[1]}}/_mcp
+
+_mcp() {{
+    local -a subcommands
+    subcommands=(
+{cmds_list}
+    )
+
+    _arguments -C \
+        '--list[List configured servers]' \
+        '--json[Force JSON output]' \
+        '--insecure[Allow HTTP on non-loopback]' \
+        '(-h --help){{-h,--help}}[Show help]' \
+        '1:subcommand:->subcmd' \
+        '*::arg:->args'
+
+    case $state in
+        subcmd)
+            _describe 'subcommand' subcommands
+            ;;
+        args)
+            case $words[1] in
+                config)
+                    _values 'config subcommand' 'path[Show config file path]' 'edit[Open config in editor]'
+                    ;;
+                completions)
+                    _values 'shell' bash zsh fish
+                    ;;
+                acl)
+                    _values 'acl subcommand' 'classify[Classify tools]' 'check[Check ACL decision]'
+                    ;;
+                logs)
+                    _arguments \
+                        '--limit[Max entries]:limit' \
+                        '--server[Filter by server]:server' \
+                        '--tool[Filter by tool prefix]:tool' \
+                        '--errors[Show only failures]' \
+                        '--since[Time filter]:duration' \
+                        '-f[Follow mode]'
+                    ;;
+                serve)
+                    _arguments \
+                        '--http[HTTP mode with bind address]:address' \
+                        '--insecure[Allow HTTP on non-loopback]'
+                    ;;
+            esac
+            ;;
+    esac
+}}
+
+_mcp "$@"
+"#
+    )
+}
+
+fn subcommand_description(cmd: &str) -> &str {
+    match cmd {
+        "search" => "Search MCP registry",
+        "add" => "Add server from registry",
+        "remove" => "Remove server from config",
+        "update" => "Refresh server config from registry",
+        "serve" => "Start proxy server",
+        "logs" => "Show audit log entries",
+        "acl" => "Manage access control",
+        "config" => "Manage configuration",
+        "completions" => "Generate shell completions",
+        "healthcheck" => "HTTP health probe",
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fish_completions_contains_subcommands() {
+        let output = fish_completions();
+        for cmd in SUBCOMMANDS {
+            assert!(output.contains(cmd), "missing subcommand: {cmd}");
+        }
+        assert!(output.contains("complete -c mcp"));
+    }
+
+    #[test]
+    fn test_bash_completions_contains_subcommands() {
+        let output = bash_completions();
+        for cmd in SUBCOMMANDS {
+            assert!(output.contains(cmd), "missing subcommand: {cmd}");
+        }
+        assert!(output.contains("complete -F _mcp mcp"));
+    }
+
+    #[test]
+    fn test_zsh_completions_contains_subcommands() {
+        let output = zsh_completions();
+        for cmd in SUBCOMMANDS {
+            assert!(output.contains(cmd), "missing subcommand: {cmd}");
+        }
+        assert!(output.contains("#compdef mcp"));
+    }
+
+    #[test]
+    fn test_unsupported_shell() {
+        let args = vec!["powershell".to_string()];
+        assert!(handle_completions_command(&args).is_err());
+    }
+
+    #[test]
+    fn test_empty_args() {
+        let args: Vec<String> = vec![];
+        assert!(handle_completions_command(&args).is_err());
+    }
+}

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -72,24 +72,61 @@ fn handle_config_edit() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvRestore {
+        editor: Option<String>,
+        visual: Option<String>,
+    }
+
+    impl EnvRestore {
+        fn capture() -> Self {
+            Self {
+                editor: std::env::var("EDITOR").ok(),
+                visual: std::env::var("VISUAL").ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match &self.editor {
+                Some(v) => std::env::set_var("EDITOR", v),
+                None => std::env::remove_var("EDITOR"),
+            }
+            match &self.visual {
+                Some(v) => std::env::set_var("VISUAL", v),
+                None => std::env::remove_var("VISUAL"),
+            }
+        }
+    }
 
     #[test]
     fn test_resolve_editor_from_env() {
+        let _guard = env_lock().lock().unwrap();
+        let _restore = EnvRestore::capture();
         std::env::set_var("EDITOR", "nano");
         assert_eq!(resolve_editor(), "nano");
-        std::env::remove_var("EDITOR");
     }
 
     #[test]
     fn test_resolve_editor_visual_fallback() {
+        let _guard = env_lock().lock().unwrap();
+        let _restore = EnvRestore::capture();
         std::env::remove_var("EDITOR");
         std::env::set_var("VISUAL", "code");
         assert_eq!(resolve_editor(), "code");
-        std::env::remove_var("VISUAL");
     }
 
     #[test]
     fn test_resolve_editor_default() {
+        let _guard = env_lock().lock().unwrap();
+        let _restore = EnvRestore::capture();
         std::env::remove_var("EDITOR");
         std::env::remove_var("VISUAL");
         let editor = resolve_editor();
@@ -102,7 +139,6 @@ mod tests {
 
     #[test]
     fn test_config_path_json_output() {
-        // Verify the JSON mode produces valid JSON with expected fields
         let path = config::config_path().unwrap();
         let json = serde_json::json!({
             "path": path.to_string_lossy(),

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,116 @@
+use anyhow::{bail, Context, Result};
+
+use crate::config;
+use crate::output::OutputFormat;
+
+pub fn handle_config_command(args: &[String], fmt: OutputFormat) -> Result<()> {
+    if args.is_empty() {
+        bail!("usage: mcp config <path|edit>");
+    }
+    match args[0].as_str() {
+        "path" => handle_config_path(fmt),
+        "edit" => handle_config_edit(),
+        other => bail!("unknown config subcommand: {other}"),
+    }
+}
+
+fn handle_config_path(fmt: OutputFormat) -> Result<()> {
+    let path = config::config_path()?;
+    match fmt {
+        OutputFormat::Json => {
+            let json = serde_json::json!({
+                "path": path.to_string_lossy(),
+                "exists": path.exists(),
+                "dir": config::config_dir()?.to_string_lossy().to_string(),
+            });
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        OutputFormat::Text => {
+            println!("{}", path.display());
+        }
+    }
+    Ok(())
+}
+
+fn resolve_editor() -> String {
+    std::env::var("EDITOR")
+        .or_else(|_| std::env::var("VISUAL"))
+        .unwrap_or_else(|_| {
+            if cfg!(target_os = "windows") {
+                "notepad".to_string()
+            } else {
+                "vi".to_string()
+            }
+        })
+}
+
+fn handle_config_edit() -> Result<()> {
+    let path = config::config_path()?;
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create config directory: {}", parent.display())
+            })?;
+        }
+        std::fs::write(&path, "{}\n")
+            .with_context(|| format!("failed to create config file: {}", path.display()))?;
+    }
+
+    let editor = resolve_editor();
+    let status = std::process::Command::new(&editor)
+        .arg(&path)
+        .status()
+        .with_context(|| format!("failed to launch editor: {editor}"))?;
+
+    if !status.success() {
+        bail!("editor exited with status {status}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_editor_from_env() {
+        std::env::set_var("EDITOR", "nano");
+        assert_eq!(resolve_editor(), "nano");
+        std::env::remove_var("EDITOR");
+    }
+
+    #[test]
+    fn test_resolve_editor_visual_fallback() {
+        std::env::remove_var("EDITOR");
+        std::env::set_var("VISUAL", "code");
+        assert_eq!(resolve_editor(), "code");
+        std::env::remove_var("VISUAL");
+    }
+
+    #[test]
+    fn test_resolve_editor_default() {
+        std::env::remove_var("EDITOR");
+        std::env::remove_var("VISUAL");
+        let editor = resolve_editor();
+        if cfg!(target_os = "windows") {
+            assert_eq!(editor, "notepad");
+        } else {
+            assert_eq!(editor, "vi");
+        }
+    }
+
+    #[test]
+    fn test_config_path_json_output() {
+        // Verify the JSON mode produces valid JSON with expected fields
+        let path = config::config_path().unwrap();
+        let json = serde_json::json!({
+            "path": path.to_string_lossy(),
+            "exists": path.exists(),
+            "dir": config::config_dir().unwrap().to_string_lossy().to_string(),
+        });
+        assert!(json["path"].is_string());
+        assert!(json["exists"].is_boolean());
+        assert!(json["dir"].is_string());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,7 +1,11 @@
 mod acl;
+mod completions;
+mod config;
 mod logs;
 mod server;
 
 pub use acl::handle_acl_command;
+pub use completions::handle_completions_command;
+pub use config::handle_config_command;
 pub use logs::handle_logs_command;
 pub use server::handle_server_command;

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,7 +10,16 @@ use crate::audit::AuditConfig;
 use crate::server_auth::ServerAuthConfig;
 
 const RESERVED_NAMES: &[&str] = &[
-    "search", "add", "remove", "list", "help", "version", "serve", "logs",
+    "search",
+    "add",
+    "remove",
+    "list",
+    "help",
+    "version",
+    "serve",
+    "logs",
+    "config",
+    "completions",
 ];
 
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]
@@ -201,7 +210,7 @@ pub fn config_dir() -> Result<PathBuf> {
     if let Some(home) = dirs::home_dir() {
         return Ok(home.join(".config").join("mcp"));
     }
-    eprintln!("warning: HOME not set, using /tmp/mcp as config directory");
+    tracing::warn!("HOME not set, using /tmp/mcp as config directory");
     Ok(PathBuf::from("/tmp/mcp"))
 }
 
@@ -409,6 +418,15 @@ fn apply_audit_env_overrides(mut audit: AuditConfig) -> AuditConfig {
         match v.trim() {
             s if s.eq_ignore_ascii_case("false") || s == "0" => audit.enabled = false,
             s if s.eq_ignore_ascii_case("true") || s == "1" => audit.enabled = true,
+            _ => {}
+        }
+    }
+    if let Some(v) = non_empty_env("MCP_AUDIT_OUTPUT") {
+        match v.to_lowercase().as_str() {
+            "file" => audit.output = crate::audit::AuditOutput::File,
+            "stdout" => audit.output = crate::audit::AuditOutput::Stdout,
+            "stderr" => audit.output = crate::audit::AuditOutput::Stderr,
+            "none" => audit.output = crate::audit::AuditOutput::None,
             _ => {}
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,13 +13,16 @@ const RESERVED_NAMES: &[&str] = &[
     "search",
     "add",
     "remove",
+    "update",
     "list",
     "help",
     "version",
     "serve",
     "logs",
+    "acl",
     "config",
     "completions",
+    "healthcheck",
 ];
 
 #[derive(Debug, Default, Deserialize, Clone, PartialEq)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -32,7 +32,7 @@ impl DbPool {
             .idle_timeout(idle_timeout)
             .open()
             .map_err(|e| anyhow::anyhow!("failed to open db: {e:?}"))?;
-        eprintln!("[db] database opened (idle timeout {:?})", idle_timeout);
+        tracing::info!(idle_timeout = ?idle_timeout, "database opened");
         Ok(Self {
             db: Some(Arc::new(db)),
         })
@@ -51,7 +51,7 @@ impl DbPool {
 /// Returns a disabled pool when audit is disabled (e.g. container with read-only fs).
 pub fn create_pool(audit_config: &AuditConfig) -> Result<Arc<DbPool>> {
     if !audit_config.enabled {
-        eprintln!("[db] audit disabled, skipping database initialization");
+        tracing::info!("audit disabled, skipping database initialization");
         return Ok(Arc::new(DbPool::disabled()));
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,29 @@
+use tracing_subscriber::EnvFilter;
+
+/// Initialize the tracing subscriber for structured logging.
+///
+/// Reads `MCP_LOG_LEVEL` (default: "info") and `MCP_LOG_FORMAT` (default: "text").
+/// When `MCP_LOG_FORMAT=json`, emits newline-delimited JSON to stderr — ideal for
+/// container log drivers and centralized logging pipelines.
+pub fn init() {
+    let level = std::env::var("MCP_LOG_LEVEL").unwrap_or_else(|_| "info".into());
+    let format = std::env::var("MCP_LOG_FORMAT").unwrap_or_else(|_| "text".into());
+
+    let filter = EnvFilter::try_new(&level).unwrap_or_else(|_| EnvFilter::new("info"));
+
+    match format.as_str() {
+        "json" => {
+            tracing_subscriber::fmt()
+                .json()
+                .with_env_filter(filter)
+                .with_target(false)
+                .init();
+        }
+        _ => {
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .with_target(false)
+                .init();
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cli_discovery;
 mod client;
 mod config;
 mod db;
+mod logging;
 mod manager;
 mod output;
 mod protocol;
@@ -24,8 +25,9 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
+    logging::init();
     if let Err(e) = run().await {
-        eprintln!("error: {e:#}");
+        tracing::error!(error = format!("{e:#}"), "fatal error");
         std::process::exit(1);
     }
 }
@@ -64,6 +66,9 @@ fn print_usage() {
     eprintln!("                                      Check ACL decision for a prompt");
     eprintln!("  mcp acl check --role <name> --server <alias> --all-tools");
     eprintln!("                                      Check all tools for a role");
+    eprintln!("  mcp config path                     Show config file path");
+    eprintln!("  mcp config edit                     Open config in $EDITOR");
+    eprintln!("  mcp completions <shell>             Generate shell completions (bash, zsh, fish)");
     eprintln!("  mcp healthcheck [url]               HTTP health probe (for containers)");
     eprintln!();
     eprintln!("Flags:");
@@ -84,10 +89,10 @@ async fn run() -> Result<()> {
     let cfg = config::load_config()?;
     let conflicts = config::validate_server_names(&cfg);
     for name in &conflicts {
-        eprintln!("warning: server \"{name}\" conflicts with a reserved command name");
-        eprintln!(
-            "  → rename it in {} to avoid unexpected behavior",
-            cfg.path.display()
+        tracing::warn!(
+            server = %name,
+            config = %cfg.path.display(),
+            "server name conflicts with a reserved command name — rename it to avoid unexpected behavior"
         );
     }
 
@@ -139,11 +144,16 @@ async fn run() -> Result<()> {
         return serve::run(cfg, http_addr.as_deref(), insecure).await;
     }
 
-    // Shared database pool for audit logging and tool cache
-    let db_pool = db::create_pool(&cfg.audit).unwrap_or_else(|e| {
-        eprintln!("warning: failed to create db pool: {e:#}");
+    // Shared database pool for audit logging and tool cache.
+    // Skip heavy DB init when audit output goes to stdout/stderr/none.
+    let db_pool = if cfg.audit.output == audit::AuditOutput::File {
+        db::create_pool(&cfg.audit).unwrap_or_else(|e| {
+            tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
+            Arc::new(db::DbPool::disabled())
+        })
+    } else {
         Arc::new(db::DbPool::disabled())
-    });
+    };
 
     // Audit logger shared across all commands
     let audit = Arc::new(
@@ -279,6 +289,12 @@ async fn run() -> Result<()> {
         }
         "acl" => {
             return cli::handle_acl_command(&args[1..], &cfg, fmt, &audit).await;
+        }
+        "config" => {
+            return cli::handle_config_command(&args[1..], fmt);
+        }
+        "completions" => {
+            return cli::handle_completions_command(&args[1..]);
         }
         _ => {}
     }

--- a/src/serve/discovery.rs
+++ b/src/serve/discovery.rs
@@ -34,7 +34,7 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
     }
 
     for name in pending.iter().map(|(n, _)| n) {
-        eprintln!("[serve] discovering tools from {name}...");
+        tracing::info!(server = %name, "discovering tools");
     }
 
     let discovery_timeout = Duration::from_secs(30);
@@ -53,14 +53,14 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
                 let resources = match client.list_resources().await {
                     Ok(r) => r,
                     Err(e) => {
-                        eprintln!("[serve] {name}: resources/list not supported or failed: {e:#}");
+                        tracing::debug!(server = %name, error = %e, "resources/list not supported or failed");
                         vec![]
                     }
                 };
                 let prompts = match client.list_prompts().await {
                     Ok(p) => p,
                     Err(e) => {
-                        eprintln!("[serve] {name}: prompts/list not supported or failed: {e:#}");
+                        tracing::debug!(server = %name, error = %e, "prompts/list not supported or failed");
                         vec![]
                     }
                 };
@@ -78,7 +78,7 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
         let (name, result) = match joined {
             Ok(t) => t,
             Err(e) => {
-                eprintln!("[serve] discovery task panicked: {e}");
+                tracing::error!(error = %e, "discovery task panicked");
                 continue;
             }
         };
@@ -90,11 +90,12 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
                     drop(client);
                     continue;
                 }
-                eprintln!(
-                    "[serve] {name}: {} tool(s), {} resource(s), {} prompt(s)",
-                    tools.len(),
-                    resources.len(),
-                    prompts.len()
+                tracing::info!(
+                    server = %name,
+                    tools = tools.len(),
+                    resources = resources.len(),
+                    prompts = prompts.len(),
+                    "discovered capabilities"
                 );
                 p.register_tools(&name, &tools);
                 p.register_resources(&name, &resources);
@@ -112,7 +113,7 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
             Ok(Err(e)) => {
                 let mut p = proxy.lock().await;
                 let msg = format!("failed to discover: {e:#}");
-                eprintln!("[serve] {name}: {msg}");
+                tracing::warn!(server = %name, error = %e, "failed to discover");
                 p.audit.log(AuditEntry {
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     source: "serve:discovery".to_string(),
@@ -139,7 +140,7 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
             Err(_) => {
                 let mut p = proxy.lock().await;
                 let msg = format!("discovery timed out ({}s)", discovery_timeout.as_secs());
-                eprintln!("[serve] {name}: {msg}");
+                tracing::warn!(server = %name, timeout_secs = discovery_timeout.as_secs(), "discovery timed out");
                 p.audit.log(AuditEntry {
                     timestamp: chrono::Utc::now().to_rfc3339(),
                     source: "serve:discovery".to_string(),
@@ -171,12 +172,12 @@ pub(crate) async fn discover_pending_backends(proxy: &SharedProxy) {
     // and would otherwise block every request handler.
     let (cache_entries, cache_store) = {
         let p = proxy.lock().await;
-        eprintln!(
-            "[serve] ready — {} backend(s), {} tool(s), {} resource(s), {} prompt(s)",
-            p.backends.len(),
-            p.tools.len(),
-            p.resources.len(),
-            p.prompts.len()
+        tracing::info!(
+            backends = p.backends.len(),
+            tools = p.tools.len(),
+            resources = p.resources.len(),
+            prompts = p.prompts.len(),
+            "ready"
         );
         (p.snapshot_cache_entries(), p.cache_store.clone())
     };
@@ -224,7 +225,7 @@ pub(crate) async fn discover_single_backend(proxy: &SharedProxy, backend_name: &
         }
     };
 
-    eprintln!("[serve] discovering tools from {backend_name}...");
+    tracing::info!(server = %backend_name, "discovering tools");
     let discovery_timeout = Duration::from_secs(30);
     let name = backend_name.to_string();
 
@@ -234,14 +235,14 @@ pub(crate) async fn discover_single_backend(proxy: &SharedProxy, backend_name: &
         let resources = match client.list_resources().await {
             Ok(r) => r,
             Err(e) => {
-                eprintln!("[serve] {name}: resources/list not supported or failed: {e:#}");
+                tracing::debug!(server = %name, error = %e, "resources/list not supported or failed");
                 vec![]
             }
         };
         let prompts = match client.list_prompts().await {
             Ok(p) => p,
             Err(e) => {
-                eprintln!("[serve] {name}: prompts/list not supported or failed: {e:#}");
+                tracing::debug!(server = %name, error = %e, "prompts/list not supported or failed");
                 vec![]
             }
         };
@@ -256,11 +257,12 @@ pub(crate) async fn discover_single_backend(proxy: &SharedProxy, backend_name: &
                 drop(client);
                 return;
             }
-            eprintln!(
-                "[serve] {name}: {} tool(s), {} resource(s), {} prompt(s)",
-                tools.len(),
-                resources.len(),
-                prompts.len()
+            tracing::info!(
+                server = %name,
+                tools = tools.len(),
+                resources = resources.len(),
+                prompts = prompts.len(),
+                "discovered capabilities"
             );
             p.register_tools(&name, &tools);
             p.register_resources(&name, &resources);
@@ -278,7 +280,7 @@ pub(crate) async fn discover_single_backend(proxy: &SharedProxy, backend_name: &
         Ok(Err(e)) => {
             let mut p = proxy.lock().await;
             let msg = format!("failed to discover: {e:#}");
-            eprintln!("[serve] {name}: {msg}");
+            tracing::warn!(server = %name, error = %e, "failed to discover");
             p.audit.log(AuditEntry {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 source: "serve:discovery".to_string(),
@@ -305,7 +307,7 @@ pub(crate) async fn discover_single_backend(proxy: &SharedProxy, backend_name: &
         Err(_) => {
             let mut p = proxy.lock().await;
             let msg = format!("discovery timed out ({}s)", discovery_timeout.as_secs());
-            eprintln!("[serve] {name}: {msg}");
+            tracing::warn!(server = %name, timeout_secs = discovery_timeout.as_secs(), "discovery timed out");
             p.audit.log(AuditEntry {
                 timestamp: chrono::Utc::now().to_rfc3339(),
                 source: "serve:discovery".to_string(),
@@ -389,20 +391,20 @@ pub(crate) async fn connect_backend(
         return Ok(existing);
     }
 
-    eprintln!("[serve] connecting to {server_name}...");
+    tracing::info!(server = %server_name, "connecting");
     let client = McpClient::connect(&config).await?;
     let tools = client.list_tools().await?;
     let resources = match client.list_resources().await {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("[serve] {server_name}: resources/list not supported or failed: {e:#}");
+            tracing::debug!(server = %server_name, error = %e, "resources/list not supported or failed");
             vec![]
         }
     };
     let prompts = match client.list_prompts().await {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("[serve] {server_name}: prompts/list not supported or failed: {e:#}");
+            tracing::debug!(server = %server_name, error = %e, "prompts/list not supported or failed");
             vec![]
         }
     };
@@ -430,9 +432,7 @@ pub(crate) async fn connect_backend(
                 .await
                 .is_err()
             {
-                eprintln!(
-                    "[serve] {name}: previous client shutdown timed out — force-killed via drop"
-                );
+                tracing::warn!(server = %name, "previous client shutdown timed out, force-killed via drop");
             }
             drop(prev);
         });

--- a/src/serve/http.rs
+++ b/src/serve/http.rs
@@ -137,7 +137,7 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
     let acl = config.server_auth.acl.clone();
 
     let pool = crate::db::create_pool(&config.audit).unwrap_or_else(|e| {
-        eprintln!("warning: failed to create db pool: {e:#}");
+        tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
         Arc::new(crate::db::DbPool::disabled())
     });
     let audit = AuditLogger::open(&config.audit, pool.clone()).unwrap_or(AuditLogger::Disabled);
@@ -202,14 +202,14 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
     // Log all incoming requests for debugging
     let request_logger = axum::middleware::from_fn(
         |req: axum::extract::Request, next: axum::middleware::Next| async move {
-            eprintln!(
-                "[serve] {} {} {}",
-                req.method(),
-                req.uri(),
-                req.headers()
+            tracing::debug!(
+                method = %req.method(),
+                uri = %req.uri(),
+                accept = req.headers()
                     .get("accept")
                     .and_then(|v| v.to_str().ok())
-                    .unwrap_or("-")
+                    .unwrap_or("-"),
+                "incoming request"
             );
             next.run(req).await
         },
@@ -222,14 +222,10 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         .fallback(|req: axum::extract::Request| async move {
             let path = req.uri().path().to_string();
             let method = req.method().clone();
-            eprintln!(
-                "[serve] UNHANDLED {} {} (headers: {:?})",
-                method,
-                path,
-                req.headers()
-                    .iter()
-                    .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("?")))
-                    .collect::<Vec<_>>()
+            tracing::debug!(
+                method = %method,
+                path = %path,
+                "unhandled request"
             );
             // OAuth/OIDC discovery endpoints: return 404 with valid JSON
             // so clients that probe for auth don't crash on empty bodies
@@ -244,11 +240,11 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         .layer(request_logger)
         .with_state(state.clone());
 
-    eprintln!("[serve] HTTP server listening on {sock_addr}");
+    tracing::info!(addr = %sock_addr, "HTTP server listening");
     if sock_addr.ip().is_loopback() {
-        eprintln!("[serve] bound to loopback — local access only");
+        tracing::info!("bound to loopback — local access only");
     } else {
-        eprintln!("[serve] WARNING: bound to non-loopback address without TLS");
+        tracing::warn!("bound to non-loopback address without TLS");
     }
 
     let listener = bind_listener_with_keepalive(sock_addr)?;
@@ -270,7 +266,7 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         {
             ctrl_c.await.ok();
         }
-        eprintln!("\n[serve] shutdown signal received");
+        tracing::info!("shutdown signal received");
         let _ = shutdown_tx.send(true);
     };
 
@@ -291,9 +287,9 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         .await
         .is_err()
     {
-        eprintln!("[serve] shutdown timed out — forcing exit");
+        tracing::warn!("shutdown timed out — forcing exit");
     }
-    eprintln!("[serve] shutting down");
+    tracing::info!("shutting down");
 
     Ok(())
 }
@@ -419,8 +415,9 @@ async fn mcp_handler(
                 Ok(Err(_)) | Err(_) => {
                     // Receiver gone or buffer wedged → evict the session.
                     state.sessions.lock().await.remove(session_id);
-                    eprintln!(
-                        "[serve] sse session {session_id} evicted: stream send timed out or closed"
+                    tracing::debug!(
+                        session_id = %session_id,
+                        "sse session evicted: stream send timed out or closed"
                     );
                 }
             }
@@ -497,8 +494,9 @@ async fn mcp_sse_handler(State(state): State<AppState>, headers: HeaderMap) -> i
                             // After ~1 minute (4 × 15s intervals) of full
                             // buffer, treat the session as wedged and evict.
                             if consecutive_send_failures >= 4 {
-                                eprintln!(
-                                    "[serve] sse session {session_id_clone} evicted: ping buffer full"
+                                tracing::debug!(
+                                    session_id = %session_id_clone,
+                                    "sse session evicted: ping buffer full"
                                 );
                                 break;
                             }

--- a/src/serve/http.rs
+++ b/src/serve/http.rs
@@ -136,10 +136,14 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
     let auth_provider = server_auth::build_auth_provider(&config.server_auth)?;
     let acl = config.server_auth.acl.clone();
 
-    let pool = crate::db::create_pool(&config.audit).unwrap_or_else(|e| {
-        tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
+    let pool = if config.audit.output == crate::audit::AuditOutput::File {
+        crate::db::create_pool(&config.audit).unwrap_or_else(|e| {
+            tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
+            Arc::new(crate::db::DbPool::disabled())
+        })
+    } else {
         Arc::new(crate::db::DbPool::disabled())
-    });
+    };
     let audit = AuditLogger::open(&config.audit, pool.clone()).unwrap_or(AuditLogger::Disabled);
     let cache_store = ToolCacheStore::new(pool);
     let mut server = ProxyServer::new(

--- a/src/serve/proxy.rs
+++ b/src/serve/proxy.rs
@@ -282,10 +282,11 @@ impl ProxyServer {
                 classify(tool, overrides.as_ref())
             };
             if classification.kind == Kind::Ambiguous {
-                eprintln!(
-                    "[serve] {server_name}:{tool_name}: classification ambiguous → treated as write (reasons: {reasons})",
-                    tool_name = tool.name,
-                    reasons = classification.reasons.join("; "),
+                tracing::warn!(
+                    server = %server_name,
+                    tool = %tool.name,
+                    reasons = %classification.reasons.join("; "),
+                    "classification ambiguous — treated as write",
                 );
             }
             self.classifications
@@ -389,7 +390,7 @@ impl ProxyServer {
                 .iter()
                 .filter(|t| t.name.starts_with(&format!("{name}{SEPARATOR}")))
                 .count();
-            eprintln!("[serve] {name}: {tool_count} tool(s) (cached)");
+            tracing::info!(server = %name, tool_count, "tools loaded from cache");
         }
     }
 
@@ -533,11 +534,12 @@ impl ProxyServer {
         self.register_resources(server_name, resources);
         self.unregister_prompts(server_name);
         self.register_prompts(server_name, prompts);
-        eprintln!(
-            "[serve] {server_name}: {} tool(s), {} resource(s), {} prompt(s) (reconnected)",
-            tools.len(),
-            resources.len(),
-            prompts.len()
+        tracing::info!(
+            server = %server_name,
+            tools = tools.len(),
+            resources = resources.len(),
+            prompts = prompts.len(),
+            "reconnected",
         );
 
         self.discovered_backends.insert(server_name.to_string());
@@ -603,10 +605,11 @@ impl ProxyServer {
             }) = self.backends.remove(&name)
             {
                 let cached_tools = self.collect_cached_tools(&name);
-                eprintln!(
-                    "[serve] shutting down idle backend: {name} (idle {:?}, {} reqs)",
-                    usage_stats.idle_duration(),
-                    usage_stats.request_count,
+                tracing::info!(
+                    server = %name,
+                    idle = ?usage_stats.idle_duration(),
+                    request_count = usage_stats.request_count,
+                    "shutting down idle backend",
                 );
                 self.backends.insert(
                     name.clone(),
@@ -738,12 +741,12 @@ pub(crate) async fn shutdown_clients_in_parallel(clients: Vec<(String, Arc<McpCl
     let mut joinset: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
     for (name, client) in clients {
         joinset.spawn(async move {
-            eprintln!("[serve] finalizing shutdown for {name}");
+            tracing::info!(server = %name, "finalizing shutdown");
             if tokio::time::timeout(Duration::from_secs(5), client.shutdown())
                 .await
                 .is_err()
             {
-                eprintln!("[serve] {name}: shutdown timed out — force-killed via drop");
+                tracing::warn!(server = %name, "shutdown timed out — force-killed via drop");
             }
             // Dropping the last Arc<McpClient> drops the transport, which
             // kills the child via kill_on_drop(true).

--- a/src/serve/stdio.rs
+++ b/src/serve/stdio.rs
@@ -16,7 +16,7 @@ use super::proxy::{shutdown_clients_in_parallel, ProxyServer, SharedProxy};
 
 pub async fn run_stdio(config: Config) -> Result<()> {
     let pool = crate::db::create_pool(&config.audit).unwrap_or_else(|e| {
-        eprintln!("warning: failed to create db pool: {e:#}");
+        tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
         Arc::new(crate::db::DbPool::disabled())
     });
     let audit = AuditLogger::open(&config.audit, pool.clone()).unwrap_or(AuditLogger::Disabled);
@@ -63,7 +63,7 @@ pub async fn run_stdio(config: Config) -> Result<()> {
         });
     }
 
-    eprintln!("[serve] waiting for MCP client...");
+    tracing::info!("waiting for MCP client");
 
     loop {
         let mut line = String::new();
@@ -103,6 +103,6 @@ pub async fn run_stdio(config: Config) -> Result<()> {
         p.drain_connected()
     };
     shutdown_clients_in_parallel(drained).await;
-    eprintln!("[serve] shutting down");
+    tracing::info!("shutting down");
     Ok(())
 }

--- a/src/serve/stdio.rs
+++ b/src/serve/stdio.rs
@@ -14,11 +14,22 @@ use super::discovery::discover_pending_backends;
 use super::dispatch::dispatch_request;
 use super::proxy::{shutdown_clients_in_parallel, ProxyServer, SharedProxy};
 
-pub async fn run_stdio(config: Config) -> Result<()> {
-    let pool = crate::db::create_pool(&config.audit).unwrap_or_else(|e| {
-        tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
+pub async fn run_stdio(mut config: Config) -> Result<()> {
+    // In stdio mode, stdout is the JSON-RPC transport. Redirect audit to stderr
+    // to avoid interleaving audit JSON lines with protocol responses.
+    if config.audit.output == crate::audit::AuditOutput::Stdout {
+        tracing::warn!("audit output=stdout conflicts with stdio transport, redirecting to stderr");
+        config.audit.output = crate::audit::AuditOutput::Stderr;
+    }
+
+    let pool = if config.audit.output == crate::audit::AuditOutput::File {
+        crate::db::create_pool(&config.audit).unwrap_or_else(|e| {
+            tracing::warn!(error = format!("{e:#}"), "failed to create db pool");
+            Arc::new(crate::db::DbPool::disabled())
+        })
+    } else {
         Arc::new(crate::db::DbPool::disabled())
-    });
+    };
     let audit = AuditLogger::open(&config.audit, pool.clone()).unwrap_or(AuditLogger::Disabled);
     let cache_store = ToolCacheStore::new(pool);
     let mut server = ProxyServer::new(

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use reqwest::Client;
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use crate::auth;
 use crate::protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
@@ -20,7 +21,13 @@ pub struct HttpTransport {
 
 impl HttpTransport {
     pub fn new(url: &str, headers: &HashMap<String, String>) -> Result<Self> {
-        let client = Client::new();
+        let timeout_secs: u64 = std::env::var("MCP_TIMEOUT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(60);
+        let client = Client::builder()
+            .timeout(Duration::from_secs(timeout_secs))
+            .build()?;
         Ok(Self {
             client,
             url: url.to_string(),
@@ -113,9 +120,9 @@ impl Transport for HttpTransport {
         // Handle 401: try OAuth and retry once
         if status == reqwest::StatusCode::UNAUTHORIZED {
             if self.has_valid_auth_header() {
-                eprintln!("Server returned 401 — token from config may be expired or invalid.");
+                tracing::warn!("server returned 401 — token may be expired or invalid");
             }
-            eprintln!("Starting authentication...");
+            tracing::info!("starting authentication");
             // Clear config auth header so OAuth token takes precedence on retry
             {
                 let mut headers = self.headers.lock().unwrap();

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -72,7 +72,7 @@ impl StdioTransport {
                         break;
                     }
                     let trimmed = line.trim_end().to_string();
-                    eprintln!("[server stderr] {trimmed}");
+                    tracing::debug!(line = %trimmed, "server stderr");
                     let mut b = buf.lock().await;
                     b.push(trimmed);
                     if b.len() > 50 {


### PR DESCRIPTION
MCP_TIMEOUT wasn't applied to HTTP transport, OAuth callback used a hardcoded port range, audit logs were ephemeral in containers, and there was no structured logging or shell completions.

Apply MCP_TIMEOUT to reqwest client builder, make OAuth callback port configurable via MCP_OAUTH_CALLBACK_PORT (single, range, or OS-assigned), add tracing-based structured logging with MCP_LOG_LEVEL/MCP_LOG_FORMAT, add MCP_AUDIT_OUTPUT=stdout/stderr for container log drivers, and introduce mcp config path/edit and mcp completions commands.

Fixes #13
Fixes #16
Fixes #76
Fixes #71
Fixes #9
Fixes #8
Fixes #5