### PR TITLE
Add MCP_AUTH_CONFIG for inline OAuth tokens

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -170,6 +170,21 @@ alias mcp-work='MCP_CONFIG_PATH=~/.config/mcp/work.json mcp'
 alias mcp-personal='MCP_CONFIG_PATH=~/.config/mcp/personal.json mcp'
 ```
 
+## Container / Kubernetes deployments
+
+This guide covers configuration on a workstation, where `mcp` reads JSON files from `~/.config/mcp/`. In a container or Kubernetes pod — typically with a read-only root filesystem — file mounts are awkward. For those scenarios, `mcp` accepts the same JSON content directly via environment variables:
+
+| File | Inline env var | Read/write |
+|---|---|---|
+| `servers.json` | [`MCP_SERVERS_CONFIG`](../reference/environment-variables.md#mcp_servers_config) | read-only |
+| `auth.json` | [`MCP_AUTH_CONFIG`](../reference/environment-variables.md#mcp_auth_config) | read-only (writes are no-ops) |
+
+When set, the inline env var takes priority over the corresponding file path (`MCP_CONFIG_PATH` / `MCP_AUTH_PATH`).
+
+These env vars are intended **only** for container deployments — don't use them on a workstation. Putting an entire JSON config in your shell environment is awkward to edit and breaks `mcp add` / `mcp remove`, which write back to the file.
+
+For full deployment instructions, see [Deploying on Kubernetes](../howto/kubernetes.md) and [Running in Docker](../howto/docker.md).
+
 ## Complete example
 
 A real-world config with multiple server types:

--- a/docs/howto/docker.md
+++ b/docs/howto/docker.md
@@ -156,7 +156,8 @@ These variables are especially useful for container deployments. See the full li
 | `MCP_AUDIT_OUTPUT` | `file` | `stdout`/`stderr` for container log drivers, `none` to disable |
 | `MCP_AUDIT_PATH` | `~/.config/mcp/db/data` | Override audit data path |
 | `MCP_AUDIT_INDEX_PATH` | `~/.config/mcp/db/index` | Override audit index path |
-| `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override OAuth token storage |
+| `MCP_AUTH_CONFIG` | — | Inline `auth.json` content (read-only, writes are no-ops). Same idea as `MCP_SERVERS_CONFIG`. |
+| `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override OAuth token storage (file path) |
 | `MCP_CLASSIFIER_CACHE` | `~/.config/mcp/tool-classification.json` | Override classifier cache |
 
 ## Kubernetes
@@ -210,5 +211,5 @@ docker run --rm ghcr.io/avelino/mcp:0.1.0 --help
 ## Limitations
 
 - **Stdio servers only work if the runtime is available inside the container.** The default image includes only the `mcp` binary and `ca-certificates`. Servers that require `npx`, `python`, or other runtimes won't work unless you build a custom image. HTTP servers (configured with `url`) work out of the box.
-- **OAuth browser flow doesn't work in Docker.** For HTTP servers that need OAuth, run `mcp add <server>` on your host first to complete authentication, then mount the config directory (which includes `auth.json`), or set `MCP_AUTH_PATH` to a mounted volume.
+- **OAuth browser flow doesn't work in Docker.** For HTTP servers that need OAuth, run `mcp add <server>` on your host first to complete authentication, then either mount the config directory (which includes `auth.json`), set `MCP_AUTH_PATH` to a mounted volume, or pass the JSON inline via `MCP_AUTH_CONFIG` (read-only — useful for read-only containers and Kubernetes Secrets).
 - **Audit logging is disabled by default** in the Docker image because `scratch` images have no writable filesystem. Use `MCP_AUDIT_OUTPUT=stdout` to stream to the container log driver, or mount a volume and set `MCP_AUDIT_ENABLED=true`.

--- a/docs/howto/kubernetes.md
+++ b/docs/howto/kubernetes.md
@@ -112,7 +112,7 @@ env:
         key: auth.json
 ```
 
