### PR TITLE
Fix homebrew install by hosting tap in main repo

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   homebrew:
-    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && !github.event.release.prerelease)
     runs-on: ubuntu-latest
     steps:
       - name: Set version
@@ -98,9 +98,6 @@ jobs:
             end
           end
           FORMULA
-
-          # Remove leading spaces from heredoc
-          sed -i 's/^          //' Formula/mcp.rb
 
       - name: Commit and push
         env:

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -3,15 +3,28 @@ name: Publish Homebrew
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v0.5.0)"
+        required: true
+
+permissions:
+  contents: write
 
 jobs:
   homebrew:
-    if: "!github.event.release.prerelease"
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
       - name: Set version
         id: version
-        run: echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Download binaries and compute checksums
         id: checksums
@@ -22,10 +35,10 @@ jobs:
           BASE="https://github.com/avelino/mcp/releases/download/${TAG}"
 
           # Download macOS and Linux binaries
-          curl -sL "${BASE}/mcp-x86_64-apple-darwin" -o mcp-x86_64-apple-darwin
-          curl -sL "${BASE}/mcp-aarch64-apple-darwin" -o mcp-aarch64-apple-darwin
-          curl -sL "${BASE}/mcp-x86_64-unknown-linux-gnu" -o mcp-x86_64-unknown-linux-gnu
-          curl -sL "${BASE}/mcp-aarch64-unknown-linux-gnu" -o mcp-aarch64-unknown-linux-gnu
+          curl -fsSL "${BASE}/mcp-x86_64-apple-darwin" -o mcp-x86_64-apple-darwin
+          curl -fsSL "${BASE}/mcp-aarch64-apple-darwin" -o mcp-aarch64-apple-darwin
+          curl -fsSL "${BASE}/mcp-x86_64-unknown-linux-gnu" -o mcp-x86_64-unknown-linux-gnu
+          curl -fsSL "${BASE}/mcp-aarch64-unknown-linux-gnu" -o mcp-aarch64-unknown-linux-gnu
 
           # Compute SHA256
           echo "sha_darwin_x86=$(sha256sum mcp-x86_64-apple-darwin | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
@@ -33,11 +46,11 @@ jobs:
           echo "sha_linux_x86=$(sha256sum mcp-x86_64-unknown-linux-gnu | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
           echo "sha_linux_arm=$(sha256sum mcp-aarch64-unknown-linux-gnu | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout tap
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          repository: avelino/homebrew-mcp
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update formula
         env:
@@ -47,6 +60,7 @@ jobs:
           SHA_LINUX_X86: ${{ steps.checksums.outputs.sha_linux_x86 }}
           SHA_LINUX_ARM: ${{ steps.checksums.outputs.sha_linux_arm }}
         run: |
+          mkdir -p Formula
           VERSION="${TAG#v}"
           cat > Formula/mcp.rb << FORMULA
           class Mcp < Formula
@@ -89,9 +103,15 @@ jobs:
           sed -i 's/^          //' Formula/mcp.rb
 
       - name: Commit and push
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/mcp.rb
-          git commit -m "mcp ${TAG}"
-          git push
+          if git diff --cached --quiet; then
+            echo "No formula changes to commit"
+            exit 0
+          fi
+          git commit -m "homebrew: bump formula to ${TAG}"
+          git push origin HEAD:main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Formula/mcp.rb
+++ b/Formula/mcp.rb
@@ -1,0 +1,34 @@
+class Mcp < Formula
+  desc "CLI that turns MCP servers into terminal commands"
+  homepage "https://github.com/avelino/mcp"
+  version "0.5.0"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/avelino/mcp/releases/download/v0.5.0/mcp-aarch64-apple-darwin"
+      sha256 "8833bbe814c45d9445adfdbaecb3e4a94ac6b506a93bd05729bfd7b1cdeb8557"
+    else
+      url "https://github.com/avelino/mcp/releases/download/v0.5.0/mcp-x86_64-apple-darwin"
+      sha256 "929d2375bd69b396e3693ff75651e50ddfff235f375c83abf5cd983ff03a9d91"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/avelino/mcp/releases/download/v0.5.0/mcp-aarch64-unknown-linux-gnu"
+      sha256 "31c704158bc9c4585b7aad63059f2d115c0de0573047cc943d044ef79e147c0e"
+    else
+      url "https://github.com/avelino/mcp/releases/download/v0.5.0/mcp-x86_64-unknown-linux-gnu"
+      sha256 "a40b6b0e94ee20ec00c5532231ea29cd3dd6c6b57bf368c3c429c21a76ca777e"
+    end
+  end
+
+  def install
+    bin.install Dir.glob("mcp*").first => "mcp"
+  end
+
+  test do
+    assert_match "mcp", shell_output("#{bin}/mcp --help")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Output is always JSON. Pipe it, `jq` it, script it.
 
 ```bash
 # Homebrew (macOS and Linux)
+brew tap avelino/mcp https://github.com/avelino/mcp.git
 brew install avelino/mcp/mcp
 
 # Docker


### PR DESCRIPTION
The brew install command in the README pointed at a tap repo
(avelino/homebrew-mcp) that doesn't exist, so every install attempt
hit a 404 (issue https://github.com/avelino/mcp/issues/87). The publish workflow was also silently broken
for the same reason.

Move the formula into Formula/mcp.rb in this repo and update the
README to tap via explicit URL. The workflow now commits the formula
back to main using GITHUB_TOKEN, drops the dependency on a separate
tap and the HOMEBREW_TAP_TOKEN secret, and adds workflow_dispatch
so existing releases can be backfilled manually.

fixed: https://github.com/avelino/mcp/issues/87