-The proxy reads the inline JSON at startup. **No file is ever written**: when `MCP_AUTH_CONFIG` is set, writes to the auth store are silently dropped (one `warn` log on first attempt). In-process token refresh keeps working for the pod's lifetime; on restart, the Secret is re-read.
+The proxy reads the inline JSON at startup and keeps it in an in-memory store. OAuth refresh and dynamic-client registration update the in-memory copy so refreshed tokens stay coherent across requests within the pod's lifetime. **Nothing is ever written to disk** — one `warn` log is emitted on the first save attempt. On pod restart, the Secret is re-read and in-memory mutations are discarded.
 
 **Refresh strategy.** When refresh tokens are about to expire, rotate the Secret externally (sealed-secrets, external-secrets-operator, a CronJob that re-runs `mcp add`, etc.) and let the rolling update pick it up. The proxy itself is not designed to write back to the Secret.
 

--- a/docs/howto/kubernetes.md
+++ b/docs/howto/kubernetes.md
@@ -81,6 +81,43 @@ env:
         key: grafana-token
 ```
 
+### OAuth tokens via Secret
+
+For backends that use OAuth (Sentry, Honeycomb, GitHub Copilot, etc.), `mcp` keeps issued access/refresh tokens and dynamic-client registrations in `auth.json`. In a pod with a read-only root filesystem, mounting a writable `auth.json` is awkward — instead, inject the contents directly via `MCP_AUTH_CONFIG`.
+
+**1. Run the OAuth flow once on a workstation:**
+
+```bash
+mcp add sentry --remote https://mcp.sentry.dev
+# completes browser flow, writes ~/.config/mcp/auth.json
+```
+
+**2. Push the resulting file into a Secret:**
+
+```bash
+kubectl -n mcp create secret generic mcp-auth \
+  --from-file=auth.json=$HOME/.config/mcp/auth.json
+```
+
+> Use a Secret (not a ConfigMap) — the file contains live access tokens.
+
+**3. Inject it as an env var in the Deployment:**
+
+```yaml
+env:
+  - name: MCP_AUTH_CONFIG
+    valueFrom:
+      secretKeyRef:
+        name: mcp-auth
+        key: auth.json
+```
+
+The proxy reads the inline JSON at startup. **No file is ever written**: when `MCP_AUTH_CONFIG` is set, writes to the auth store are silently dropped (one `warn` log on first attempt). In-process token refresh keeps working for the pod's lifetime; on restart, the Secret is re-read.
+
+**Refresh strategy.** When refresh tokens are about to expire, rotate the Secret externally (sealed-secrets, external-secrets-operator, a CronJob that re-runs `mcp add`, etc.) and let the rolling update pick it up. The proxy itself is not designed to write back to the Secret.
+
+**Limitation.** Since `MCP_AUTH_CONFIG` is read-only, you cannot run `mcp add <server>` against a running pod and have the registration persist. Always pre-provision the auth store on a workstation or in a one-off Job, then ship it via the Secret.
+
 ### Pinning the image version
 
 Edit `deploy/kubernetes/kustomization.yaml`:
@@ -209,6 +246,7 @@ When Kubernetes sends `SIGTERM` (during rolling updates or scale-down):
 | Variable | Manifest value | Description |
 |----------|----------------|-------------|
 | `MCP_SERVERS_CONFIG` | (from ConfigMap) | Inline JSON config (highest priority) |
+| `MCP_AUTH_CONFIG` | (from Secret, optional) | Inline OAuth tokens (`auth.json`). Read-only — writes are no-ops. |
 | `MCP_PROXY_REQUEST_TIMEOUT` | `120` (app default) | Max seconds per JSON-RPC request |
 | `MCP_AUDIT_ENABLED` | `false` | Enable audit logging |
 | `MCP_AUDIT_OUTPUT` | `file` | `stdout` for cluster log pipeline, `file` for PVC, `none` to disable |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -21,7 +21,8 @@ These variables configure `mcp` behavior:
 | `MCP_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error`. Uses `tracing` `EnvFilter` syntax — you can also set per-module levels like `mcp=debug,hyper=warn`. |
 | `MCP_LOG_FORMAT` | `text` | Log output format: `text` (human-readable) or `json` (structured, for container log drivers). |
 | `MCP_OAUTH_CALLBACK_PORT` | `8085-8099` | Port or range for the OAuth callback listener. Single port (`9000`), range (`9000-9010`), or `0` for OS-assigned. |
-| `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override the OAuth token storage location |
+| `MCP_AUTH_CONFIG` | — | Inline JSON content of `auth.json` (read-only). Highest priority for auth — skips file read. Writes are no-ops with a single `warn` log. Intended for k8s/Docker Secrets. |
+| `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override the OAuth token storage location (file path) |
 
 ### Config loading priority
 
@@ -149,13 +150,58 @@ Override the ChronDB data and index directories. These take priority over the `a
 MCP_AUDIT_PATH=/var/lib/mcp/data MCP_AUDIT_INDEX_PATH=/var/lib/mcp/index mcp serve --http 0.0.0.0:8080
 ```
 
+### `MCP_AUTH_CONFIG`
+
+Inline JSON content of `auth.json`, equivalent to [`MCP_SERVERS_CONFIG`](#mcp_servers_config) but for OAuth tokens and dynamic-client registrations. Highest priority — when set, the file at `MCP_AUTH_PATH` (or the default location) is **not** read.
+
+```bash
+export MCP_AUTH_CONFIG='{
+  "clients": {
+    "https://mcp.sentry.dev": {"client_id": "abc123"}
+  },
+  "tokens": {
+    "https://mcp.sentry.dev": {
+      "access_token": "${SENTRY_ACCESS_TOKEN}",
+      "refresh_token": "${SENTRY_REFRESH_TOKEN}"
+    }
+  }
+}'
+mcp serve --http 0.0.0.0:8080
+```
+
+**Read-only by design.** When `MCP_AUTH_CONFIG` is set, `mcp` treats the auth store as immutable — the source of truth is the env var (typically a k8s Secret), so persisting back to disk would be ineffective and confusing. Writes are silently dropped and a single `warn` log is emitted at first attempt. Token refreshes still work *in-process* for the lifetime of the proxy; on restart, the Secret is read again.
+
+**Use cases:**
+
+- Kubernetes deployments where the pod has a read-only filesystem and OAuth tokens come from a Secret (see [Deploying on Kubernetes](../howto/kubernetes.md))
+- Docker containers where mounting a writable `auth.json` is undesirable
+- CI environments that need pre-provisioned tokens for ephemeral runs
+
+**Not recommended for:**
+
+- Local development on a workstation — use the default `auth.json` and let `mcp add` handle the OAuth flow.
+- Any environment where you expect `mcp add <server>` to register a new client and persist the result. That flow requires a writable file.
+
+`MCP_AUTH_CONFIG` takes priority over `MCP_AUTH_PATH`. If both are set, the inline content wins. An empty or whitespace-only value falls through to the file path.
+
 ### `MCP_AUTH_PATH`
 
-Override the OAuth token storage location. Default is `~/.config/mcp/auth.json`. Useful in containers where `$HOME` doesn't exist or is read-only.
+Override the OAuth token storage location (file path). Default is `~/.config/mcp/auth.json`. Useful in containers where `$HOME` doesn't exist, or to share an auth store across multiple `mcp` invocations.
 
 ```bash
 MCP_AUTH_PATH=/data/auth.json mcp add sentry --remote https://mcp.sentry.dev
 ```
+
+For container deployments where the filesystem is read-only or you want tokens injected from a secret manager, use [`MCP_AUTH_CONFIG`](#mcp_auth_config) instead.
+
+### Auth loading priority
+
+`mcp` resolves the auth store in this order:
+
+1. **`MCP_AUTH_CONFIG`** — inline JSON (read-only, no file I/O)
+2. **`MCP_AUTH_PATH`** — file path override
+3. **`MCP_CONFIG_DIR`/auth.json** — config directory override
+4. **`~/.config/mcp/auth.json`** — default file location
 
 ## Config variables
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -169,7 +169,9 @@ export MCP_AUTH_CONFIG='{
 mcp serve --http 0.0.0.0:8080
 ```
 
-**Read-only by design.** When `MCP_AUTH_CONFIG` is set, `mcp` treats the auth store as immutable — the source of truth is the env var (typically a k8s Secret), so persisting back to disk would be ineffective and confusing. Writes are silently dropped and a single `warn` log is emitted at first attempt. Token refreshes still work *in-process* for the lifetime of the proxy; on restart, the Secret is read again.
+`${VAR}` placeholders are expanded the same way as in [`MCP_SERVERS_CONFIG`](#mcp_servers_config), so you can split tokens across multiple Secret keys.
+
+**Read-only on disk; mutable in memory.** When `MCP_AUTH_CONFIG` is set, the env var seeds an in-memory auth store on first load. Subsequent OAuth flows — token refresh, dynamic-client registration — update the cache so refreshed tokens are visible to later calls within the same process. Nothing is ever written back to disk (the source of truth is the Secret), and a single `warn` log is emitted on the first save attempt. On pod restart, the Secret is read again — any in-memory mutations are discarded.
 
 **Use cases:**
 

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -2,8 +2,25 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Once;
 
 use crate::config;
+
+/// Inline JSON content of the auth store, provided via env var.
+/// Highest precedence — when set, file-based loading is skipped and writes
+/// become no-ops (logged once via `tracing::warn`).
+const AUTH_CONFIG_ENV: &str = "MCP_AUTH_CONFIG";
+
+/// File path override for `auth.json`. Lower precedence than `MCP_AUTH_CONFIG`.
+const AUTH_PATH_ENV: &str = "MCP_AUTH_PATH";
+
+/// Returns inline auth content from `MCP_AUTH_CONFIG`, if set and non-empty.
+fn auth_inline_content() -> Option<String> {
+    std::env::var(AUTH_CONFIG_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct StoredTokens {
@@ -30,7 +47,7 @@ pub struct AuthStore {
 }
 
 pub fn auth_store_path() -> Result<PathBuf> {
-    if let Ok(path) = std::env::var("MCP_AUTH_PATH") {
+    if let Ok(path) = std::env::var(AUTH_PATH_ENV) {
         let path = path.trim();
         if !path.is_empty() {
             return Ok(PathBuf::from(path));
@@ -40,6 +57,13 @@ pub fn auth_store_path() -> Result<PathBuf> {
 }
 
 pub fn load_auth_store() -> Result<AuthStore> {
+    // Priority 1: inline content via MCP_AUTH_CONFIG (no file mount needed).
+    // Intended for read-only deployments (k8s Secrets, Docker secrets).
+    if let Some(content) = auth_inline_content() {
+        return Ok(serde_json::from_str(&content).unwrap_or_default());
+    }
+
+    // Priority 2: file path (MCP_AUTH_PATH or default location).
     let path = auth_store_path()?;
     if !path.exists() {
         return Ok(AuthStore::default());
@@ -49,6 +73,21 @@ pub fn load_auth_store() -> Result<AuthStore> {
 }
 
 pub fn save_auth_store(store: &AuthStore) -> Result<()> {
+    // Inline auth config is read-only by design: the source of truth is the
+    // env var (typically a k8s Secret), so persisting back to disk would be
+    // ineffective and confusing. Token refreshes still work in-process for
+    // the lifetime of the proxy; on restart, the Secret is read again.
+    if auth_inline_content().is_some() {
+        static WARN_ONCE: Once = Once::new();
+        WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                env = AUTH_CONFIG_ENV,
+                "inline auth config is read-only; skipping write to auth store"
+            );
+        });
+        return Ok(());
+    }
+
     let path = auth_store_path()?;
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -117,6 +156,158 @@ mod tests {
         let stored = to_stored_tokens(&resp);
         assert!(stored.expires_at.is_none());
         assert!(stored.refresh_token.is_none());
+    }
+
+    // --- Inline auth config tests (MCP_AUTH_CONFIG) ---
+
+    /// Serialize env var access for tests that set/remove env vars.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Snapshot env vars touched by these tests, restore on drop.
+    /// Prevents cross-test pollution when running in parallel — even with
+    /// `ENV_LOCK`, a panicking test would leak its env state otherwise.
+    struct EnvGuard {
+        config: Option<String>,
+        path: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn capture() -> Self {
+            Self {
+                config: std::env::var(AUTH_CONFIG_ENV).ok(),
+                path: std::env::var(AUTH_PATH_ENV).ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.config {
+                Some(v) => std::env::set_var(AUTH_CONFIG_ENV, v),
+                None => std::env::remove_var(AUTH_CONFIG_ENV),
+            }
+            match &self.path {
+                Some(v) => std::env::set_var(AUTH_PATH_ENV, v),
+                None => std::env::remove_var(AUTH_PATH_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn test_load_inline_auth_config() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+
+        let json = r#"{
+            "clients": {
+                "https://example.com": {"client_id": "cid_inline"}
+            },
+            "tokens": {
+                "https://example.com": {
+                    "access_token": "tok_inline",
+                    "refresh_token": "ref_inline",
+                    "expires_at": 9999999999
+                }
+            }
+        }"#;
+        std::env::set_var(AUTH_CONFIG_ENV, json);
+        // Point path to a non-existent file; inline must win without touching it.
+        std::env::set_var(AUTH_PATH_ENV, "/dev/null/nonexistent-auth.json");
+
+        let store = load_auth_store().unwrap();
+        assert_eq!(store.clients["https://example.com"].client_id, "cid_inline");
+        assert_eq!(
+            store.tokens["https://example.com"].access_token,
+            "tok_inline"
+        );
+    }
+
+    #[test]
+    fn test_save_inline_auth_config_is_noop() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("auth.json");
+        std::env::set_var(AUTH_CONFIG_ENV, r#"{"clients":{},"tokens":{}}"#);
+        std::env::set_var(AUTH_PATH_ENV, target.to_str().unwrap());
+
+        let mut store = AuthStore::default();
+        store.tokens.insert(
+            "https://example.com".to_string(),
+            StoredTokens {
+                access_token: "fresh".to_string(),
+                refresh_token: None,
+                expires_at: None,
+            },
+        );
+
+        // Save returns Ok(()) but must NOT create the file: inline mode is
+        // read-only by design (k8s Secret is the source of truth).
+        save_auth_store(&store).unwrap();
+        assert!(
+            !target.exists(),
+            "save_auth_store must be a no-op when MCP_AUTH_CONFIG is set"
+        );
+    }
+
+    #[test]
+    fn test_inline_invalid_json_returns_default_store() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+
+        std::env::set_var(AUTH_CONFIG_ENV, "{ not json }}}");
+        std::env::remove_var(AUTH_PATH_ENV);
+
+        // Mirror file-based behavior: malformed JSON degrades to empty store
+        // rather than crashing the proxy on startup.
+        let store = load_auth_store().unwrap();
+        assert!(store.clients.is_empty());
+        assert!(store.tokens.is_empty());
+    }
+
+    #[test]
+    fn test_empty_inline_falls_back_to_path() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        write!(
+            file,
+            r#"{{"clients":{{"https://file.com":{{"client_id":"cid_file"}}}},"tokens":{{}}}}"#
+        )
+        .unwrap();
+
+        // Empty/whitespace MCP_AUTH_CONFIG must not shadow the file path.
+        std::env::set_var(AUTH_CONFIG_ENV, "   ");
+        std::env::set_var(AUTH_PATH_ENV, file.path().to_str().unwrap());
+
+        let store = load_auth_store().unwrap();
+        assert_eq!(store.clients["https://file.com"].client_id, "cid_file");
+    }
+
+    #[test]
+    fn test_inline_takes_precedence_over_path() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        use std::io::Write;
+        write!(
+            file,
+            r#"{{"clients":{{"https://file.com":{{"client_id":"cid_file"}}}},"tokens":{{}}}}"#
+        )
+        .unwrap();
+        std::env::set_var(AUTH_PATH_ENV, file.path().to_str().unwrap());
+        std::env::set_var(
+            AUTH_CONFIG_ENV,
+            r#"{"clients":{"https://inline.com":{"client_id":"cid_inline"}},"tokens":{}}"#,
+        );
+
+        let store = load_auth_store().unwrap();
+        assert!(store.clients.contains_key("https://inline.com"));
+        assert!(!store.clients.contains_key("https://file.com"));
     }
 
     #[test]

--- a/src/auth/store.rs
+++ b/src/auth/store.rs
@@ -2,13 +2,14 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::Once;
+use std::sync::{Once, OnceLock, RwLock};
 
 use crate::config;
 
 /// Inline JSON content of the auth store, provided via env var.
 /// Highest precedence — when set, file-based loading is skipped and writes
-/// become no-ops (logged once via `tracing::warn`).
+/// are routed to an in-memory cache instead of disk (with a single
+/// `tracing::warn` on the first attempt).
 const AUTH_CONFIG_ENV: &str = "MCP_AUTH_CONFIG";
 
 /// File path override for `auth.json`. Lower precedence than `MCP_AUTH_CONFIG`.
@@ -22,6 +23,24 @@ fn auth_inline_content() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// In-memory auth store used when `MCP_AUTH_CONFIG` is set. Lazy-populated
+/// from the env var on first `load_auth_store()` call. `save_auth_store()`
+/// updates the cache so OAuth refresh / dynamic-client registration keep
+/// working in-process for the lifetime of the proxy — without touching
+/// the (typically read-only) underlying Secret.
+fn inline_cache() -> &'static RwLock<Option<AuthStore>> {
+    static CACHE: OnceLock<RwLock<Option<AuthStore>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(None))
+}
+
+/// Parse inline JSON, expanding `${VAR}` placeholders the same way
+/// `MCP_SERVERS_CONFIG` does. Malformed JSON degrades to an empty store
+/// rather than crashing the proxy on startup.
+fn parse_inline(content: &str) -> AuthStore {
+    let expanded = config::substitute_env_vars(content);
+    serde_json::from_str(&expanded).unwrap_or_default()
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct StoredTokens {
     pub access_token: String,
@@ -31,14 +50,14 @@ pub struct StoredTokens {
     pub expires_at: Option<u64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ClientRegistration {
     pub client_id: String,
     #[serde(default)]
     pub client_secret: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default, Clone)]
 pub struct AuthStore {
     #[serde(default)]
     pub clients: HashMap<String, ClientRegistration>,
@@ -58,9 +77,21 @@ pub fn auth_store_path() -> Result<PathBuf> {
 
 pub fn load_auth_store() -> Result<AuthStore> {
     // Priority 1: inline content via MCP_AUTH_CONFIG (no file mount needed).
-    // Intended for read-only deployments (k8s Secrets, Docker secrets).
+    // Backed by an in-memory cache so OAuth refresh and dynamic-client
+    // registrations stay coherent across calls — the env var is the seed,
+    // not the source of truth at runtime.
     if let Some(content) = auth_inline_content() {
-        return Ok(serde_json::from_str(&content).unwrap_or_default());
+        // Fast path: cache already populated.
+        if let Some(store) = inline_cache().read().unwrap().as_ref() {
+            return Ok(store.clone());
+        }
+        // Slow path: seed cache from env. The double-check inside the write
+        // lock handles the race where another thread populated it first.
+        let mut write = inline_cache().write().unwrap();
+        if write.is_none() {
+            *write = Some(parse_inline(&content));
+        }
+        return Ok(write.as_ref().unwrap().clone());
     }
 
     // Priority 2: file path (MCP_AUTH_PATH or default location).
@@ -73,16 +104,17 @@ pub fn load_auth_store() -> Result<AuthStore> {
 }
 
 pub fn save_auth_store(store: &AuthStore) -> Result<()> {
-    // Inline auth config is read-only by design: the source of truth is the
-    // env var (typically a k8s Secret), so persisting back to disk would be
-    // ineffective and confusing. Token refreshes still work in-process for
-    // the lifetime of the proxy; on restart, the Secret is read again.
+    // Inline mode: writes are routed to the in-memory cache, not disk. The
+    // source of truth on disk is whatever provisioned the env var (typically
+    // a k8s Secret), so we never write back. In-process mutations (refreshed
+    // tokens, new client registrations) survive until the proxy restarts.
     if auth_inline_content().is_some() {
+        *inline_cache().write().unwrap() = Some(store.clone());
         static WARN_ONCE: Once = Once::new();
         WARN_ONCE.call_once(|| {
             tracing::warn!(
                 env = AUTH_CONFIG_ENV,
-                "inline auth config is read-only; skipping write to auth store"
+                "inline auth config is read-only on disk; updates kept in memory only"
             );
         });
         return Ok(());
@@ -190,13 +222,21 @@ mod tests {
                 Some(v) => std::env::set_var(AUTH_PATH_ENV, v),
                 None => std::env::remove_var(AUTH_PATH_ENV),
             }
+            // Cache is process-global; reset between tests so the next one
+            // starts from a clean slate (matches a fresh proxy boot).
+            *inline_cache().write().unwrap() = None;
         }
+    }
+
+    fn reset_inline_cache() {
+        *inline_cache().write().unwrap() = None;
     }
 
     #[test]
     fn test_load_inline_auth_config() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture();
+        reset_inline_cache();
 
         let json = r#"{
             "clients": {
@@ -223,9 +263,10 @@ mod tests {
     }
 
     #[test]
-    fn test_save_inline_auth_config_is_noop() {
+    fn test_save_inline_does_not_touch_disk() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture();
+        reset_inline_cache();
 
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("auth.json");
@@ -242,19 +283,109 @@ mod tests {
             },
         );
 
-        // Save returns Ok(()) but must NOT create the file: inline mode is
-        // read-only by design (k8s Secret is the source of truth).
+        // Save succeeds but must NOT touch disk: in inline mode, mutations
+        // live only in the in-memory cache, never on the (typically read-only)
+        // backing Secret.
         save_auth_store(&store).unwrap();
         assert!(
             !target.exists(),
-            "save_auth_store must be a no-op when MCP_AUTH_CONFIG is set"
+            "save_auth_store must not write to disk when MCP_AUTH_CONFIG is set"
         );
+    }
+
+    #[test]
+    fn test_inline_save_then_load_round_trip() {
+        // Regression for review feedback: in inline mode, save+load must
+        // preserve mutations across calls (OAuth refresh, dynamic client
+        // registration). Without the in-memory cache, the second load would
+        // re-parse the env var and lose every change.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+        reset_inline_cache();
+
+        std::env::set_var(
+            AUTH_CONFIG_ENV,
+            r#"{"clients":{},"tokens":{"https://api.example.com":{"access_token":"old","refresh_token":"r1"}}}"#,
+        );
+        std::env::remove_var(AUTH_PATH_ENV);
+
+        // Simulate an OAuth refresh: load, mutate, save.
+        let mut store = load_auth_store().unwrap();
+        store.tokens.insert(
+            "https://api.example.com".to_string(),
+            StoredTokens {
+                access_token: "refreshed".to_string(),
+                refresh_token: Some("r2".to_string()),
+                expires_at: Some(9999999999),
+            },
+        );
+        store.clients.insert(
+            "https://new-server.example.com".to_string(),
+            ClientRegistration {
+                client_id: "newly-registered".to_string(),
+                client_secret: None,
+            },
+        );
+        save_auth_store(&store).unwrap();
+
+        // Subsequent loads must see the in-memory mutations, not the
+        // original env content.
+        let reloaded = load_auth_store().unwrap();
+        assert_eq!(
+            reloaded.tokens["https://api.example.com"].access_token,
+            "refreshed"
+        );
+        assert_eq!(
+            reloaded.tokens["https://api.example.com"]
+                .refresh_token
+                .as_deref(),
+            Some("r2")
+        );
+        assert_eq!(
+            reloaded.clients["https://new-server.example.com"].client_id,
+            "newly-registered"
+        );
+    }
+
+    #[test]
+    fn test_inline_substitutes_env_vars() {
+        // Parity with MCP_SERVERS_CONFIG: ${VAR} placeholders inside inline
+        // auth content must be expanded against the surrounding environment,
+        // so secrets can be split across multiple Secret keys.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+        reset_inline_cache();
+
+        std::env::set_var("MCP_TEST_AUTH_TOKEN", "tok_from_env");
+        std::env::set_var("MCP_TEST_AUTH_REFRESH", "ref_from_env");
+        std::env::set_var(
+            AUTH_CONFIG_ENV,
+            r#"{
+                "clients": {},
+                "tokens": {
+                    "https://api.example.com": {
+                        "access_token": "${MCP_TEST_AUTH_TOKEN}",
+                        "refresh_token": "${MCP_TEST_AUTH_REFRESH}"
+                    }
+                }
+            }"#,
+        );
+        std::env::remove_var(AUTH_PATH_ENV);
+
+        let store = load_auth_store().unwrap();
+        let toks = &store.tokens["https://api.example.com"];
+        assert_eq!(toks.access_token, "tok_from_env");
+        assert_eq!(toks.refresh_token.as_deref(), Some("ref_from_env"));
+
+        std::env::remove_var("MCP_TEST_AUTH_TOKEN");
+        std::env::remove_var("MCP_TEST_AUTH_REFRESH");
     }
 
     #[test]
     fn test_inline_invalid_json_returns_default_store() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture();
+        reset_inline_cache();
 
         std::env::set_var(AUTH_CONFIG_ENV, "{ not json }}}");
         std::env::remove_var(AUTH_PATH_ENV);
@@ -270,6 +401,7 @@ mod tests {
     fn test_empty_inline_falls_back_to_path() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture();
+        reset_inline_cache();
 
         let mut file = tempfile::NamedTempFile::new().unwrap();
         use std::io::Write;
@@ -291,6 +423,7 @@ mod tests {
     fn test_inline_takes_precedence_over_path() {
         let _lock = ENV_LOCK.lock().unwrap();
         let _guard = EnvGuard::capture();
+        reset_inline_cache();
 
         let mut file = tempfile::NamedTempFile::new().unwrap();
         use std::io::Write;

--- a/src/config.rs
+++ b/src/config.rs
@@ -442,7 +442,11 @@ fn apply_audit_env_overrides(mut audit: AuditConfig) -> AuditConfig {
     audit
 }
 
-fn substitute_env_vars(input: &str) -> String {
+/// Replace `${VAR_NAME}` placeholders with the value of the corresponding
+/// environment variable. Missing or empty vars resolve to an empty string —
+/// matching the existing behavior used for `MCP_SERVERS_CONFIG` so that
+/// `MCP_AUTH_CONFIG` stays at parity.
+pub(crate) fn substitute_env_vars(input: &str) -> String {
     let re = Regex::new(r"\$\{([^}]+)\}").unwrap();
     re.replace_all(input, |caps: &regex::Captures| {
         let var_name = &caps[1];


### PR DESCRIPTION
Deploying mcp serve in Kubernetes with a read-only root filesystem made auth.json awkward: MCP_AUTH_PATH only accepts a file path, so OAuth tokens had to be mounted as a file instead of injected from a Secret like every other piece of config. MCP_SERVERS_CONFIG already solved this for servers.json — auth needed the same escape hatch.

Mirror the MCP_SERVERS_CONFIG pattern: when MCP_AUTH_CONFIG is set, load_auth_store reads the JSON inline and skips the file entirely, taking precedence over MCP_AUTH_PATH. Since auth.json is mutable (OAuth refresh writes new tokens), save_auth_store becomes a no-op in inline mode with a single warn log via std::sync::Once — refresh keeps working in-process for the pod's lifetime, and on restart the Secret is read again. Documented as a container-only feature in the k8s/docker how-tos so it doesn't pollute the workstation guide.