### PR TITLE
Add OAuth Authorization Server with DCR for mcp serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +869,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +991,7 @@ dependencies = [
  "console",
  "dirs 6.0.0",
  "indicatif",
+ "jsonwebtoken",
  "open",
  "rand",
  "regex",
@@ -1025,6 +1050,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1095,6 +1145,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1192,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1584,6 +1650,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1797,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ shell-words = "1"
 socket2 = { version = "0.6", features = ["all"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+jsonwebtoken = "9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,6 +25,7 @@
 
 * [Docker](howto/docker.md)
 * [Kubernetes](howto/kubernetes.md)
+* [OAuth Authorization Server (Claude.ai, ChatGPT, Cursor)](howto/oauth-as.md)
 * [Supported services](howto/services.md)
 * [Troubleshooting](howto/troubleshooting.md)
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -157,13 +157,15 @@ The sections above cover **client-side** authentication — how `mcp` authentica
 
 This is configured via the `serverAuth` key in `servers.json`. See the [proxy mode guide](proxy-mode.md#authentication) for full details.
 
+> **Schema change.** As of the OAuth Authorization Server feature, `serverAuth` takes a `providers: ["..."]` array instead of a single `provider: "..."` string. The new shape lets a single instance accept multiple kinds of bearer credentials in parallel — for example, static tokens for local CLI tools *and* OAuth-issued JWTs for Claude.ai web. Configs using the old `provider` field will silently boot as `NoAuth`; rewrite them as shown below.
+
 ### Quick example
 
 ```json
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "bearer",
+    "providers": ["bearer"],
     "bearer": {
       "tokens": {
         "tok-alice": "alice",
@@ -193,7 +195,7 @@ Both forms can coexist in the same config file.
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "bearer",
+    "providers": ["bearer"],
     "bearer": {
       "tokens": {
         "tok-alice": { "subject": "alice", "roles": ["admin"] },
@@ -220,18 +222,39 @@ See [proxy mode ACL docs](proxy-mode.md#access-control-acl) for the full schema,
 
 | Provider | Use case |
 |----------|----------|
-| `none` (default) | No auth — all requests are anonymous |
+| `none` (default when `providers` is empty) | No auth — all requests are anonymous |
 | `bearer` | Static token-to-user mapping, with optional per-token roles |
 | `forwarded` | Trust reverse proxy `X-Forwarded-User` header (and optional `X-Forwarded-Groups` for roles) |
+| `oauth_as` | Run an OAuth 2.0 Authorization Server with Dynamic Client Registration so Claude.ai, ChatGPT, Cursor and other AI clients can connect as Custom Connectors. See the [OAuth AS how-to](../howto/oauth-as.md). |
 
-### Forwarded provider and roles
-
-When `provider` is `forwarded`, the proxy reads the user from the configured user header (default `x-forwarded-user`) and, optionally, a groups header (default `x-forwarded-groups`, following the oauth2-proxy convention) to populate roles.
+`providers` is a list — combine multiple in the same instance:
 
 ```json
 {
   "serverAuth": {
-    "provider": "forwarded",
+    "providers": ["bearer", "oauth_as"],
+    "bearer": { "tokens": { "tok-local-dev": { "subject": "avelino", "roles": ["admin"] } } },
+    "oauthAs": {
+      "issuerUrl": "https://mcp.example.com",
+      "jwtSecret": "${MCP_OAUTH_AS_JWT_SECRET}",
+      "trustedSourceCidrs": ["10.0.0.0/8"],
+      "redirectUriAllowlist": ["https://claude.ai/api/mcp/auth_callback"],
+      "injectedRoles": ["oauth-user"]
+    }
+  }
+}
+```
+
+The chain tries each provider in order; the first one that accepts the request wins. When all reject, the chain returns the error of the *first* configured provider — which avoids leaking which token format hit a closer-to-success path. Order is a performance hint (cheap lookups first), not a correctness one.
+
+### Forwarded provider and roles
+
+With `"forwarded"` in `providers`, the proxy reads the user from the configured user header (default `x-forwarded-user`) and, optionally, a groups header (default `x-forwarded-groups`, following the oauth2-proxy convention) to populate roles.
+
+```json
+{
+  "serverAuth": {
+    "providers": ["forwarded"],
     "forwarded": {
       "header": "x-forwarded-user",
       "groups_header": "x-forwarded-groups"

--- a/docs/guides/enterprise-token-management.md
+++ b/docs/guides/enterprise-token-management.md
@@ -118,7 +118,7 @@ Use bearer tokens to identify each engineer and control access:
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "bearer",
+    "providers": ["bearer"],
     "bearer": {
       "tokens": {
         "eng-alice-a1b2c3": "alice",
@@ -141,8 +141,26 @@ Or, if you already have an identity provider behind a reverse proxy:
 ```json
 {
   "serverAuth": {
-    "provider": "forwarded",
+    "providers": ["forwarded"],
     "forwarded": { "header": "x-forwarded-user" }
+  }
+}
+```
+
+Or, if engineers also want to connect via Claude.ai / ChatGPT / Cursor as Custom Connectors, run `bearer` and `oauth_as` together — same instance, same `/mcp`:
+
+```json
+{
+  "serverAuth": {
+    "providers": ["bearer", "oauth_as"],
+    "bearer": { "tokens": { "eng-alice-a1b2c3": { "subject": "alice", "roles": ["dev"] } } },
+    "oauthAs": {
+      "issuerUrl": "https://mcp.internal:8443",
+      "jwtSecret": "${MCP_OAUTH_AS_JWT_SECRET}",
+      "trustedSourceCidrs": ["10.0.0.0/8"],
+      "redirectUriAllowlist": ["https://claude.ai/api/mcp/auth_callback"],
+      "injectedRoles": ["ai-client"]
+    }
   }
 }
 ```

--- a/docs/guides/proxy-mode.md
+++ b/docs/guides/proxy-mode.md
@@ -450,6 +450,8 @@ The proxy supports server-side authentication for HTTP mode. Authentication is c
 
 By default, no authentication is required. This is suitable for local development and stdio mode.
 
+> **Schema.** `serverAuth.providers` is a `Vec<String>`. List one or many — the proxy runs them as a chain, accepting the first identity that validates. Empty list (or omitted) = anonymous (`NoAuth`). The legacy `provider: "..."` single-string field is no longer accepted; configs that still carry it boot as `NoAuth`.
+
 ### Bearer token auth
 
 Static token-to-user mapping. Each token maps to a subject identity:
@@ -458,7 +460,7 @@ Static token-to-user mapping. Each token maps to a subject identity:
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "bearer",
+    "providers": ["bearer"],
     "bearer": {
       "tokens": {
         "secret-token-abc": "alice",
@@ -486,13 +488,35 @@ Trusts a reverse proxy header (e.g. `X-Forwarded-User`). Only use behind a trust
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "forwarded",
+    "providers": ["forwarded"],
     "forwarded": {
       "header": "x-forwarded-user"
     }
   }
 }
 ```
+
+### OAuth Authorization Server
+
+Lets Claude.ai, ChatGPT, Cursor and other AI clients connect as Custom Connectors via OAuth 2.0 + Dynamic Client Registration. Combine with `bearer` to keep static tokens working for local dev on the same instance:
+
+```json
+{
+  "serverAuth": {
+    "providers": ["bearer", "oauth_as"],
+    "bearer": { "tokens": { "tok-local-dev": { "subject": "avelino", "roles": ["admin"] } } },
+    "oauthAs": {
+      "issuerUrl": "https://mcp.example.com",
+      "jwtSecret": "${MCP_OAUTH_AS_JWT_SECRET}",
+      "trustedSourceCidrs": ["10.0.0.0/8"],
+      "redirectUriAllowlist": ["https://claude.ai/api/mcp/auth_callback"],
+      "injectedRoles": ["oauth-user"]
+    }
+  }
+}
+```
+
+Full setup, security notes, and troubleshooting in the [OAuth AS how-to](../howto/oauth-as.md).
 
 ### Access control (ACL)
 
@@ -506,7 +530,7 @@ Define reusable roles with server-aware, read/write-aware grants:
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "bearer",
+    "providers": ["bearer"],
     "bearer": {
       "tokens": {
         "tok-alice": { "subject": "alice", "roles": ["admin"] },

--- a/docs/howto/docker.md
+++ b/docs/howto/docker.md
@@ -105,8 +105,10 @@ docker run -d \
       "sentry": {"url": "https://mcp.sentry.dev/sse"}
     },
     "serverAuth": {
-      "provider": "bearer",
-      "tokens": ["my-secret-token"]
+      "providers": ["bearer"],
+      "bearer": {
+        "tokens": { "my-secret-token": "ops" }
+      }
     }
   }' \
   -p 8080:8080 \

--- a/docs/howto/oauth-as.md
+++ b/docs/howto/oauth-as.md
@@ -1,0 +1,231 @@
+# OAuth Authorization Server — connect Claude.ai, ChatGPT, Cursor
+
+`mcp serve` ships an OAuth 2.0 Authorization Server with Dynamic
+Client Registration ([RFC 7591][rfc7591]). It lets you plug a self-hosted
+proxy directly into Claude.ai, ChatGPT, Cursor and other AI clients
+that consume the [MCP authorization spec][mcp-auth] — no static
+bearer token to share, no extra OAuth infra in the middle.
+
+## Why this exists
+
+Before `oauth_as`:
+
+- `BearerTokenAuth` (static `subject → token` map) is fine for local
+  dev and CI but Claude.ai-style clients refuse to connect to it.
+- `ForwardedUserAuth` works only when a separate IdP-aware reverse
+  proxy is in front. That's a heavy lift just to expose a fleet of
+  MCP servers to your AI tools.
+
+`oauth_as` makes `mcp serve` itself the Authorization Server — but
+delegates *user* authentication to a trusted reverse proxy
+(oauth2-proxy, Cloudflare Access, Pomerium, anything that sets
+`X-Forwarded-User`). MCP never handles passwords. The OAuth flow
+just wraps the SSO session that already exists.
+
+## Architecture
+
+```
++----------+    +----------------+    +-------------------+
+| Claude   |--->|  oauth2-proxy  |--->|    mcp serve      |
+|  / etc.  |    |  (your IdP)    |    | OAuth AS + /mcp   |
++----------+    +----------------+    +-------------------+
+   ^  user          ^ SSO session         ^
+   | OAuth          | sets headers        | validates JWT
+   | flow           | X-Forwarded-User    | on every request
+                    | X-Forwarded-Groups
+```
+
+The reverse proxy authenticates the human. `mcp serve` reads the
+trusted headers at `/authorize` and emits a short-lived authorization
+code, then a JWT access token that subsequent `/mcp` requests carry
+in `Authorization: Bearer …`.
+
+## Two providers, one endpoint
+
+The most common deployment runs **`oauth_as` and `bearer` in
+parallel** on the same instance:
+
+- Local dev / CI uses a static bearer token.
+- Claude.ai web uses the OAuth flow.
+
+Both kinds of `Authorization: Bearer …` hit the same `/mcp`. The
+[`ProviderChain`][src-chain] tries each provider in order and the
+first one that accepts wins. ACL discriminates per role (see below),
+so static-bearer and OAuth identities can have completely different
+permissions on the same set of backends.
+
+## Configure `serverAuth`
+
+Drop this into `servers.json` (the working `mcp serve` config file):
+
+```json
+{
+  "serverAuth": {
+    "providers": ["bearer", "oauth_as"],
+
+    "bearer": {
+      "tokens": {
+        "tok-local-dev": { "subject": "avelino", "roles": ["admin"] }
+      }
+    },
+
+    "oauthAs": {
+      "issuerUrl": "https://mcp.example.com",
+      "jwtSecret": "${MCP_OAUTH_AS_JWT_SECRET}",
+      "trustedUserHeader": "x-forwarded-user",
+      "trustedGroupsHeader": "x-forwarded-groups",
+      "trustedSourceCidrs": ["127.0.0.1/32", "10.0.0.0/8"],
+      "accessTokenTtlSeconds": 3600,
+      "refreshTokenTtlSeconds": 2592000,
+      "authorizationCodeTtlSeconds": 60,
+      "scopesSupported": ["mcp"],
+      "redirectUriAllowlist": [
+        "https://claude.ai/api/mcp/auth_callback",
+        "https://chat.openai.com/aip/*/oauth/callback"
+      ],
+      "injectedRoles": ["oauth-user"]
+    },
+
+    "acl": {
+      "default": "deny",
+      "rules": [
+        { "roles": ["admin"],      "tools": ["*"],         "policy": "allow" },
+        { "roles": ["oauth-user"], "tools": ["sentry__*"], "policy": "allow" }
+      ]
+    }
+  }
+}
+```
+
+Field-by-field for `oauthAs`:
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `issuerUrl` | yes | — | Public HTTPS URL the AS advertises. Must match what clients reach. |
+| `jwtSecret` | yes | — | HMAC-SHA256 signing key. **≥ 32 bytes.** Boot fails otherwise. |
+| `trustedUserHeader` | no | `x-forwarded-user` | The header your reverse proxy sets. |
+| `trustedGroupsHeader` | no | `x-forwarded-groups` | Comma-separated → JWT `groups` claim. |
+| `trustedSourceCidrs` | yes | — | CIDRs allowed to reach `/authorize`. **Empty list rejected at boot** — without it any client could spoof `X-Forwarded-User`. |
+| `accessTokenTtlSeconds` | no | `3600` | JWT lifetime. |
+| `refreshTokenTtlSeconds` | no | `2592000` (30d) | Refresh token lifetime. |
+| `authorizationCodeTtlSeconds` | no | `60` | Code lifetime. |
+| `scopesSupported` | no | `[]` | Advertised in metadata. |
+| `redirectUriAllowlist` | yes | — | Patterns clients may register. Trailing `*` for ChatGPT-style URIs. |
+| `injectedRoles` | no | `[]` | Roles always added to issued JWTs. Marker for ACL discrimination. |
+
+## How `injectedRoles` filters which mcpServers an AI client can use
+
+Tools are routed to backends by prefix: `sentry__list_issues` lives
+in the `sentry` backend, `github__create_issue` in `github`, and so
+on. `injectedRoles: ["oauth-user"]` stamps every OAuth-issued JWT
+with the `oauth-user` role. Combine that with an ACL rule like
+`{"roles": ["oauth-user"], "tools": ["sentry__*"], "policy": "allow"}`
+and Claude.ai web sees only `sentry` tools, while your local-dev
+admin token still sees everything.
+
+There's no special "OAuth user" path in the dispatcher. The same
+`is_tool_allowed` evaluator that gates static-bearer requests gates
+JWT requests too.
+
+## Run it
+
+1. **Generate the JWT secret** (32+ random bytes, kept out of the
+   config file):
+
+   ```bash
+   export MCP_OAUTH_AS_JWT_SECRET=$(openssl rand -hex 32)
+   ```
+
+2. **Front it with oauth2-proxy** (or Cloudflare Access, Pomerium,
+   etc.) so all traffic to `mcp serve` already has
+   `X-Forwarded-User` set. The [oauth2-proxy quickstart][oauth2-proxy]
+   walks through pointing it at Google / GitHub / Okta.
+
+3. **Boot the proxy**:
+
+   ```bash
+   mcp serve --bind 127.0.0.1:8080
+   ```
+
+   Bind to loopback so only the reverse proxy can reach it. Anything
+   else needs `--insecure`.
+
+4. **Validate the discovery endpoints** before pointing a client at
+   it:
+
+   ```bash
+   curl https://mcp.example.com/.well-known/oauth-protected-resource
+   curl https://mcp.example.com/.well-known/oauth-authorization-server
+   ```
+
+   Both must return JSON. Empty bodies or HTML pages mean the
+   provider isn't enabled or the proxy isn't routing the path.
+
+5. **Connect from Claude.ai**:
+   - Settings → Connectors → "Add custom connector"
+   - URL: `https://mcp.example.com/mcp`
+   - Authenticate with whatever IdP your reverse proxy uses
+   - Tools should appear once the OAuth flow completes
+
+The same URL works in ChatGPT (admin → connectors) and Cursor
+(settings → MCP).
+
+## State persistence
+
+`oauth_as` persists registered clients and refresh tokens to
+`auth_server.json` in the config dir. Inflight authorization codes
+are *not* persisted — restart drops them, which is the safer default
+than letting captured codes resume post-restart.
+
+Override the location with `MCP_AUTH_SERVER_PATH=/path/to/file`, or
+inline the whole content with `MCP_AUTH_SERVER_CONFIG='{"clients":{}, "refresh_tokens":{}}'`.
+The inline mode is for read-only Secret mounts in Kubernetes — same
+contract as `MCP_AUTH_CONFIG` for the client store.
+
+## Security notes
+
+- **`trustedSourceCidrs` is mandatory.** With an empty list, any
+  client could send a request directly to `mcp serve` carrying a
+  forged `X-Forwarded-User` and walk away with an authorization
+  code. The boot path refuses to start without at least one CIDR.
+
+- **HTTPS issuer.** Setting `issuerUrl` to plain `http://` works
+  technically but means tokens flow in cleartext. Document this for
+  your auditors if you intentionally chose plain HTTP for an
+  internal-only deployment.
+
+- **JWT secret rotation invalidates all existing tokens.** v1 has no
+  in-place rotation. Plan for a forced re-login when you change the
+  secret.
+
+- **PKCE S256 only.** The metadata advertises only `S256`. Clients
+  attempting `plain` are rejected at `/authorize`. This is the
+  OAuth 2.1 / MCP authorization spec baseline.
+
+- **Refresh tokens rotate** on every successful refresh. A captured
+  refresh token is valid for one use at most.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `403 /authorize must originate from a trusted reverse proxy` | Peer IP is not in `trustedSourceCidrs`. |
+| `400 redirect_uri rejected: …` | URI not in `redirectUriAllowlist` *or* not registered by the client. |
+| `400 invalid_grant` on `/token` | Code expired (60s default), already used, or PKCE verifier doesn't match. |
+| Claude.ai: "couldn't connect" with no error | The discovery endpoints returned non-JSON or 5xx. Curl them. |
+| Boot fails: `oauthAs.jwtSecret must be at least 32 bytes` | The env var is empty or shorter. |
+| Boot fails: `oauthAs.trustedSourceCidrs must list at least one CIDR` | The anti-spoof list was left empty. |
+
+## References
+
+- MCP authorization spec: <https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization>
+- RFC 7591 — Dynamic Client Registration: <https://www.rfc-editor.org/rfc/rfc7591>
+- RFC 8414 — Authorization Server Metadata: <https://www.rfc-editor.org/rfc/rfc8414>
+- RFC 9728 — Protected Resource Metadata: <https://www.rfc-editor.org/rfc/rfc9728>
+- RFC 7636 — PKCE: <https://www.rfc-editor.org/rfc/rfc7636>
+- Claude.ai Custom Connectors: <https://support.claude.com/en/articles/11175166-get-started-with-custom-connectors-using-remote-mcp>
+
+[rfc7591]: https://www.rfc-editor.org/rfc/rfc7591
+[mcp-auth]: https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+[oauth2-proxy]: https://oauth2-proxy.github.io/oauth2-proxy/
+[src-chain]: https://github.com/avelino/mcp/blob/main/src/server_auth/providers.rs

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -239,25 +239,31 @@ Optional. Configures authentication for `mcp serve --http`. Ignored for direct C
 {
   "mcpServers": { ... },
   "serverAuth": {
-    "provider": "<provider>",
+    "providers": ["<provider>", "<provider>"],
     "bearer": { ... },
     "forwarded": { ... },
+    "oauthAs": { ... },
     "acl": { ... }
   }
 }
 ```
 
-### Provider
+### Providers
+
+`providers` is an array of provider names, evaluated in order as a chain. The first provider that accepts the request wins; if all reject, the chain returns the error of the *first* provider configured (oracle-resistant). Empty array (or omitted) is equivalent to anonymous access.
 
 | Value | Description |
 |-------|-------------|
-| `"none"` (default) | No authentication — all requests are anonymous |
-| `"bearer"` | Static bearer token validation |
-| `"forwarded"` | Trust reverse proxy header |
+| `"none"` | Anonymous identity (`subject: "anonymous"`, no roles). Useful for testing. |
+| `"bearer"` | Static bearer token validation. Reads from `bearer` sub-config. |
+| `"forwarded"` | Trust reverse proxy header (e.g. `X-Forwarded-User`). Reads from `forwarded` sub-config. |
+| `"oauth_as"` | OAuth 2.0 Authorization Server with Dynamic Client Registration — the route required by Claude.ai / ChatGPT / Cursor. Reads from `oauthAs` sub-config. See the [OAuth AS how-to](../howto/oauth-as.md). |
+
+> **Schema change.** Earlier versions used a single `provider: "..."` string. The new schema is the array `providers: [...]`. Configs carrying the legacy field deserialize into an empty providers list and boot as `NoAuth` — silently weakening auth, so an explicit migration is required. Booting with a missing sub-config (e.g. `"bearer"` listed without a `bearer` block) fails at startup rather than degrading.
 
 ### Bearer config
 
-Required when `provider` is `"bearer"`. Each entry in `tokens` accepts two shapes:
+Required when `"bearer"` is in `providers`. Each entry in `tokens` accepts two shapes:
 
 - **Legacy (string):** `"<token>": "<subject>"` — subject only, no roles.
 - **Extended (object):** `"<token>": { "subject": "<subject>", "roles": ["<role>", ...] }` — subject plus roles used by ACL evaluation.
@@ -288,7 +294,7 @@ Each extended entry:
 
 ### Forwarded config
 
-Optional when `provider` is `"forwarded"`. Reads the authenticated user from a header set by a trusted reverse proxy, and optionally reads a groups header to populate roles.
+Optional when `"forwarded"` is in `providers`. Reads the authenticated user from a header set by a trusted reverse proxy, and optionally reads a groups header to populate roles.
 
 ```json
 {
@@ -307,6 +313,47 @@ Optional when `provider` is `"forwarded"`. Reads the authenticated user from a h
 Groups header value is parsed as a comma-separated list: each entry is trimmed and empty entries are dropped. Missing header yields empty roles (not an error). Role matching is case-sensitive.
 
 > Only use `forwarded` behind a trusted reverse proxy. The proxy **must** strip these headers from incoming client requests — otherwise a client could forge identity and roles.
+
+### OAuth AS config (`oauthAs`)
+
+Required when `"oauth_as"` is in `providers`. Turns `mcp serve` into an OAuth 2.0 Authorization Server with Dynamic Client Registration so Claude.ai, ChatGPT, Cursor and other AI clients can connect. User authentication is delegated to a trusted reverse proxy (oauth2-proxy / Cloudflare Access / Pomerium) — `mcp serve` never handles passwords.
+
+```json
+{
+  "oauthAs": {
+    "issuerUrl": "https://mcp.example.com",
+    "jwtSecret": "${MCP_OAUTH_AS_JWT_SECRET}",
+    "trustedUserHeader": "x-forwarded-user",
+    "trustedGroupsHeader": "x-forwarded-groups",
+    "trustedSourceCidrs": ["10.0.0.0/8"],
+    "accessTokenTtlSeconds": 3600,
+    "refreshTokenTtlSeconds": 2592000,
+    "authorizationCodeTtlSeconds": 60,
+    "scopesSupported": ["mcp"],
+    "redirectUriAllowlist": [
+      "https://claude.ai/api/mcp/auth_callback",
+      "https://chat.openai.com/aip/*/oauth/callback"
+    ],
+    "injectedRoles": ["oauth-user"]
+  }
+}
+```
+
+| Field | Type | Required | Default | Description |
+|-------|------|---------|---------|-------------|
+| `issuerUrl` | string | yes | — | Public origin the AS advertises in metadata and embeds as `iss` in JWTs. Must match what clients reach. |
+| `jwtSecret` | string | yes | — | HMAC-SHA256 signing key. **Must be ≥ 32 bytes** — boot fails otherwise. |
+| `trustedUserHeader` | string | no | `"x-forwarded-user"` | Header read at `/authorize` to identify the human. |
+| `trustedGroupsHeader` | string | no | `"x-forwarded-groups"` | Comma-separated → JWT `groups` claim. |
+| `trustedSourceCidrs` | string[] | yes | — | CIDRs allowed to reach `/authorize`. **Empty list rejected at boot** — without it any client could spoof the trusted user header. |
+| `accessTokenTtlSeconds` | number | no | `3600` | JWT lifetime. |
+| `refreshTokenTtlSeconds` | number | no | `2592000` (30d) | Refresh-token lifetime. |
+| `authorizationCodeTtlSeconds` | number | no | `60` | Authorization-code lifetime. |
+| `scopesSupported` | string[] | no | `[]` | Scopes advertised in metadata. |
+| `redirectUriAllowlist` | string[] | yes | — | Patterns clients may register. Trailing `*` allowed (for ChatGPT-style URIs). |
+| `injectedRoles` | string[] | no | `[]` | Roles always added to issued JWTs — useful as a "came in via OAuth" marker for ACL discrimination. |
+
+State (registered clients via DCR + refresh tokens) persists to `auth_server.json` in the config directory; override with `MCP_AUTH_SERVER_PATH` or inline via `MCP_AUTH_SERVER_CONFIG`. See the [OAuth AS how-to](../howto/oauth-as.md) for setup, security notes, and troubleshooting.
 
 ### ACL config
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -23,6 +23,9 @@ These variables configure `mcp` behavior:
 | `MCP_OAUTH_CALLBACK_PORT` | `8085-8099` | Port or range for the OAuth callback listener. Single port (`9000`), range (`9000-9010`), or `0` for OS-assigned. |
 | `MCP_AUTH_CONFIG` | — | Inline JSON content of `auth.json` (read-only). Highest priority for auth — skips file read. Writes are no-ops with a single `warn` log. Intended for k8s/Docker Secrets. |
 | `MCP_AUTH_PATH` | `~/.config/mcp/auth.json` | Override the OAuth token storage location (file path) |
+| `MCP_AUTH_SERVER_CONFIG` | — | Inline JSON of the OAuth Authorization Server state (`auth_server.json`). Same precedence model as `MCP_AUTH_CONFIG`: read-only on disk, mutable in memory. Used when `serverAuth.providers` includes `"oauth_as"`. |
+| `MCP_AUTH_SERVER_PATH` | `~/.config/mcp/auth_server.json` | File path for AS state (registered DCR clients + refresh tokens). Used when `serverAuth.providers` includes `"oauth_as"`. |
+| `MCP_OAUTH_AS_JWT_SECRET` | — | HMAC-SHA256 signing key for issued JWTs when running the OAuth Authorization Server. Must be ≥ 32 bytes. Typically referenced from `serverAuth.oauthAs.jwtSecret` via `${MCP_OAUTH_AS_JWT_SECRET}`. Rotation invalidates every previously issued token. |
 
 ### Config loading priority
 
@@ -204,6 +207,43 @@ For container deployments where the filesystem is read-only or you want tokens i
 2. **`MCP_AUTH_PATH`** — file path override
 3. **`MCP_CONFIG_DIR`/auth.json** — config directory override
 4. **`~/.config/mcp/auth.json`** — default file location
+
+### `MCP_AUTH_SERVER_CONFIG`
+
+Inline JSON for the OAuth Authorization Server state — registered clients (Dynamic Client Registration / RFC 7591) and persisted refresh tokens. Equivalent to `MCP_AUTH_CONFIG` but for the *server-side* AS state file (`auth_server.json`), used only when `serverAuth.providers` contains `"oauth_as"`.
+
+Same precedence model: inline content takes priority, writes during runtime stay in memory only (the on-disk source is treated as read-only, matching how Kubernetes Secrets behave).
+
+```bash
+export MCP_AUTH_SERVER_CONFIG='{
+  "clients": {},
+  "refresh_tokens": {}
+}'
+```
+
+Authorization codes are intentionally **not** persisted — restart drops them, which is the safer default than letting captured codes resume post-restart.
+
+### `MCP_AUTH_SERVER_PATH`
+
+Override the file location for AS state. Default is `~/.config/mcp/auth_server.json`. The file is rewritten atomically via tempfile-then-rename, so a crash mid-write cannot leave a partial JSON behind.
+
+```bash
+MCP_AUTH_SERVER_PATH=/var/lib/mcp/auth_server.json mcp serve --http 0.0.0.0:8080
+```
+
+`MCP_AUTH_SERVER_CONFIG` takes priority over `MCP_AUTH_SERVER_PATH`. Both apply only when `oauth_as` is in `serverAuth.providers`; otherwise they're ignored.
+
+### `MCP_OAUTH_AS_JWT_SECRET`
+
+HMAC-SHA256 signing key for the JWTs issued by the OAuth Authorization Server. Must be at least 32 bytes — boot fails otherwise. Generate with:
+
+```bash
+export MCP_OAUTH_AS_JWT_SECRET=$(openssl rand -hex 32)
+```
+
+Reference it from `serverAuth.oauthAs.jwtSecret` via `${MCP_OAUTH_AS_JWT_SECRET}` so the secret never lives in the config file.
+
+> Rotation invalidates every previously issued access and refresh token. v1 has no in-place rotation — plan for a forced re-login when changing the secret.
 
 ## Config variables
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,5 +1,6 @@
 mod hints;
 pub mod oauth;
+pub(crate) mod oauth_primitives;
 pub mod store;
 
 use anyhow::{Context, Result};

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -1,15 +1,12 @@
 use anyhow::{bail, Context, Result};
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use base64::Engine;
-use rand::Rng;
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use url::Url;
 
 use super::hints;
+use super::oauth_primitives::{generate_pkce, generate_random_string};
 use super::store::{self, to_stored_tokens};
 
 const DEFAULT_CALLBACK_PORT_START: u16 = 8085;
@@ -291,28 +288,6 @@ async fn get_or_register_client(
     Ok(client_id)
 }
 
-// --- PKCE ---
-
-fn generate_pkce() -> (String, String) {
-    let verifier = generate_random_string(43);
-    let mut hasher = Sha256::new();
-    hasher.update(verifier.as_bytes());
-    let hash = hasher.finalize();
-    let challenge = URL_SAFE_NO_PAD.encode(hash);
-    (verifier, challenge)
-}
-
-fn generate_random_string(len: usize) -> String {
-    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
-    let mut rng = rand::rng();
-    (0..len)
-        .map(|_| {
-            let idx = rng.random_range(0..CHARSET.len());
-            CHARSET[idx] as char
-        })
-        .collect()
-}
-
 // --- Callback server ---
 
 async fn bind_callback_listener() -> Result<(TcpListener, u16)> {
@@ -398,30 +373,8 @@ async fn send_callback_response(stream: &mut tokio::net::TcpStream, message: &st
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_generate_pkce() {
-        let (verifier, challenge) = generate_pkce();
-        assert!(verifier.len() >= 43);
-        assert!(!challenge.is_empty());
-        assert!(!challenge.contains('='));
-        assert!(!challenge.contains('+'));
-        assert!(!challenge.contains('/'));
-
-        let mut hasher = Sha256::new();
-        hasher.update(verifier.as_bytes());
-        let hash = hasher.finalize();
-        let expected = URL_SAFE_NO_PAD.encode(hash);
-        assert_eq!(challenge, expected);
-    }
-
-    #[test]
-    fn test_generate_random_string() {
-        let s = generate_random_string(32);
-        assert_eq!(s.len(), 32);
-        assert!(s
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || "-._~".contains(c)));
-    }
+    // PKCE / random-string tests live with the helpers in
+    // `super::oauth_primitives` — see `src/auth/oauth_primitives.rs`.
 
     #[test]
     fn test_parse_port_spec_single_port() {

--- a/src/auth/oauth_primitives.rs
+++ b/src/auth/oauth_primitives.rs
@@ -1,0 +1,105 @@
+//! Shared OAuth 2.0 primitives — PKCE (RFC 7636), random opaque
+//! identifiers, and the SHA-256 + base64url-no-pad helper that backs
+//! `code_challenge` derivation.
+//!
+//! Both the *client* flow (`super::oauth`, `mcp` authenticating against
+//! a remote MCP server) and the *server* flow (`crate::server_auth::oauth_as`,
+//! `mcp serve` acting as an OAuth Authorization Server) call into these
+//! helpers. Keeping them in one module avoids two-implementation drift
+//! and centralizes the crypto choices (charset, length, hashing) that
+//! must agree across both sides.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use rand::Rng;
+use sha2::{Digest, Sha256};
+
+/// Charset for opaque random tokens — the unreserved set from RFC 3986
+/// (`A-Z`, `a-z`, `0-9`, `-`, `.`, `_`, `~`). Identical to the PKCE
+/// `code_verifier` charset (RFC 7636 §4.1), so the same generator backs
+/// both verifiers and arbitrary opaque IDs (authorization codes, DCR
+/// `client_id`, JWT `jti`, etc.) without re-encoding.
+const TOKEN_CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+/// Generate a fresh PKCE `(code_verifier, code_challenge)` pair.
+///
+/// Verifier is 43 bytes from [`TOKEN_CHARSET`] — the minimum length
+/// allowed by RFC 7636 §4.1 and the one Claude uses too. Challenge is
+/// `BASE64URL(SHA-256(verifier))` with no padding (the `S256` method).
+/// The `plain` method is intentionally not provided.
+pub(crate) fn generate_pkce() -> (String, String) {
+    let verifier = generate_random_string(43);
+    let challenge = s256_challenge(&verifier);
+    (verifier, challenge)
+}
+
+/// Compute the PKCE `S256` challenge from a verifier — used by the
+/// authorization server to recompute and compare against the challenge
+/// stored at `/authorize` time when the client presents the verifier
+/// at `/token`.
+pub(crate) fn s256_challenge(verifier: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(hasher.finalize())
+}
+
+/// Generate `len` chars of opaque random token from [`TOKEN_CHARSET`].
+/// Suitable for PKCE verifiers, OAuth authorization codes, DCR
+/// `client_id` values, and JWT `jti` claims.
+pub(crate) fn generate_random_string(len: usize) -> String {
+    let mut rng = rand::rng();
+    (0..len)
+        .map(|_| {
+            let idx = rng.random_range(0..TOKEN_CHARSET.len());
+            TOKEN_CHARSET[idx] as char
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_pkce() {
+        let (verifier, challenge) = generate_pkce();
+        assert!(verifier.len() >= 43);
+        assert!(!challenge.is_empty());
+        assert!(!challenge.contains('='));
+        assert!(!challenge.contains('+'));
+        assert!(!challenge.contains('/'));
+
+        // Challenge must be deterministic from verifier.
+        assert_eq!(challenge, s256_challenge(&verifier));
+    }
+
+    #[test]
+    fn test_s256_challenge_is_deterministic() {
+        let v = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        // Spot value matches the canonical example in RFC 7636 Appendix B.
+        assert_eq!(
+            s256_challenge(v),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn test_generate_random_string_length_and_charset() {
+        let s = generate_random_string(32);
+        assert_eq!(s.len(), 32);
+        assert!(s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || "-._~".contains(c)));
+    }
+
+    #[test]
+    fn test_generate_random_string_uniqueness() {
+        // Not a cryptographic guarantee, but a sanity check: 64 bytes
+        // from a 66-char alphabet should collide with negligible
+        // probability across 100 draws.
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..100 {
+            assert!(seen.insert(generate_random_string(64)));
+        }
+    }
+}

--- a/src/serve/http.rs
+++ b/src/serve/http.rs
@@ -17,6 +17,7 @@ use crate::audit::{AuditEntry, AuditLogger};
 use crate::cache::ToolCacheStore;
 use crate::config::Config;
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
+use crate::server_auth::oauth_as::{self, AsState};
 use crate::server_auth::{self, AclConfig, AuthIdentity, AuthProvider, Credentials};
 
 use super::discovery::discover_pending_backends;
@@ -133,7 +134,20 @@ fn validate_bind_addr(addr: &str, insecure: bool) -> Result<std::net::SocketAddr
 pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result<()> {
     let sock_addr = validate_bind_addr(bind_addr, insecure)?;
 
-    let auth_provider = server_auth::build_auth_provider(&config.server_auth)?;
+    // OAuth AS state — only allocated when the operator opted in via
+    // `serverAuth.providers` containing "oauth_as". Loaded from disk
+    // (or env-var inline) so registered clients and refresh tokens
+    // survive a restart.
+    let as_enabled = config.server_auth.providers.iter().any(|p| p == "oauth_as");
+    let as_state: Option<Arc<AsState>> = if as_enabled {
+        let s = oauth_as::load_state()
+            .map_err(|e| anyhow::anyhow!("failed to load AS state: {e:#}"))?;
+        Some(Arc::new(s))
+    } else {
+        None
+    };
+
+    let auth_provider = server_auth::build_auth_provider(&config.server_auth, as_state.as_ref())?;
     let acl = config.server_auth.acl.clone();
 
     let pool = if config.audit.output == crate::audit::AuditOutput::File {
@@ -165,6 +179,27 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         sessions: Arc::new(Mutex::new(HashMap::new())),
         shutdown: shutdown_rx,
     };
+
+    // Background GC for the OAuth AS — drops expired authorization
+    // codes and refresh tokens. Cheap pass; runs every 60s.
+    if let Some(ref state) = as_state {
+        let gc_state = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                let removed = gc_state.gc_expired();
+                if removed > 0 {
+                    if let Err(e) = oauth_as::save_state(&gc_state) {
+                        tracing::warn!(
+                            error = format!("{e:#}"),
+                            "failed to persist AS state after GC"
+                        );
+                    }
+                }
+            }
+        });
+    }
 
     // Background reaper: shuts down idle backends periodically.
     // Lock is released before async shutdown so request handlers are never
@@ -219,10 +254,30 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         },
     );
 
-    let app = Router::new()
+    let core_router = Router::new()
         .route("/health", get(health_handler))
         .route("/mcp", post(mcp_handler).get(mcp_sse_handler))
         .route("/mcp/sse", get(mcp_sse_handler))
+        .with_state(state.clone());
+
+    // Mount the OAuth AS sub-router when the operator enabled it.
+    // Without it, the well-known/discovery paths simply 404 — same
+    // shape the previous short-circuit produced, just routed through
+    // the standard fallback now.
+    let app = if let Some(ref state) = as_state {
+        let cfg = Arc::new(
+            config
+                .server_auth
+                .oauth_as
+                .clone()
+                .expect("oauth_as enabled but no oauthAs config — caught at boot"),
+        );
+        core_router.merge(oauth_as::router(cfg, state.clone()))
+    } else {
+        core_router
+    };
+
+    let app = app
         .fallback(|req: axum::extract::Request| async move {
             let path = req.uri().path().to_string();
             let method = req.method().clone();
@@ -231,18 +286,9 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
                 path = %path,
                 "unhandled request"
             );
-            // OAuth/OIDC discovery endpoints: return 404 with valid JSON
-            // so clients that probe for auth don't crash on empty bodies
-            if path.contains(".well-known") || path == "/register" {
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(json!({"error": "not_found", "error_description": "This server does not support OAuth"})),
-                );
-            }
             (StatusCode::NOT_FOUND, Json(json!({"error": "not found"})))
         })
-        .layer(request_logger)
-        .with_state(state.clone());
+        .layer(request_logger);
 
     tracing::info!(addr = %sock_addr, "HTTP server listening");
     if sock_addr.ip().is_loopback() {
@@ -274,9 +320,17 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         let _ = shutdown_tx.send(true);
     };
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal)
-        .await?;
+    // ConnectInfo<SocketAddr> is required by the OAuth /authorize
+    // handler so it can verify the request originates from a trusted
+    // CIDR (anti-spoof against direct clients injecting
+    // X-Forwarded-User). Wiring it unconditionally is harmless for
+    // other handlers.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal)
+    .await?;
 
     // Cleanup backends — bounded so a stuck handler doesn't block exit.
     // Drain under the lock (cheap), then run all shutdowns in parallel.

--- a/src/server_auth/mod.rs
+++ b/src/server_auth/mod.rs
@@ -1,9 +1,11 @@
 mod acl;
+pub mod oauth_as;
 mod providers;
 
 pub(crate) use acl::glob_match;
 pub use acl::{AclConfig, Decision, MatchedRule, PromptContext, ResourceContext, ToolContext};
-pub use providers::{BearerTokenAuth, ForwardedUserAuth, NoAuth};
+pub use oauth_as::OAuthAsConfig;
+pub use providers::{BearerTokenAuth, ForwardedUserAuth, NoAuth, ProviderChain};
 
 // Re-exported for tests in other modules (serve.rs)
 #[cfg(test)]
@@ -48,31 +50,34 @@ pub trait AuthProvider: Send + Sync {
 }
 
 /// Configuration for server-side authentication.
-#[derive(Debug, Deserialize, Clone)]
+///
+/// `providers` lists every provider that runs on `/mcp` requests, in
+/// order. The composite [`ProviderChain`] tries each one until the
+/// first acceptance. This shape is what makes the issue #90 use case
+/// work: a single `mcp serve` instance accepts both static bearer
+/// tokens (local dev) and OAuth-issued JWTs (Claude.ai web) at the
+/// same endpoint.
+///
+/// Sub-configs are looked up by provider name:
+/// - `"bearer"` → reads [`Self::bearer`].
+/// - `"forwarded"` → reads [`Self::forwarded`].
+/// - `"oauth_as"` → reads [`Self::oauth_as`].
+/// - `"none"` is also accepted, yielding `NoAuth` (anonymous).
+///
+/// Empty `providers` is equivalent to `["none"]` — anonymous access,
+/// useful for stdio mode and local dev with no auth at all.
+#[derive(Debug, Default, Deserialize, Clone)]
 pub struct ServerAuthConfig {
-    #[serde(default = "default_provider")]
-    pub provider: String,
+    #[serde(default)]
+    pub providers: Vec<String>,
     #[serde(default)]
     pub bearer: Option<BearerConfig>,
     #[serde(default)]
     pub forwarded: Option<ForwardedConfig>,
+    #[serde(default, rename = "oauthAs")]
+    pub oauth_as: Option<OAuthAsConfig>,
     #[serde(default)]
     pub acl: Option<AclConfig>,
-}
-
-impl Default for ServerAuthConfig {
-    fn default() -> Self {
-        Self {
-            provider: "none".to_string(),
-            bearer: None,
-            forwarded: None,
-            acl: None,
-        }
-    }
-}
-
-fn default_provider() -> String {
-    "none".to_string()
 }
 
 /// A single bearer token entry. Accepts two shapes for backwards compatibility:
@@ -110,27 +115,73 @@ fn default_groups_header() -> String {
     "x-forwarded-groups".to_string()
 }
 
-/// Build an AuthProvider from config.
-pub fn build_auth_provider(config: &ServerAuthConfig) -> Result<Arc<dyn AuthProvider>> {
-    match config.provider.as_str() {
-        "none" => Ok(Arc::new(NoAuth)),
-        "bearer" => {
-            let bearer = config
-                .bearer
-                .as_ref()
-                .ok_or_else(|| anyhow::anyhow!("bearer provider requires 'bearer' config"))?;
-            Ok(Arc::new(BearerTokenAuth::new(bearer.tokens.clone())))
-        }
-        "forwarded" => {
-            let (header, groups_header) = config
-                .forwarded
-                .as_ref()
-                .map(|f| (f.header.clone(), f.groups_header.clone()))
-                .unwrap_or_else(|| (default_header(), default_groups_header()));
-            Ok(Arc::new(ForwardedUserAuth::new(header, groups_header)))
-        }
-        other => anyhow::bail!("unknown auth provider: {other}"),
+/// Build an AuthProvider chain from config.
+///
+/// Each name in `config.providers` is resolved to a concrete provider
+/// and wrapped in a [`ProviderChain`] that tries them in order. Boot
+/// fails fast if a name references a sub-config that is missing —
+/// silent fallback would let a misconfigured deploy run with weaker
+/// auth than the operator intended.
+///
+/// `as_state` is required iff `"oauth_as"` is in `providers`: the
+/// JWT validator needs the registered-client store to enforce
+/// audience checks against revocation. Callers (typically `run_http`)
+/// load the state from disk and pass an `Arc` here.
+///
+/// Schema is intentionally not backwards-compatible with the legacy
+/// `provider: String` field: configs that still carry it deserialize
+/// into an empty `providers` vec, which boots as `NoAuth`. Operators
+/// upgrading must rewrite their `serverAuth` block — the breaking
+/// change is documented in `docs/howto/oauth-as.md`.
+pub fn build_auth_provider(
+    config: &ServerAuthConfig,
+    as_state: Option<&Arc<oauth_as::AsState>>,
+) -> Result<Arc<dyn AuthProvider>> {
+    if config.providers.is_empty() {
+        return Ok(Arc::new(NoAuth));
     }
+
+    let mut providers: Vec<Arc<dyn AuthProvider>> = Vec::with_capacity(config.providers.len());
+    for name in &config.providers {
+        let p: Arc<dyn AuthProvider> = match name.as_str() {
+            "none" => Arc::new(NoAuth),
+            "bearer" => {
+                let bearer = config.bearer.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "providers includes 'bearer' but 'bearer' sub-config is missing"
+                    )
+                })?;
+                Arc::new(BearerTokenAuth::new(bearer.tokens.clone()))
+            }
+            "forwarded" => {
+                let (header, groups_header) = config
+                    .forwarded
+                    .as_ref()
+                    .map(|f| (f.header.clone(), f.groups_header.clone()))
+                    .unwrap_or_else(|| (default_header(), default_groups_header()));
+                Arc::new(ForwardedUserAuth::new(header, groups_header))
+            }
+            "oauth_as" => {
+                let oauth = config.oauth_as.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "providers includes 'oauth_as' but 'oauthAs' sub-config is missing"
+                    )
+                })?;
+                oauth.validate()?;
+                let state = as_state.cloned().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "providers includes 'oauth_as' but no AS state was provided to \
+                         build_auth_provider — caller must load it before this call"
+                    )
+                })?;
+                Arc::new(oauth_as::OAuthAsAuth::new(Arc::new(oauth.clone()), state))
+            }
+            other => anyhow::bail!("unknown auth provider: {other}"),
+        };
+        providers.push(p);
+    }
+
+    Ok(Arc::new(ProviderChain::new(providers)))
 }
 
 /// Check if a resource is allowed for the given identity.
@@ -214,9 +265,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_no_auth() {
+    async fn test_build_no_auth_for_empty_providers() {
+        // Empty providers list = anonymous, suitable for stdio/dev.
         let config = ServerAuthConfig::default();
-        let provider = build_auth_provider(&config).unwrap();
+        let provider = build_auth_provider(&config, None).unwrap();
         let creds = Credentials::new();
         let identity = provider.authenticate(&creds).await.unwrap();
         assert_eq!(identity.subject, "anonymous");
@@ -230,11 +282,11 @@ mod tests {
             BearerToken::Subject("alice".to_string()),
         );
         let config = ServerAuthConfig {
-            provider: "bearer".to_string(),
+            providers: vec!["bearer".to_string()],
             bearer: Some(BearerConfig { tokens }),
             ..Default::default()
         };
-        let provider = build_auth_provider(&config).unwrap();
+        let provider = build_auth_provider(&config, None).unwrap();
 
         let mut creds = Credentials::new();
         creds.insert("authorization".to_string(), "Bearer secret-abc".to_string());
@@ -243,26 +295,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_bearer_missing_config() {
+    async fn test_build_bearer_missing_config_fails_at_boot() {
+        // Listing 'bearer' without a 'bearer' sub-config is a misconfig
+        // that must NOT silently fall back to NoAuth.
         let config = ServerAuthConfig {
-            provider: "bearer".to_string(),
+            providers: vec!["bearer".to_string()],
             bearer: None,
             ..Default::default()
         };
-        assert!(build_auth_provider(&config).is_err());
+        let err = match build_auth_provider(&config, None) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("bearer"));
     }
 
     #[tokio::test]
     async fn test_build_forwarded_auth() {
         let config = ServerAuthConfig {
-            provider: "forwarded".to_string(),
+            providers: vec!["forwarded".to_string()],
             forwarded: Some(ForwardedConfig {
                 header: "x-forwarded-user".to_string(),
                 groups_header: "x-forwarded-groups".to_string(),
             }),
             ..Default::default()
         };
-        let provider = build_auth_provider(&config).unwrap();
+        let provider = build_auth_provider(&config, None).unwrap();
 
         let mut creds = Credentials::new();
         creds.insert("x-forwarded-user".to_string(), "bob".to_string());
@@ -273,25 +331,78 @@ mod tests {
     #[test]
     fn test_build_unknown_provider() {
         let config = ServerAuthConfig {
-            provider: "jwt".to_string(),
+            providers: vec!["jwt".to_string()],
             ..Default::default()
         };
-        assert!(build_auth_provider(&config).is_err());
+        let err = match build_auth_provider(&config, None) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("unknown auth provider"));
+    }
+
+    #[test]
+    fn test_build_oauth_as_without_subconfig_fails_at_boot() {
+        // Same security guard as bearer/forwarded: missing sub-config
+        // must NOT be papered over as NoAuth.
+        let config = ServerAuthConfig {
+            providers: vec!["oauth_as".to_string()],
+            oauth_as: None,
+            ..Default::default()
+        };
+        let err = match build_auth_provider(&config, None) {
+            Ok(_) => panic!("expected error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("oauthAs"));
+    }
+
+    #[tokio::test]
+    async fn test_build_chain_with_bearer_and_forwarded() {
+        // The actual issue #90 case: two providers active in parallel.
+        // Static bearer covers local dev; forwarded covers proxy-fronted
+        // deployments. Both must work in the same instance.
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-local".to_string(),
+            BearerToken::Subject("avelino".to_string()),
+        );
+        let config = ServerAuthConfig {
+            providers: vec!["bearer".to_string(), "forwarded".to_string()],
+            bearer: Some(BearerConfig { tokens }),
+            forwarded: Some(ForwardedConfig {
+                header: "x-forwarded-user".to_string(),
+                groups_header: "x-forwarded-groups".to_string(),
+            }),
+            ..Default::default()
+        };
+        let provider = build_auth_provider(&config, None).unwrap();
+
+        // Path A: static bearer.
+        let mut a = Credentials::new();
+        a.insert("authorization".to_string(), "Bearer tok-local".to_string());
+        assert_eq!(provider.authenticate(&a).await.unwrap().subject, "avelino");
+
+        // Path B: forwarded header. Same instance, no reconfiguration.
+        let mut b = Credentials::new();
+        b.insert("x-forwarded-user".to_string(), "alice".to_string());
+        assert_eq!(provider.authenticate(&b).await.unwrap().subject, "alice");
     }
 
     #[test]
     fn test_default_config_deserialize() {
         let json = r#"{}"#;
         let config: ServerAuthConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.provider, "none");
+        assert!(config.providers.is_empty());
         assert!(config.bearer.is_none());
+        assert!(config.oauth_as.is_none());
         assert!(config.acl.is_none());
     }
 
     #[test]
     fn test_full_config_deserialize() {
         let json = r#"{
-            "provider": "bearer",
+            "providers": ["bearer"],
             "bearer": {
                 "tokens": {
                     "tok-1": "alice",
@@ -306,13 +417,31 @@ mod tests {
             }
         }"#;
         let config: ServerAuthConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.provider, "bearer");
+        assert_eq!(config.providers, vec!["bearer".to_string()]);
         assert_eq!(config.bearer.unwrap().tokens.len(), 2);
         let acl = config.acl.unwrap();
         match &acl {
             AclConfig::Legacy(legacy) => assert_eq!(legacy.rules.len(), 1),
             AclConfig::RoleBased(_) => panic!("expected legacy schema"),
         }
+    }
+
+    #[test]
+    fn test_legacy_provider_field_is_ignored_silently_into_no_auth() {
+        // No backwards-compat: the old `provider: "bearer"` field is
+        // not recognized. With #[serde(default)] on `providers`, the
+        // unknown key is dropped and the chain becomes empty → NoAuth.
+        // This is the documented breaking change for issue #90 — old
+        // configs do not auto-upgrade.
+        let json = r#"{
+            "provider": "bearer",
+            "bearer": { "tokens": { "tok-1": "alice" } }
+        }"#;
+        let config: ServerAuthConfig = serde_json::from_str(json).unwrap();
+        assert!(
+            config.providers.is_empty(),
+            "legacy `provider` field must NOT auto-populate `providers`"
+        );
     }
 
     #[test]

--- a/src/server_auth/oauth_as/authorize.rs
+++ b/src/server_auth/oauth_as/authorize.rs
@@ -1,0 +1,349 @@
+//! GET /authorize — entry point of the OAuth flow.
+//!
+//! The user has already authenticated through the upstream reverse
+//! proxy (oauth2-proxy / Cloudflare Access / Pomerium), which sets
+//! `X-Forwarded-User` (and optionally `X-Forwarded-Groups`). We
+//! verify the request originates from the configured trusted CIDR
+//! ranges, extract subject + roles, validate the OAuth params
+//! (PKCE S256 mandatory), emit a one-shot authorization code, and
+//! redirect to the client's `redirect_uri`.
+//!
+//! No HTML consent screen in v1. The user already consented at the
+//! IdP step in front of `mcp serve`. Adding a second consent here is
+//! noise without a security gain — that decision is documented in
+//! the issue #90 plan.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    extract::{ConnectInfo, Query, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Redirect, Response},
+};
+
+use crate::auth::oauth_primitives::generate_random_string;
+use crate::server_auth::providers::read_trusted_user;
+
+use super::cidr::{ip_in_any, parse_all};
+use super::redirect_uri;
+use super::register::AppCtx;
+use super::types::AuthorizationCode;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct AuthorizeQuery {
+    pub response_type: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub code_challenge: String,
+    pub code_challenge_method: String,
+    pub state: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+fn err_response(code: StatusCode, message: &str) -> Response {
+    (code, message.to_string()).into_response()
+}
+
+/// Build the redirect URI that carries the authorization code back to
+/// the client, preserving the supplied `state` parameter as RFC 6749 §4.1.2 demands.
+fn build_redirect(redirect_uri: &str, code: &str, state: &str) -> String {
+    let separator = if redirect_uri.contains('?') { '&' } else { '?' };
+    format!(
+        "{redirect_uri}{separator}code={}&state={}",
+        url_encode(code),
+        url_encode(state)
+    )
+}
+
+fn url_encode(s: &str) -> String {
+    url::form_urlencoded::byte_serialize(s.as_bytes()).collect()
+}
+
+/// Extract credentials from request headers — same shape as
+/// `serve/http.rs::extract_credentials` so handler code reuses
+/// `read_trusted_user` without new plumbing.
+fn extract_creds(headers: &HeaderMap) -> crate::server_auth::Credentials {
+    let mut c = crate::server_auth::Credentials::new();
+    for (name, value) in headers.iter() {
+        if let Ok(v) = value.to_str() {
+            c.insert(name.as_str().to_lowercase(), v.to_string());
+        }
+    }
+    c
+}
+
+pub async fn authorize(
+    State(ctx): State<Arc<AppCtx>>,
+    ConnectInfo(peer): ConnectInfo<SocketAddr>,
+    Query(q): Query<AuthorizeQuery>,
+    headers: HeaderMap,
+) -> Response {
+    // 1. Anti-spoof: must come from a trusted source CIDR.
+    let cidrs = match parse_all(&ctx.config.trusted_source_cidrs) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "invalid CIDR in oauthAs.trustedSourceCidrs");
+            return err_response(StatusCode::INTERNAL_SERVER_ERROR, "AS misconfigured");
+        }
+    };
+    if !ip_in_any(peer.ip(), &cidrs) {
+        tracing::warn!(peer = %peer.ip(), "rejecting /authorize from untrusted source");
+        return err_response(
+            StatusCode::FORBIDDEN,
+            "/authorize must originate from a trusted reverse proxy",
+        );
+    }
+
+    // 2. PKCE method: S256 only. Never `plain`.
+    if q.code_challenge_method != "S256" {
+        return err_response(
+            StatusCode::BAD_REQUEST,
+            "code_challenge_method must be S256",
+        );
+    }
+    if q.code_challenge.is_empty() {
+        return err_response(StatusCode::BAD_REQUEST, "code_challenge is required");
+    }
+    if q.response_type != "code" {
+        return err_response(StatusCode::BAD_REQUEST, "response_type must be 'code'");
+    }
+
+    // 3. Client must have been registered via DCR.
+    let client = match ctx.state.get_client(&q.client_id) {
+        Some(c) => c,
+        None => return err_response(StatusCode::BAD_REQUEST, "unknown client_id"),
+    };
+
+    // 4. redirect_uri must (a) match what was registered AND (b)
+    //    pass the operator allowlist. Both checks together close the
+    //    open-redirect class of bugs.
+    if !client.redirect_uris.contains(&q.redirect_uri) {
+        return err_response(
+            StatusCode::BAD_REQUEST,
+            "redirect_uri does not match registered client",
+        );
+    }
+    if let Err(e) = redirect_uri::validate(&q.redirect_uri, &ctx.config.redirect_uri_allowlist) {
+        return err_response(
+            StatusCode::BAD_REQUEST,
+            &format!("redirect_uri rejected: {e}"),
+        );
+    }
+
+    // 5. Trusted header: must be present and the user must be set.
+    let creds = extract_creds(&headers);
+    let (subject, roles) = match read_trusted_user(
+        &creds,
+        &ctx.config.trusted_user_header,
+        &ctx.config.trusted_groups_header,
+    ) {
+        Some(t) => t,
+        None => {
+            return err_response(
+                StatusCode::UNAUTHORIZED,
+                "missing or empty trusted user header",
+            )
+        }
+    };
+
+    // 6. Mint a one-shot code.
+    let code = generate_random_string(64);
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    ctx.state.put_code(AuthorizationCode {
+        code: code.clone(),
+        client_id: q.client_id,
+        redirect_uri: q.redirect_uri.clone(),
+        code_challenge: q.code_challenge,
+        scope: q.scope,
+        subject,
+        roles,
+        expires_at_unix: now + ctx.config.authorization_code_ttl_seconds,
+    });
+
+    Redirect::to(&build_redirect(&q.redirect_uri, &code, &q.state)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server_auth::oauth_as::types::RegisteredClient;
+
+    fn ctx() -> Arc<AppCtx> {
+        let config = Arc::new(super::super::OAuthAsConfig {
+            issuer_url: "https://mcp.example.com".to_string(),
+            jwt_secret: "x".repeat(32),
+            trusted_user_header: "x-forwarded-user".to_string(),
+            trusted_groups_header: "x-forwarded-groups".to_string(),
+            trusted_source_cidrs: vec!["127.0.0.0/8".to_string()],
+            access_token_ttl_seconds: 3600,
+            refresh_token_ttl_seconds: 2_592_000,
+            authorization_code_ttl_seconds: 60,
+            scopes_supported: vec!["mcp".to_string()],
+            redirect_uri_allowlist: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+            injected_roles: vec!["oauth-user".to_string()],
+        });
+        let state = Arc::new(super::super::AsState::default());
+        state
+            .register_client(RegisteredClient {
+                client_id: "client-A".to_string(),
+                client_name: None,
+                redirect_uris: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+                grant_types: vec!["authorization_code".to_string()],
+                created_at_unix: 0,
+            })
+            .unwrap();
+        Arc::new(AppCtx { config, state })
+    }
+
+    fn good_query() -> AuthorizeQuery {
+        AuthorizeQuery {
+            response_type: "code".to_string(),
+            client_id: "client-A".to_string(),
+            redirect_uri: "https://claude.ai/api/mcp/auth_callback".to_string(),
+            code_challenge: "abcXYZ-_~.123".to_string(),
+            code_challenge_method: "S256".to_string(),
+            state: "opaque-csrf".to_string(),
+            scope: Some("mcp".to_string()),
+        }
+    }
+
+    fn good_headers() -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-user", "alice".parse().unwrap());
+        h.insert("x-forwarded-groups", "dev,oncall".parse().unwrap());
+        h
+    }
+
+    fn loopback() -> ConnectInfo<SocketAddr> {
+        ConnectInfo("127.0.0.1:54321".parse().unwrap())
+    }
+    fn external() -> ConnectInfo<SocketAddr> {
+        ConnectInfo("8.8.8.8:54321".parse().unwrap())
+    }
+
+    fn parse_redirect_location(resp: Response) -> String {
+        resp.headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn test_authorize_emits_code_for_trusted_user() {
+        let ctx = ctx();
+        let resp = authorize(
+            State(ctx.clone()),
+            loopback(),
+            Query(good_query()),
+            good_headers(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        let loc = parse_redirect_location(resp);
+        assert!(loc.starts_with("https://claude.ai/api/mcp/auth_callback?"));
+        assert!(loc.contains("code="));
+        assert!(loc.contains("state=opaque-csrf"));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rejects_untrusted_source() {
+        // Anti-spoof guard: peer IP outside trustedSourceCidrs must
+        // be rejected even when all OAuth params look correct.
+        let ctx = ctx();
+        let resp = authorize(State(ctx), external(), Query(good_query()), good_headers()).await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rejects_pkce_plain() {
+        let ctx = ctx();
+        let mut q = good_query();
+        q.code_challenge_method = "plain".to_string();
+        let resp = authorize(State(ctx), loopback(), Query(q), good_headers()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rejects_missing_code_challenge() {
+        let ctx = ctx();
+        let mut q = good_query();
+        q.code_challenge = String::new();
+        let resp = authorize(State(ctx), loopback(), Query(q), good_headers()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rejects_unknown_client() {
+        let ctx = ctx();
+        let mut q = good_query();
+        q.client_id = "ghost".to_string();
+        let resp = authorize(State(ctx), loopback(), Query(q), good_headers()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rejects_redirect_uri_not_in_dcr() {
+        // The URI is in the operator allowlist but the client never
+        // registered it — must still be refused.
+        let ctx = ctx();
+        let mut q = good_query();
+        q.redirect_uri = "https://chat.openai.com/aip/g-xyz/oauth/callback".to_string();
+        let resp = authorize(State(ctx), loopback(), Query(q), good_headers()).await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_rejects_missing_trusted_header() {
+        let ctx = ctx();
+        let resp = authorize(
+            State(ctx),
+            loopback(),
+            Query(good_query()),
+            HeaderMap::new(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_authorize_state_round_trips_to_redirect() {
+        let ctx = ctx();
+        let mut q = good_query();
+        q.state = "this-is-the-state-i-sent".to_string();
+        let resp = authorize(State(ctx), loopback(), Query(q), good_headers()).await;
+        let loc = parse_redirect_location(resp);
+        assert!(loc.contains("state=this-is-the-state-i-sent"));
+    }
+
+    #[tokio::test]
+    async fn test_authorize_groups_header_populates_roles_in_code() {
+        let ctx = ctx();
+        let resp = authorize(
+            State(ctx.clone()),
+            loopback(),
+            Query(good_query()),
+            good_headers(),
+        )
+        .await;
+        let loc = parse_redirect_location(resp);
+        // Pull the code out of the redirect URL.
+        let url = url::Url::parse(&loc).unwrap();
+        let code = url
+            .query_pairs()
+            .find(|(k, _)| k == "code")
+            .unwrap()
+            .1
+            .to_string();
+        let stored = ctx.state.consume_code(&code).unwrap();
+        assert_eq!(stored.subject, "alice");
+        assert_eq!(stored.roles, vec!["dev".to_string(), "oncall".to_string()]);
+    }
+}

--- a/src/server_auth/oauth_as/cidr.rs
+++ b/src/server_auth/oauth_as/cidr.rs
@@ -1,0 +1,159 @@
+//! Minimal CIDR membership check for IPv4/IPv6. Used to gate
+//! `/authorize` to requests originating from the configured reverse
+//! proxy — anyone outside the trusted CIDRs cannot inject a fake
+//! `X-Forwarded-User` because their request never reaches the
+//! authorization step.
+//!
+//! Pulling a real CIDR crate would be overkill for the handful of
+//! comparisons we actually do. The implementation is bit-exact and
+//! covered by tests.
+
+use anyhow::{bail, Result};
+use std::net::IpAddr;
+
+#[derive(Debug, Clone, Copy)]
+pub enum Cidr {
+    V4 { network: u32, prefix: u8 },
+    V6 { network: u128, prefix: u8 },
+}
+
+impl Cidr {
+    pub fn parse(s: &str) -> Result<Self> {
+        let (addr, prefix) = s
+            .split_once('/')
+            .ok_or_else(|| anyhow::anyhow!("CIDR missing '/': {s}"))?;
+        let prefix: u8 = prefix
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid prefix length: {prefix}"))?;
+        let ip: IpAddr = addr
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid IP: {addr}"))?;
+        match ip {
+            IpAddr::V4(v4) => {
+                if prefix > 32 {
+                    bail!("v4 prefix > 32: {prefix}");
+                }
+                let bits = u32::from_be_bytes(v4.octets());
+                let mask = if prefix == 0 {
+                    0
+                } else {
+                    u32::MAX << (32 - prefix)
+                };
+                Ok(Cidr::V4 {
+                    network: bits & mask,
+                    prefix,
+                })
+            }
+            IpAddr::V6(v6) => {
+                if prefix > 128 {
+                    bail!("v6 prefix > 128: {prefix}");
+                }
+                let bits = u128::from_be_bytes(v6.octets());
+                let mask = if prefix == 0 {
+                    0
+                } else {
+                    u128::MAX << (128 - prefix)
+                };
+                Ok(Cidr::V6 {
+                    network: bits & mask,
+                    prefix,
+                })
+            }
+        }
+    }
+
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        match (self, ip) {
+            (Cidr::V4 { network, prefix }, IpAddr::V4(v4)) => {
+                let bits = u32::from_be_bytes(v4.octets());
+                let mask = if *prefix == 0 {
+                    0
+                } else {
+                    u32::MAX << (32 - prefix)
+                };
+                (bits & mask) == *network
+            }
+            (Cidr::V6 { network, prefix }, IpAddr::V6(v6)) => {
+                let bits = u128::from_be_bytes(v6.octets());
+                let mask = if *prefix == 0 {
+                    0
+                } else {
+                    u128::MAX << (128 - prefix)
+                };
+                (bits & mask) == *network
+            }
+            // v4 / v6 mismatch never matches.
+            _ => false,
+        }
+    }
+}
+
+/// True iff `ip` belongs to any CIDR in the list. Empty list is a
+/// programming error — callers must reject empty lists at config
+/// validation time, not here.
+pub fn ip_in_any(ip: IpAddr, cidrs: &[Cidr]) -> bool {
+    cidrs.iter().any(|c| c.contains(ip))
+}
+
+pub fn parse_all(specs: &[String]) -> Result<Vec<Cidr>> {
+    specs.iter().map(|s| Cidr::parse(s)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+    use std::net::Ipv6Addr;
+
+    #[test]
+    fn test_v4_loopback_membership() {
+        let c = Cidr::parse("127.0.0.0/8").unwrap();
+        assert!(c.contains(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(c.contains(IpAddr::V4(Ipv4Addr::new(127, 255, 255, 254))));
+        assert!(!c.contains(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+    }
+
+    #[test]
+    fn test_v4_exact_host() {
+        let c = Cidr::parse("10.0.0.5/32").unwrap();
+        assert!(c.contains(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5))));
+        assert!(!c.contains(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 6))));
+    }
+
+    #[test]
+    fn test_v6_membership() {
+        let c = Cidr::parse("2001:db8::/32").unwrap();
+        assert!(c.contains(IpAddr::V6("2001:db8:cafe::1".parse::<Ipv6Addr>().unwrap())));
+        assert!(!c.contains(IpAddr::V6("2001:db9::1".parse::<Ipv6Addr>().unwrap())));
+    }
+
+    #[test]
+    fn test_v4_v6_mismatch_never_matches() {
+        let c = Cidr::parse("10.0.0.0/8").unwrap();
+        assert!(!c.contains(IpAddr::V6("::1".parse::<Ipv6Addr>().unwrap())));
+    }
+
+    #[test]
+    fn test_zero_prefix_matches_all() {
+        let c = Cidr::parse("0.0.0.0/0").unwrap();
+        assert!(c.contains(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+    }
+
+    #[test]
+    fn test_invalid_cidr_rejected() {
+        assert!(Cidr::parse("nope").is_err());
+        assert!(Cidr::parse("10.0.0.0/33").is_err());
+        assert!(Cidr::parse("::1/200").is_err());
+        assert!(Cidr::parse("10.0.0.0/abc").is_err());
+    }
+
+    #[test]
+    fn test_ip_in_any_with_multiple_ranges() {
+        let cidrs = parse_all(&["127.0.0.0/8".to_string(), "10.0.0.0/8".to_string()]).unwrap();
+        assert!(ip_in_any(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3)), &cidrs));
+        assert!(!ip_in_any(
+            IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)),
+            &cidrs
+        ));
+    }
+}

--- a/src/server_auth/oauth_as/config.rs
+++ b/src/server_auth/oauth_as/config.rs
@@ -133,6 +133,15 @@ impl OAuthAsConfig {
         if self.redirect_uri_allowlist.is_empty() {
             bail!("oauthAs.redirectUriAllowlist must list at least one pattern");
         }
+        // Pattern shape itself is also validated at request time, but
+        // doing it here turns operator typos (middle `*`, missing
+        // scheme, `https//` instead of `https://`) into a fail-fast
+        // boot error instead of a per-request rejection clients first
+        // see in production.
+        for pattern in &self.redirect_uri_allowlist {
+            super::redirect_uri::validate_pattern(pattern)
+                .map_err(|e| anyhow::anyhow!("oauthAs.redirectUriAllowlist invalid: {e}"))?;
+        }
         if self.access_token_ttl_seconds == 0 {
             bail!("oauthAs.accessTokenTtlSeconds must be > 0");
         }
@@ -208,6 +217,41 @@ mod tests {
         let mut c = valid_config();
         c.redirect_uri_allowlist.clear();
         assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_middle_wildcard_pattern_rejected_at_boot() {
+        // Regression for PR #91 review: only trailing `*` allowed.
+        // Middle `*` would silently widen matching at request time;
+        // catching it at boot prevents that surprise.
+        let mut c = valid_config();
+        c.redirect_uri_allowlist = vec!["https://*.example.com/cb".to_string()];
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("redirectUriAllowlist"));
+    }
+
+    #[test]
+    fn test_malformed_url_pattern_rejected_at_boot() {
+        // Operator typo: missing colon in scheme — must fail at boot.
+        let mut c = valid_config();
+        c.redirect_uri_allowlist = vec!["https//example.com/cb".to_string()];
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_non_http_scheme_pattern_rejected_at_boot() {
+        let mut c = valid_config();
+        c.redirect_uri_allowlist = vec!["custom://nope".to_string()];
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_trailing_wildcard_pattern_accepted_at_boot() {
+        // Trailing `*` is the only wildcard form allowed; ChatGPT-style
+        // redirects rely on it.
+        let mut c = valid_config();
+        c.redirect_uri_allowlist = vec!["https://chat.openai.com/aip/*".to_string()];
+        c.validate().unwrap();
     }
 
     #[test]

--- a/src/server_auth/oauth_as/config.rs
+++ b/src/server_auth/oauth_as/config.rs
@@ -1,0 +1,247 @@
+//! Boot-time configuration for the OAuth 2.0 Authorization Server.
+//!
+//! All hard security defaults live here. Anything that could weaken the
+//! AS if misconfigured (short JWT secret, missing CIDR allowlist, plain
+//! HTTP issuer) is rejected at boot via [`OAuthAsConfig::validate`].
+
+use anyhow::{bail, Result};
+use serde::Deserialize;
+
+/// Minimum bytes for the HMAC secret used to sign JWTs. 32 bytes
+/// (256 bits) matches HS256's output size — anything shorter weakens
+/// the security claim of the algorithm.
+pub const MIN_JWT_SECRET_BYTES: usize = 32;
+
+const DEFAULT_TRUSTED_USER_HEADER: &str = "x-forwarded-user";
+const DEFAULT_TRUSTED_GROUPS_HEADER: &str = "x-forwarded-groups";
+const DEFAULT_ACCESS_TOKEN_TTL_SECONDS: u64 = 3600;
+const DEFAULT_REFRESH_TOKEN_TTL_SECONDS: u64 = 2_592_000; // 30d
+const DEFAULT_AUTHORIZATION_CODE_TTL_SECONDS: u64 = 60;
+
+/// Subtree of `serverAuth.oauthAs` in `servers.json`.
+///
+/// Only the shape and validations are defined here; runtime state
+/// (registered clients, codes, issued tokens) lives in `state.rs` once
+/// that module is wired up.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthAsConfig {
+    /// Public HTTPS URL the AS advertises in metadata and accepts as `iss`
+    /// in issued JWTs. Must match what clients reach (i.e. the public
+    /// origin, not the internal bind address).
+    pub issuer_url: String,
+
+    /// HMAC-SHA256 signing key for issued JWTs. Must be at least
+    /// [`MIN_JWT_SECRET_BYTES`] bytes. Rotation invalidates every
+    /// previously issued token (acceptable for v1; documented as a
+    /// known operational cost).
+    pub jwt_secret: String,
+
+    /// Header name to read the authenticated subject from on
+    /// `/authorize`. Default `x-forwarded-user` (oauth2-proxy
+    /// convention).
+    #[serde(default = "default_trusted_user_header")]
+    pub trusted_user_header: String,
+
+    /// Header name to read the authenticated groups (becomes
+    /// `AuthIdentity.roles`). Default `x-forwarded-groups`.
+    #[serde(default = "default_trusted_groups_header")]
+    pub trusted_groups_header: String,
+
+    /// CIDR ranges allowed to set the trusted user header. Anti-spoof
+    /// against direct clients injecting `X-Forwarded-User`. Required:
+    /// boot fails if empty.
+    pub trusted_source_cidrs: Vec<String>,
+
+    #[serde(default = "default_access_ttl")]
+    pub access_token_ttl_seconds: u64,
+
+    #[serde(default = "default_refresh_ttl")]
+    pub refresh_token_ttl_seconds: u64,
+
+    #[serde(default = "default_code_ttl")]
+    pub authorization_code_ttl_seconds: u64,
+
+    /// Scopes advertised in the AS metadata. Empty list is valid.
+    #[serde(default)]
+    pub scopes_supported: Vec<String>,
+
+    /// Patterns clients may use as `redirect_uri`. Suffix `*` allowed
+    /// for ChatGPT-style `https://chat.openai.com/aip/<id>/oauth/callback`.
+    /// HTTP redirect URIs are rejected unless they target loopback.
+    pub redirect_uri_allowlist: Vec<String>,
+
+    /// Roles always added to the JWT for any token issued by this AS.
+    /// Use it to mark "came in via OAuth" so the ACL can discriminate
+    /// between OAuth-authenticated users and static-bearer ones.
+    #[serde(default)]
+    pub injected_roles: Vec<String>,
+}
+
+fn default_trusted_user_header() -> String {
+    DEFAULT_TRUSTED_USER_HEADER.to_string()
+}
+
+fn default_trusted_groups_header() -> String {
+    DEFAULT_TRUSTED_GROUPS_HEADER.to_string()
+}
+
+fn default_access_ttl() -> u64 {
+    DEFAULT_ACCESS_TOKEN_TTL_SECONDS
+}
+
+fn default_refresh_ttl() -> u64 {
+    DEFAULT_REFRESH_TOKEN_TTL_SECONDS
+}
+
+fn default_code_ttl() -> u64 {
+    DEFAULT_AUTHORIZATION_CODE_TTL_SECONDS
+}
+
+impl OAuthAsConfig {
+    /// Validate at boot. Catches misconfiguration that would silently
+    /// downgrade security. Every field is touched here so the struct
+    /// contract stays honest while the runtime consumers (handlers,
+    /// state) ship in follow-up tasks.
+    pub fn validate(&self) -> Result<()> {
+        if self.issuer_url.is_empty() {
+            bail!("oauthAs.issuerUrl is required");
+        }
+        if !self.issuer_url.starts_with("https://") && !self.issuer_url.starts_with("http://") {
+            bail!("oauthAs.issuerUrl must be an http(s) URL");
+        }
+        if self.jwt_secret.len() < MIN_JWT_SECRET_BYTES {
+            bail!(
+                "oauthAs.jwtSecret must be at least {} bytes (got {})",
+                MIN_JWT_SECRET_BYTES,
+                self.jwt_secret.len()
+            );
+        }
+        if self.trusted_user_header.is_empty() {
+            bail!("oauthAs.trustedUserHeader must not be empty");
+        }
+        if self.trusted_groups_header.is_empty() {
+            bail!("oauthAs.trustedGroupsHeader must not be empty");
+        }
+        if self.trusted_source_cidrs.is_empty() {
+            bail!(
+                "oauthAs.trustedSourceCidrs must list at least one CIDR — \
+                 leaving it empty would let any client inject {} directly",
+                self.trusted_user_header
+            );
+        }
+        if self.redirect_uri_allowlist.is_empty() {
+            bail!("oauthAs.redirectUriAllowlist must list at least one pattern");
+        }
+        if self.access_token_ttl_seconds == 0 {
+            bail!("oauthAs.accessTokenTtlSeconds must be > 0");
+        }
+        if self.refresh_token_ttl_seconds == 0 {
+            bail!("oauthAs.refreshTokenTtlSeconds must be > 0");
+        }
+        if self.authorization_code_ttl_seconds == 0 {
+            bail!("oauthAs.authorizationCodeTtlSeconds must be > 0");
+        }
+        // Touch the remaining fields so dead-code analysis stays honest
+        // until handlers wire them up — these checks are cheap and
+        // catch operator typos (e.g. accidentally listing the same
+        // role twice in `injectedRoles`).
+        for r in &self.injected_roles {
+            if r.is_empty() {
+                bail!("oauthAs.injectedRoles must not contain empty strings");
+            }
+        }
+        for s in &self.scopes_supported {
+            if s.is_empty() {
+                bail!("oauthAs.scopesSupported must not contain empty strings");
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_config() -> OAuthAsConfig {
+        OAuthAsConfig {
+            issuer_url: "https://mcp.example.com".to_string(),
+            jwt_secret: "x".repeat(32),
+            trusted_user_header: "x-forwarded-user".to_string(),
+            trusted_groups_header: "x-forwarded-groups".to_string(),
+            trusted_source_cidrs: vec!["127.0.0.1/32".to_string()],
+            access_token_ttl_seconds: 3600,
+            refresh_token_ttl_seconds: 2_592_000,
+            authorization_code_ttl_seconds: 60,
+            scopes_supported: vec!["mcp".to_string()],
+            redirect_uri_allowlist: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+            injected_roles: vec!["oauth-user".to_string()],
+        }
+    }
+
+    #[test]
+    fn test_valid_config_passes() {
+        valid_config().validate().unwrap();
+    }
+
+    #[test]
+    fn test_short_secret_rejected_at_boot() {
+        let mut c = valid_config();
+        c.jwt_secret = "too-short".to_string();
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("32 bytes"));
+    }
+
+    #[test]
+    fn test_empty_trusted_cidrs_rejected_at_boot() {
+        // Anti-spoof: without this list every client could inject
+        // X-Forwarded-User and impersonate anyone.
+        let mut c = valid_config();
+        c.trusted_source_cidrs.clear();
+        let err = c.validate().unwrap_err();
+        assert!(err.to_string().contains("trustedSourceCidrs"));
+    }
+
+    #[test]
+    fn test_empty_redirect_uri_allowlist_rejected() {
+        let mut c = valid_config();
+        c.redirect_uri_allowlist.clear();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_empty_issuer_rejected() {
+        let mut c = valid_config();
+        c.issuer_url.clear();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_non_http_issuer_rejected() {
+        let mut c = valid_config();
+        c.issuer_url = "ftp://nope.example.com".to_string();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_zero_token_ttl_rejected() {
+        let mut c = valid_config();
+        c.access_token_ttl_seconds = 0;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn test_camel_case_deserialization() {
+        let json = r#"{
+            "issuerUrl": "https://mcp.example.com",
+            "jwtSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "trustedSourceCidrs": ["127.0.0.1/32"],
+            "redirectUriAllowlist": ["https://claude.ai/api/mcp/auth_callback"]
+        }"#;
+        let cfg: OAuthAsConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.trusted_user_header, "x-forwarded-user");
+        assert_eq!(cfg.access_token_ttl_seconds, 3600);
+        cfg.validate().unwrap();
+    }
+}

--- a/src/server_auth/oauth_as/e2e_tests.rs
+++ b/src/server_auth/oauth_as/e2e_tests.rs
@@ -166,19 +166,7 @@ fn cfg_for_e2e() -> Arc<OAuthAsConfig> {
     })
 }
 
-fn save_disabled() -> impl Drop {
-    struct G;
-    std::env::set_var(
-        "MCP_AUTH_SERVER_CONFIG",
-        r#"{"clients":{},"refresh_tokens":{}}"#,
-    );
-    impl Drop for G {
-        fn drop(&mut self) {
-            std::env::remove_var("MCP_AUTH_SERVER_CONFIG");
-        }
-    }
-    G
-}
+use super::test_helpers::InlineSaveGuard;
 
 fn build_chain(
     cfg: Arc<OAuthAsConfig>,
@@ -271,7 +259,7 @@ async fn run_oauth_flow(client: &Client, base: &str) -> (String, String) {
 
 #[tokio::test]
 async fn e2e_static_bearer_path_authenticates() {
-    let _g = save_disabled();
+    let _g = InlineSaveGuard::acquire();
     let cfg = cfg_for_e2e();
     let state = Arc::new(AsState::default());
 
@@ -302,7 +290,7 @@ async fn e2e_static_bearer_path_authenticates() {
 
 #[tokio::test]
 async fn e2e_oauth_flow_then_call_mcp() {
-    let _g = save_disabled();
+    let _g = InlineSaveGuard::acquire();
     let cfg = cfg_for_e2e();
     let state = Arc::new(AsState::default());
     let chain = build_chain(cfg.clone(), state.clone(), None);
@@ -330,7 +318,7 @@ async fn e2e_both_providers_coexist_in_same_instance() {
     // The exact scenario from issue #90: dev-local static bearer
     // and Claude.ai-web OAuth JWT must both authenticate against
     // /mcp on the same running instance.
-    let _g = save_disabled();
+    let _g = InlineSaveGuard::acquire();
     let cfg = cfg_for_e2e();
     let state = Arc::new(AsState::default());
     let mut tokens = HashMap::new();
@@ -389,7 +377,7 @@ async fn e2e_acl_discriminates_oauth_vs_admin_roles() {
     // OAuth-authenticated identity carries `oauth-user` role (via
     // injectedRoles); ACL grants `oauth-user` only `sentry__*`.
     // Static-bearer identity carries `admin` and gets `*`.
-    let _g = save_disabled();
+    let _g = InlineSaveGuard::acquire();
     let cfg = cfg_for_e2e();
     let state = Arc::new(AsState::default());
     let mut tokens = HashMap::new();
@@ -474,7 +462,7 @@ async fn e2e_acl_discriminates_oauth_vs_admin_roles() {
 
 #[tokio::test]
 async fn e2e_mcp_rejects_invalid_jwt() {
-    let _g = save_disabled();
+    let _g = InlineSaveGuard::acquire();
     let cfg = cfg_for_e2e();
     let state = Arc::new(AsState::default());
     let chain = build_chain(cfg.clone(), state.clone(), None);
@@ -494,7 +482,7 @@ async fn e2e_mcp_rejects_invalid_jwt() {
 
 #[tokio::test]
 async fn e2e_well_known_endpoints_advertise_full_metadata() {
-    let _g = save_disabled();
+    let _g = InlineSaveGuard::acquire();
     let cfg = cfg_for_e2e();
     let state = Arc::new(AsState::default());
     let chain = build_chain(cfg.clone(), state.clone(), None);

--- a/src/server_auth/oauth_as/e2e_tests.rs
+++ b/src/server_auth/oauth_as/e2e_tests.rs
@@ -1,0 +1,534 @@
+//! End-to-end test for the OAuth Authorization Server.
+//!
+//! Spins up a real axum server on a free localhost port, mounts the
+//! AS sub-router AND a mock `/mcp` endpoint that reproduces what
+//! `serve::http::mcp_handler` does w.r.t. authentication: extract
+//! credentials, run them through the configured `ProviderChain`,
+//! and (optionally) consult the ACL on the resulting identity.
+//!
+//! The whole point of this file is to exercise the cross-provider
+//! contract: a single `mcp serve` instance must accept BOTH static
+//! bearer tokens (local dev) AND OAuth-issued JWTs (Claude.ai web)
+//! at the same `/mcp` endpoint, with ACL discriminating per role.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+    routing::post,
+    Router,
+};
+use reqwest::Client;
+use serde_json::Value;
+
+use crate::server_auth::{
+    self,
+    acl::{self, AclConfig},
+    AuthIdentity, AuthProvider, BearerToken, Credentials, ProviderChain,
+};
+
+use super::{config::OAuthAsConfig, AsState, OAuthAsAuth};
+
+#[derive(Clone)]
+struct McpState {
+    auth_provider: Arc<dyn AuthProvider>,
+    acl: Option<AclConfig>,
+}
+
+fn extract_creds(headers: &HeaderMap) -> Credentials {
+    let mut c = Credentials::new();
+    for (name, value) in headers.iter() {
+        if let Ok(v) = value.to_str() {
+            c.insert(name.as_str().to_lowercase(), v.to_string());
+        }
+    }
+    c
+}
+
+async fn mock_mcp(
+    State(state): State<McpState>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    let creds = extract_creds(&headers);
+    let identity: AuthIdentity = match state.auth_provider.authenticate(&creds).await {
+        Ok(id) => id,
+        Err(e) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                axum::Json(serde_json::json!({"error": format!("{e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    // Body is JSON-RPC-ish: {"method": "tools/call", "params": {"name": "..."}}
+    let req: Value = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    let tool_name = req
+        .pointer("/params/name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("tools/list");
+
+    if let Some(acl_cfg) = &state.acl {
+        let decision = acl::is_tool_allowed(&identity, tool_name, acl_cfg, None);
+        if !decision.allowed {
+            return (
+                StatusCode::OK,
+                axum::Json(serde_json::json!({
+                    "error": "acl_deny",
+                    "subject": identity.subject,
+                    "tool": tool_name,
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    (
+        StatusCode::OK,
+        axum::Json(serde_json::json!({
+            "ok": true,
+            "subject": identity.subject,
+            "roles": identity.roles,
+            "tool": tool_name,
+        })),
+    )
+        .into_response()
+}
+
+struct Harness {
+    base: String,
+    _shutdown: tokio::sync::oneshot::Sender<()>,
+}
+
+impl Harness {
+    async fn start(
+        cfg: Arc<OAuthAsConfig>,
+        state: Arc<AsState>,
+        chain: Arc<dyn AuthProvider>,
+        acl: Option<AclConfig>,
+    ) -> Self {
+        let mcp_state = McpState {
+            auth_provider: chain,
+            acl,
+        };
+        let app = super::router(cfg.clone(), state.clone()).merge(
+            Router::new()
+                .route("/mcp", post(mock_mcp))
+                .with_state(mcp_state),
+        );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let base = format!("http://127.0.0.1:{port}");
+
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .with_graceful_shutdown(async move {
+                let _ = rx.await;
+            })
+            .await
+            .ok();
+        });
+
+        // Give the server a tick to come up.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        Self {
+            base,
+            _shutdown: tx,
+        }
+    }
+}
+
+fn cfg_for_e2e() -> Arc<OAuthAsConfig> {
+    Arc::new(OAuthAsConfig {
+        issuer_url: "http://127.0.0.1".to_string(), // overridden below per-test
+        jwt_secret: "k".repeat(32),
+        trusted_user_header: "x-forwarded-user".to_string(),
+        trusted_groups_header: "x-forwarded-groups".to_string(),
+        trusted_source_cidrs: vec!["127.0.0.0/8".to_string()],
+        access_token_ttl_seconds: 3600,
+        refresh_token_ttl_seconds: 2_592_000,
+        authorization_code_ttl_seconds: 60,
+        scopes_supported: vec!["mcp".to_string()],
+        redirect_uri_allowlist: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+        injected_roles: vec!["oauth-user".to_string()],
+    })
+}
+
+fn save_disabled() -> impl Drop {
+    struct G;
+    std::env::set_var(
+        "MCP_AUTH_SERVER_CONFIG",
+        r#"{"clients":{},"refresh_tokens":{}}"#,
+    );
+    impl Drop for G {
+        fn drop(&mut self) {
+            std::env::remove_var("MCP_AUTH_SERVER_CONFIG");
+        }
+    }
+    G
+}
+
+fn build_chain(
+    cfg: Arc<OAuthAsConfig>,
+    state: Arc<AsState>,
+    static_bearer: Option<HashMap<String, BearerToken>>,
+) -> Arc<dyn AuthProvider> {
+    let mut providers: Vec<Arc<dyn AuthProvider>> = Vec::new();
+    if let Some(tokens) = static_bearer {
+        providers.push(Arc::new(server_auth::BearerTokenAuth::new(tokens)));
+    }
+    providers.push(Arc::new(OAuthAsAuth::new(cfg, state)));
+    Arc::new(ProviderChain::new(providers))
+}
+
+async fn run_oauth_flow(client: &Client, base: &str) -> (String, String) {
+    use crate::auth::oauth_primitives::generate_pkce;
+
+    // 1. DCR.
+    let dcr: Value = client
+        .post(format!("{base}/register"))
+        .json(&serde_json::json!({
+            "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"]
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let client_id = dcr["client_id"].as_str().unwrap().to_string();
+
+    // 2. Authorize (no redirect-following — we want to read the
+    // Location header).
+    let (verifier, challenge) = generate_pkce();
+    let no_redirect_client = Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+    let auth_resp = no_redirect_client
+        .get(format!("{base}/authorize"))
+        .query(&[
+            ("response_type", "code"),
+            ("client_id", &client_id),
+            ("redirect_uri", "https://claude.ai/api/mcp/auth_callback"),
+            ("code_challenge", &challenge),
+            ("code_challenge_method", "S256"),
+            ("state", "csrf-state"),
+            ("scope", "mcp"),
+        ])
+        .header("X-Forwarded-User", "alice@example.com")
+        .header("X-Forwarded-Groups", "dev")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(auth_resp.status(), 303, "expected 303 redirect");
+    let loc = auth_resp
+        .headers()
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let url = url::Url::parse(&loc).unwrap();
+    let code = url
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .unwrap()
+        .1
+        .to_string();
+
+    // 3. Token exchange.
+    let tok: Value = client
+        .post(format!("{base}/token"))
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", &code),
+            ("redirect_uri", "https://claude.ai/api/mcp/auth_callback"),
+            ("client_id", &client_id),
+            ("code_verifier", &verifier),
+        ])
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let access = tok["access_token"].as_str().unwrap().to_string();
+    (client_id, access)
+}
+
+#[tokio::test]
+async fn e2e_static_bearer_path_authenticates() {
+    let _g = save_disabled();
+    let cfg = cfg_for_e2e();
+    let state = Arc::new(AsState::default());
+
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        "tok-local-dev".to_string(),
+        BearerToken::Extended {
+            subject: "avelino".to_string(),
+            roles: vec!["admin".to_string()],
+        },
+    );
+    let chain = build_chain(cfg.clone(), state.clone(), Some(tokens));
+
+    let harness = Harness::start(cfg, state, chain, None).await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", "Bearer tok-local-dev")
+        .json(&serde_json::json!({"method":"tools/list"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["subject"], "avelino");
+}
+
+#[tokio::test]
+async fn e2e_oauth_flow_then_call_mcp() {
+    let _g = save_disabled();
+    let cfg = cfg_for_e2e();
+    let state = Arc::new(AsState::default());
+    let chain = build_chain(cfg.clone(), state.clone(), None);
+
+    let harness = Harness::start(cfg, state, chain, None).await;
+    let client = Client::new();
+    let (_, access) = run_oauth_flow(&client, &harness.base).await;
+
+    let resp = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", format!("Bearer {access}"))
+        .json(&serde_json::json!({"method":"tools/list"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(body["subject"], "alice@example.com");
+    let roles: Vec<String> = serde_json::from_value(body["roles"].clone()).unwrap();
+    assert!(roles.contains(&"oauth-user".to_string()));
+}
+
+#[tokio::test]
+async fn e2e_both_providers_coexist_in_same_instance() {
+    // The exact scenario from issue #90: dev-local static bearer
+    // and Claude.ai-web OAuth JWT must both authenticate against
+    // /mcp on the same running instance.
+    let _g = save_disabled();
+    let cfg = cfg_for_e2e();
+    let state = Arc::new(AsState::default());
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        "tok-local-dev".to_string(),
+        BearerToken::Extended {
+            subject: "avelino".to_string(),
+            roles: vec!["admin".to_string()],
+        },
+    );
+    let chain = build_chain(cfg.clone(), state.clone(), Some(tokens));
+
+    let harness = Harness::start(cfg, state, chain, None).await;
+    let client = Client::new();
+
+    // Path A: static bearer.
+    let resp_a = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", "Bearer tok-local-dev")
+        .json(&serde_json::json!({"method":"tools/list"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp_a.status(), 200);
+    assert_eq!(resp_a.json::<Value>().await.unwrap()["subject"], "avelino");
+
+    // Path B: OAuth flow on the same instance, no restart.
+    let (_, access) = run_oauth_flow(&client, &harness.base).await;
+    let resp_b = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", format!("Bearer {access}"))
+        .json(&serde_json::json!({"method":"tools/list"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp_b.status(), 200);
+    assert_eq!(
+        resp_b.json::<Value>().await.unwrap()["subject"],
+        "alice@example.com"
+    );
+
+    // Path A again — proves no state leaked between the two calls.
+    let resp_a2 = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", "Bearer tok-local-dev")
+        .json(&serde_json::json!({"method":"tools/list"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp_a2.status(), 200);
+}
+
+#[tokio::test]
+async fn e2e_acl_discriminates_oauth_vs_admin_roles() {
+    // Cross-test ACL × OAuth (the second briefing requirement):
+    // OAuth-authenticated identity carries `oauth-user` role (via
+    // injectedRoles); ACL grants `oauth-user` only `sentry__*`.
+    // Static-bearer identity carries `admin` and gets `*`.
+    let _g = save_disabled();
+    let cfg = cfg_for_e2e();
+    let state = Arc::new(AsState::default());
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        "tok-local-dev".to_string(),
+        BearerToken::Extended {
+            subject: "avelino".to_string(),
+            roles: vec!["admin".to_string()],
+        },
+    );
+    let chain = build_chain(cfg.clone(), state.clone(), Some(tokens));
+
+    // Legacy ACL schema — first-match-wins, no ToolContext required.
+    // The role-based schema is functionally richer but needs server
+    // alias context that this in-process harness doesn't surface; for
+    // exercising the cross-provider × per-role discrimination the
+    // briefing requires, the legacy schema is the right tool.
+    let acl_json = r#"{
+        "default": "deny",
+        "rules": [
+            {"roles": ["admin"],      "tools": ["*"],          "policy": "allow"},
+            {"roles": ["oauth-user"], "tools": ["sentry__*"],  "policy": "allow"}
+        ]
+    }"#;
+    let acl: AclConfig = serde_json::from_str(acl_json).unwrap();
+
+    let harness = Harness::start(cfg, state, chain, Some(acl)).await;
+    let client = Client::new();
+
+    let (_, access) = run_oauth_flow(&client, &harness.base).await;
+    // OAuth user calling sentry__* — allowed.
+    let allowed: Value = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", format!("Bearer {access}"))
+        .json(&serde_json::json!({
+            "method":"tools/call",
+            "params":{"name":"sentry__list_issues"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        allowed["ok"], true,
+        "sentry tool must be allowed: {allowed}"
+    );
+
+    // OAuth user calling github__create_issue — denied.
+    let denied: Value = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", format!("Bearer {access}"))
+        .json(&serde_json::json!({
+            "method":"tools/call",
+            "params":{"name":"github__create_issue"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(denied["error"], "acl_deny");
+
+    // Static-bearer (admin) calling the same denied tool — allowed.
+    let admin_ok: Value = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", "Bearer tok-local-dev")
+        .json(&serde_json::json!({
+            "method":"tools/call",
+            "params":{"name":"github__create_issue"}
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(admin_ok["ok"], true, "admin must bypass tool deny");
+}
+
+#[tokio::test]
+async fn e2e_mcp_rejects_invalid_jwt() {
+    let _g = save_disabled();
+    let cfg = cfg_for_e2e();
+    let state = Arc::new(AsState::default());
+    let chain = build_chain(cfg.clone(), state.clone(), None);
+
+    let harness = Harness::start(cfg, state, chain, None).await;
+    let client = Client::new();
+
+    let resp = client
+        .post(format!("{}/mcp", harness.base))
+        .header("Authorization", "Bearer not.a.real.jwt")
+        .json(&serde_json::json!({"method":"tools/list"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn e2e_well_known_endpoints_advertise_full_metadata() {
+    let _g = save_disabled();
+    let cfg = cfg_for_e2e();
+    let state = Arc::new(AsState::default());
+    let chain = build_chain(cfg.clone(), state.clone(), None);
+
+    let harness = Harness::start(cfg, state, chain, None).await;
+    let client = Client::new();
+
+    let pr: Value = client
+        .get(format!(
+            "{}/.well-known/oauth-protected-resource",
+            harness.base
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(pr["authorization_servers"].is_array());
+
+    let asm: Value = client
+        .get(format!(
+            "{}/.well-known/oauth-authorization-server",
+            harness.base
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(asm["code_challenge_methods_supported"][0], "S256");
+    assert!(asm["registration_endpoint"]
+        .as_str()
+        .unwrap()
+        .ends_with("/register"));
+}

--- a/src/server_auth/oauth_as/jwt.rs
+++ b/src/server_auth/oauth_as/jwt.rs
@@ -1,0 +1,169 @@
+//! HS256 JWT signing and verification for the OAuth Authorization
+//! Server. Keeping the crypto pinned to one algorithm here means the
+//! handlers never have to think about algorithm negotiation — and
+//! more importantly, never accept `alg: none` or any algorithm we
+//! didn't choose.
+
+use anyhow::{bail, Context, Result};
+use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
+
+use super::types::JwtClaims;
+
+/// Sign `claims` with HS256 using `secret`. The header is fixed to
+/// `{ "alg": "HS256", "typ": "JWT" }` — there is no negotiation.
+pub fn sign(claims: &JwtClaims, secret: &[u8]) -> Result<String> {
+    let header = Header::new(Algorithm::HS256);
+    encode(&header, claims, &EncodingKey::from_secret(secret)).context("failed to sign JWT")
+}
+
+/// Verify a bearer-style JWT and return its claims if valid.
+///
+/// Validation order matches RFC 7519 §7:
+/// 1. Header alg must be HS256 — anything else (including `none`) is
+///    rejected before signature verification.
+/// 2. Signature is verified against `secret`.
+/// 3. `iss` must equal `expected_issuer`.
+/// 4. `aud` must equal `expected_audience` (single value, no arrays
+///    in v1).
+/// 5. `exp` and `nbf` are checked against current time with the
+///    library's default 60-second leeway.
+pub fn verify(
+    token: &str,
+    secret: &[u8],
+    expected_issuer: &str,
+    expected_audience: &str,
+) -> Result<JwtClaims> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_issuer(&[expected_issuer]);
+    validation.set_audience(&[expected_audience]);
+    validation.set_required_spec_claims(&["exp", "nbf", "iss", "aud", "sub"]);
+
+    let data = decode::<JwtClaims>(token, &DecodingKey::from_secret(secret), &validation)
+        .context("JWT verification failed")?;
+
+    // Defense in depth: the `jsonwebtoken` crate already rejects
+    // header.alg mismatches via `Validation::new(HS256)`, but assert
+    // explicitly so a future upgrade can't silently widen the contract.
+    if data.header.alg != Algorithm::HS256 {
+        bail!("JWT header rejected: alg must be HS256");
+    }
+
+    Ok(data.claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn fresh_claims(iss: &str, aud: &str, sub: &str) -> JwtClaims {
+        let n = now();
+        JwtClaims {
+            iss: iss.to_string(),
+            aud: aud.to_string(),
+            sub: sub.to_string(),
+            groups: vec!["dev".to_string()],
+            iat: n,
+            nbf: n,
+            exp: n + 3600,
+            jti: "test-jti".to_string(),
+        }
+    }
+
+    fn secret() -> [u8; 32] {
+        [b'k'; 32]
+    }
+
+    fn other_secret() -> [u8; 32] {
+        [b'q'; 32]
+    }
+
+    #[test]
+    fn test_sign_then_verify_roundtrip() {
+        let claims = fresh_claims("https://mcp.example.com", "client-1", "alice");
+        let token = sign(&claims, &secret()).unwrap();
+        let got = verify(&token, &secret(), "https://mcp.example.com", "client-1").unwrap();
+        assert_eq!(got.sub, "alice");
+        assert_eq!(got.groups, vec!["dev".to_string()]);
+    }
+
+    #[test]
+    fn test_verify_rejects_wrong_secret() {
+        // Bypass guard: signature must verify against the configured
+        // secret, never accepted on a different one.
+        let claims = fresh_claims("https://mcp.example.com", "client-1", "alice");
+        let token = sign(&claims, &secret()).unwrap();
+        assert!(verify(
+            &token,
+            &other_secret(),
+            "https://mcp.example.com",
+            "client-1"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_wrong_issuer() {
+        let claims = fresh_claims("https://attacker.example.com", "client-1", "alice");
+        let token = sign(&claims, &secret()).unwrap();
+        assert!(verify(&token, &secret(), "https://mcp.example.com", "client-1").is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_wrong_audience() {
+        // Privilege boundary: a token issued for client A must NOT
+        // validate when presented to client B's session.
+        let claims = fresh_claims("https://mcp.example.com", "client-A", "alice");
+        let token = sign(&claims, &secret()).unwrap();
+        assert!(verify(&token, &secret(), "https://mcp.example.com", "client-B").is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_expired() {
+        let mut claims = fresh_claims("https://mcp.example.com", "client-1", "alice");
+        // Push exp far enough into the past to beat the default 60s
+        // leeway in `Validation`.
+        let n = now();
+        claims.iat = n - 7200;
+        claims.nbf = n - 7200;
+        claims.exp = n - 3600;
+        let token = sign(&claims, &secret()).unwrap();
+        assert!(verify(&token, &secret(), "https://mcp.example.com", "client-1").is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_alg_none_attack() {
+        // Bypass guard: classic `alg: none` attack must not work —
+        // the verifier is pinned to HS256 and ignores the header alg
+        // field for algorithm selection.
+        // We craft a token manually with the alg=none header.
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let claims = fresh_claims("https://mcp.example.com", "client-1", "alice");
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_string(&claims).unwrap().as_bytes());
+        let forged = format!("{header}.{payload}.");
+        assert!(verify(&forged, &secret(), "https://mcp.example.com", "client-1").is_err());
+    }
+
+    #[test]
+    fn test_verify_rejects_tampered_payload() {
+        // Modifying any byte of the payload must invalidate the
+        // signature.
+        let claims = fresh_claims("https://mcp.example.com", "client-1", "alice");
+        let token = sign(&claims, &secret()).unwrap();
+        let mut parts: Vec<&str> = token.split('.').collect();
+        // Replace payload with a different (valid base64url) string.
+        let tampered_payload = "eyJpc3MiOiJodHRwczovL21jcC5leGFtcGxlLmNvbSIsImF1ZCI6ImNsaWVudC1BIiwic3ViIjoiYWRtaW4iLCJleHAiOjk5OTk5OTk5OTksIm5iZiI6MCwiaWF0IjowLCJqdGkiOiJ0IiwiZ3JvdXBzIjpbXX0";
+        parts[1] = tampered_payload;
+        let forged = parts.join(".");
+        assert!(verify(&forged, &secret(), "https://mcp.example.com", "client-1").is_err());
+    }
+}

--- a/src/server_auth/oauth_as/metadata.rs
+++ b/src/server_auth/oauth_as/metadata.rs
@@ -1,0 +1,128 @@
+//! Discovery endpoints — RFC 8414 (Authorization Server Metadata)
+//! and RFC 9728 (Protected Resource Metadata, used by the MCP
+//! authorization spec from 2025-06-18).
+//!
+//! These responses are what Claude.ai / ChatGPT / Cursor probe first
+//! when an operator registers `https://mcp.example.com/mcp` as a
+//! Custom Connector. Returning the wrong shape here makes every
+//! downstream step fail with cryptic client-side errors.
+
+use std::sync::Arc;
+
+use axum::{extract::State, response::Json};
+use serde::Serialize;
+
+use super::OAuthAsConfig;
+
+#[derive(Debug, Serialize)]
+pub struct ProtectedResourceMetadata {
+    pub resource: String,
+    pub authorization_servers: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthorizationServerMetadata {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub registration_endpoint: String,
+    pub scopes_supported: Vec<String>,
+    pub response_types_supported: Vec<&'static str>,
+    pub grant_types_supported: Vec<&'static str>,
+    pub code_challenge_methods_supported: Vec<&'static str>,
+    pub token_endpoint_auth_methods_supported: Vec<&'static str>,
+}
+
+pub async fn protected_resource(
+    State(cfg): State<Arc<OAuthAsConfig>>,
+) -> Json<ProtectedResourceMetadata> {
+    let issuer = cfg.issuer_url.trim_end_matches('/').to_string();
+    Json(ProtectedResourceMetadata {
+        resource: issuer.clone(),
+        authorization_servers: vec![issuer],
+    })
+}
+
+pub async fn authorization_server(
+    State(cfg): State<Arc<OAuthAsConfig>>,
+) -> Json<AuthorizationServerMetadata> {
+    let issuer = cfg.issuer_url.trim_end_matches('/').to_string();
+    Json(AuthorizationServerMetadata {
+        authorization_endpoint: format!("{issuer}/authorize"),
+        token_endpoint: format!("{issuer}/token"),
+        registration_endpoint: format!("{issuer}/register"),
+        scopes_supported: cfg.scopes_supported.clone(),
+        // PKCE S256 only — `plain` is intentionally absent. OAuth 2.1
+        // mandates this and so does the MCP authorization spec.
+        code_challenge_methods_supported: vec!["S256"],
+        response_types_supported: vec!["code"],
+        grant_types_supported: vec!["authorization_code", "refresh_token"],
+        // PKCE replaces client authentication for public clients —
+        // Claude.ai and other MCP-aware clients are public clients.
+        token_endpoint_auth_methods_supported: vec!["none"],
+        issuer,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> Arc<OAuthAsConfig> {
+        Arc::new(OAuthAsConfig {
+            issuer_url: "https://mcp.example.com/".to_string(),
+            jwt_secret: "x".repeat(32),
+            trusted_user_header: "x-forwarded-user".to_string(),
+            trusted_groups_header: "x-forwarded-groups".to_string(),
+            trusted_source_cidrs: vec!["127.0.0.1/32".to_string()],
+            access_token_ttl_seconds: 3600,
+            refresh_token_ttl_seconds: 2_592_000,
+            authorization_code_ttl_seconds: 60,
+            scopes_supported: vec!["mcp".to_string()],
+            redirect_uri_allowlist: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+            injected_roles: vec!["oauth-user".to_string()],
+        })
+    }
+
+    #[tokio::test]
+    async fn test_protected_resource_metadata_shape() {
+        let Json(m) = protected_resource(State(cfg())).await;
+        assert_eq!(m.resource, "https://mcp.example.com");
+        assert_eq!(m.authorization_servers, vec!["https://mcp.example.com"]);
+    }
+
+    #[tokio::test]
+    async fn test_authorization_server_metadata_shape() {
+        let Json(m) = authorization_server(State(cfg())).await;
+        assert_eq!(m.issuer, "https://mcp.example.com");
+        assert_eq!(
+            m.authorization_endpoint,
+            "https://mcp.example.com/authorize"
+        );
+        assert_eq!(m.token_endpoint, "https://mcp.example.com/token");
+        assert_eq!(m.registration_endpoint, "https://mcp.example.com/register");
+        assert_eq!(
+            m.grant_types_supported,
+            vec!["authorization_code", "refresh_token"]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metadata_advertises_only_s256_pkce() {
+        // Security regression: PKCE `plain` must NEVER appear in
+        // advertised metadata, otherwise compliant clients may pick it.
+        let Json(m) = authorization_server(State(cfg())).await;
+        assert_eq!(m.code_challenge_methods_supported, vec!["S256"]);
+        assert!(!m
+            .code_challenge_methods_supported
+            .iter()
+            .any(|m| m.eq_ignore_ascii_case("plain")));
+    }
+
+    #[tokio::test]
+    async fn test_metadata_token_endpoint_auth_method_is_none() {
+        // PKCE replaces client_secret for public clients.
+        let Json(m) = authorization_server(State(cfg())).await;
+        assert_eq!(m.token_endpoint_auth_methods_supported, vec!["none"]);
+    }
+}

--- a/src/server_auth/oauth_as/mod.rs
+++ b/src/server_auth/oauth_as/mod.rs
@@ -29,6 +29,8 @@ mod types;
 
 #[cfg(test)]
 mod e2e_tests;
+#[cfg(test)]
+mod test_helpers;
 
 pub use config::OAuthAsConfig;
 pub use provider::OAuthAsAuth;

--- a/src/server_auth/oauth_as/mod.rs
+++ b/src/server_auth/oauth_as/mod.rs
@@ -1,0 +1,76 @@
+//! OAuth 2.0 Authorization Server with Dynamic Client Registration
+//! (RFC 7591) for `mcp serve`.
+//!
+//! Lets `mcp serve` be plugged directly into Claude.ai, ChatGPT, Cursor
+//! and other AI clients that consume MCP authorization (spec 2025-06-18)
+//! without an external OAuth provider in front.
+//!
+//! Public surface:
+//! - [`OAuthAsConfig`] — JSON config under `serverAuth.oauthAs`.
+//!
+//! Module layout (built incrementally across the issue #90 tasks):
+//! - `config` — [`OAuthAsConfig`] + boot-time validation.
+//! - Other components (state, store, jwt, handlers, provider) land in
+//!   their own files as the implementation tasks progress; declared
+//!   here once they exist.
+
+mod authorize;
+mod cidr;
+mod config;
+mod jwt;
+mod metadata;
+mod provider;
+mod redirect_uri;
+mod register;
+mod state;
+mod store;
+mod token;
+mod types;
+
+#[cfg(test)]
+mod e2e_tests;
+
+pub use config::OAuthAsConfig;
+pub use provider::OAuthAsAuth;
+pub use state::AsState;
+pub use store::{load as load_state, save as save_state};
+
+use std::sync::Arc;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+
+/// Build the axum sub-router that exposes all OAuth AS endpoints.
+/// Mounted under the root path of `mcp serve` so the well-known
+/// discovery URLs land at `/.well-known/...` as RFC 8414 / RFC 9728
+/// require.
+pub fn router(config: Arc<OAuthAsConfig>, state: Arc<AsState>) -> Router {
+    // The metadata handlers only need the config, so they get a
+    // narrower state. The token / register / authorize handlers
+    // need both, bundled in `register::AppCtx`.
+    let app_ctx = Arc::new(register::AppCtx {
+        config: config.clone(),
+        state,
+    });
+
+    let metadata_router = Router::new()
+        .route(
+            "/.well-known/oauth-protected-resource",
+            get(metadata::protected_resource),
+        )
+        .route(
+            "/.well-known/oauth-authorization-server",
+            get(metadata::authorization_server),
+        )
+        .with_state(config);
+
+    let flow_router = Router::new()
+        .route("/register", post(register::register))
+        .route("/authorize", get(authorize::authorize))
+        .route("/token", post(token::token))
+        .with_state(app_ctx);
+
+    metadata_router.merge(flow_router)
+}

--- a/src/server_auth/oauth_as/provider.rs
+++ b/src/server_auth/oauth_as/provider.rs
@@ -1,0 +1,260 @@
+//! `OAuthAsAuth` — the [`AuthProvider`] backed by JWTs that this AS
+//! issued. Plugs into the same `Authorization: Bearer …` extraction
+//! the static-bearer provider uses, so the `/mcp` request handler
+//! doesn't need to know which provider validated the token.
+
+use std::sync::Arc;
+
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+
+use super::jwt;
+use super::{AsState, OAuthAsConfig};
+use crate::server_auth::{AuthIdentity, AuthProvider, Credentials};
+
+pub struct OAuthAsAuth {
+    config: Arc<OAuthAsConfig>,
+    state: Arc<AsState>,
+}
+
+impl OAuthAsAuth {
+    pub fn new(config: Arc<OAuthAsConfig>, state: Arc<AsState>) -> Self {
+        Self { config, state }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for OAuthAsAuth {
+    async fn authenticate(&self, creds: &Credentials) -> Result<AuthIdentity> {
+        let header = creds
+            .get("authorization")
+            .context("missing Authorization header")?;
+        if header.len() < 7 || !header[..7].eq_ignore_ascii_case("bearer ") {
+            bail!("Authorization header must use Bearer scheme");
+        }
+        let token = &header[7..];
+
+        // Heuristic: a JWT has exactly two dots. Anything else is
+        // certainly not for us — fail fast with a stable error so the
+        // composite chain can move on without burning HMAC verify.
+        if token.matches('.').count() != 2 {
+            bail!("token is not a JWT");
+        }
+
+        // We don't know which client_id this token was issued for
+        // until we decode the (untrusted) payload. Peek at it
+        // unsafely first to learn the audience, then call the proper
+        // `verify` with that audience pinned. This keeps audience
+        // enforcement strict without having to disable it during
+        // decode.
+        let aud = peek_audience(token).context("could not extract audience claim")?;
+
+        // Check the audience refers to a registered client. If the
+        // client was deregistered (or never existed), reject — even
+        // a signature-valid token must not bypass client revocation.
+        if self.state.get_client(&aud).is_none() {
+            bail!("token audience does not refer to a registered client");
+        }
+
+        let issuer = self.config.issuer_url.trim_end_matches('/');
+        let claims = jwt::verify(token, self.config.jwt_secret.as_bytes(), issuer, &aud)?;
+
+        if claims.sub.is_empty() {
+            bail!("JWT subject claim is empty");
+        }
+
+        Ok(AuthIdentity::new(claims.sub, claims.groups))
+    }
+}
+
+/// Decode the JWT payload (without verifying the signature) just to
+/// read the `aud` claim. This is the standard pattern for issuers
+/// that require audience-aware verification.
+fn peek_audience(token: &str) -> Result<String> {
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine;
+
+    let mut parts = token.splitn(3, '.');
+    let _header = parts.next();
+    let payload = parts.next().context("JWT missing payload segment")?;
+    let bytes = URL_SAFE_NO_PAD
+        .decode(payload)
+        .context("JWT payload not base64url")?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).context("JWT payload not JSON")?;
+    let aud = v
+        .get("aud")
+        .and_then(|x| x.as_str())
+        .context("aud claim missing or not a string")?;
+    Ok(aud.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::oauth_primitives::generate_random_string;
+    use crate::server_auth::oauth_as::types::{JwtClaims, RegisteredClient};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    fn cfg() -> Arc<OAuthAsConfig> {
+        Arc::new(OAuthAsConfig {
+            issuer_url: "https://mcp.example.com".to_string(),
+            jwt_secret: "k".repeat(32),
+            trusted_user_header: "x-forwarded-user".to_string(),
+            trusted_groups_header: "x-forwarded-groups".to_string(),
+            trusted_source_cidrs: vec!["127.0.0.1/32".to_string()],
+            access_token_ttl_seconds: 3600,
+            refresh_token_ttl_seconds: 2_592_000,
+            authorization_code_ttl_seconds: 60,
+            scopes_supported: vec!["mcp".to_string()],
+            redirect_uri_allowlist: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+            injected_roles: vec!["oauth-user".to_string()],
+        })
+    }
+
+    fn state_with_client(client_id: &str) -> Arc<AsState> {
+        let s = Arc::new(AsState::default());
+        s.register_client(RegisteredClient {
+            client_id: client_id.to_string(),
+            client_name: None,
+            redirect_uris: vec![],
+            grant_types: vec![],
+            created_at_unix: 0,
+        })
+        .unwrap();
+        s
+    }
+
+    fn fresh_jwt(secret: &[u8], issuer: &str, aud: &str, sub: &str, groups: Vec<String>) -> String {
+        let n = now();
+        let claims = JwtClaims {
+            iss: issuer.to_string(),
+            aud: aud.to_string(),
+            sub: sub.to_string(),
+            groups,
+            iat: n,
+            nbf: n,
+            exp: n + 3600,
+            jti: generate_random_string(8),
+        };
+        jwt::sign(&claims, secret).unwrap()
+    }
+
+    fn auth_header(token: &str) -> Credentials {
+        let mut c = Credentials::new();
+        c.insert("authorization".to_string(), format!("Bearer {token}"));
+        c
+    }
+
+    #[tokio::test]
+    async fn test_provider_accepts_valid_jwt() {
+        let cfg = cfg();
+        let state = state_with_client("client-A");
+        let token = fresh_jwt(
+            cfg.jwt_secret.as_bytes(),
+            "https://mcp.example.com",
+            "client-A",
+            "alice",
+            vec!["dev".to_string()],
+        );
+        let p = OAuthAsAuth::new(cfg, state);
+        let id = p.authenticate(&auth_header(&token)).await.unwrap();
+        assert_eq!(id.subject, "alice");
+        assert_eq!(id.roles, vec!["dev".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_provider_rejects_jwt_signed_by_other_secret() {
+        let cfg = cfg();
+        let state = state_with_client("client-A");
+        let token = fresh_jwt(
+            b"q".repeat(32).as_slice(),
+            "https://mcp.example.com",
+            "client-A",
+            "alice",
+            vec![],
+        );
+        let p = OAuthAsAuth::new(cfg, state);
+        assert!(p.authenticate(&auth_header(&token)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_provider_rejects_jwt_with_wrong_issuer() {
+        let cfg = cfg();
+        let state = state_with_client("client-A");
+        let token = fresh_jwt(
+            cfg.jwt_secret.as_bytes(),
+            "https://attacker.example.com",
+            "client-A",
+            "alice",
+            vec![],
+        );
+        let p = OAuthAsAuth::new(cfg, state);
+        assert!(p.authenticate(&auth_header(&token)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_provider_rejects_jwt_for_revoked_client() {
+        // The signature is valid and issuer matches, but the client
+        // referenced by `aud` was removed from the registry — must
+        // be rejected. This is how operators revoke OAuth access.
+        let cfg = cfg();
+        let state = Arc::new(AsState::default()); // no clients
+        let token = fresh_jwt(
+            cfg.jwt_secret.as_bytes(),
+            "https://mcp.example.com",
+            "ghost-client",
+            "alice",
+            vec![],
+        );
+        let p = OAuthAsAuth::new(cfg, state);
+        assert!(p.authenticate(&auth_header(&token)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_provider_rejects_non_jwt_string() {
+        let p = OAuthAsAuth::new(cfg(), state_with_client("c"));
+        assert!(p
+            .authenticate(&auth_header("opaque-static-token"))
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_provider_rejects_missing_authorization() {
+        let p = OAuthAsAuth::new(cfg(), state_with_client("c"));
+        assert!(p.authenticate(&Credentials::new()).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_provider_rejects_non_bearer_scheme() {
+        let mut c = Credentials::new();
+        c.insert("authorization".to_string(), "Basic abc".to_string());
+        let p = OAuthAsAuth::new(cfg(), state_with_client("c"));
+        assert!(p.authenticate(&c).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_provider_populates_subject_and_roles() {
+        let cfg = cfg();
+        let state = state_with_client("client-A");
+        let token = fresh_jwt(
+            cfg.jwt_secret.as_bytes(),
+            "https://mcp.example.com",
+            "client-A",
+            "user@example.com",
+            vec!["oauth-user".to_string(), "dev".to_string()],
+        );
+        let p = OAuthAsAuth::new(cfg, state);
+        let id = p.authenticate(&auth_header(&token)).await.unwrap();
+        assert_eq!(id.subject, "user@example.com");
+        assert!(id.roles.contains(&"oauth-user".to_string()));
+        assert!(id.roles.contains(&"dev".to_string()));
+    }
+}

--- a/src/server_auth/oauth_as/redirect_uri.rs
+++ b/src/server_auth/oauth_as/redirect_uri.rs
@@ -27,6 +27,28 @@ fn matches_pattern(candidate: &str, pattern: &str) -> bool {
     }
 }
 
+/// Validate that an allowlist pattern is well-formed. Used both at
+/// boot (so misconfiguration fails fast) and at request time. Only
+/// trailing `*` wildcards are accepted.
+pub(crate) fn validate_pattern(pattern: &str) -> Result<()> {
+    if pattern.contains('*') && !pattern.ends_with('*') {
+        bail!("redirect_uri allowlist patterns may only use trailing '*': {pattern}");
+    }
+    // The non-wildcard prefix must be a parseable http(s) URL on its
+    // own. This catches operator typos like `https//example.com/cb`
+    // (missing colon) or schemes other than http/https before any
+    // request hits the server.
+    let prefix = pattern.trim_end_matches('*');
+    let parsed = Url::parse(prefix).map_err(|_| {
+        anyhow::anyhow!("redirect_uri allowlist pattern is not a valid URL: {pattern}")
+    })?;
+    let scheme = parsed.scheme();
+    if scheme != "https" && scheme != "http" {
+        bail!("redirect_uri allowlist pattern scheme must be http or https: {pattern}");
+    }
+    Ok(())
+}
+
 /// Validate a redirect URI for use in an OAuth flow. Returns `Ok(())`
 /// when the URI passes both the allowlist and the security checks.
 pub fn validate(uri: &str, allowlist: &[String]) -> Result<()> {
@@ -36,29 +58,40 @@ pub fn validate(uri: &str, allowlist: &[String]) -> Result<()> {
     if scheme != "https" && scheme != "http" {
         bail!("redirect_uri scheme must be http or https: {uri}");
     }
+    // RFC 6749 §3.1.2: redirect_uri MUST NOT include a fragment
+    // component. Also, `build_redirect` would compose the response
+    // URL incorrectly if a fragment were present.
+    if parsed.fragment().is_some() {
+        bail!("redirect_uri must not contain a fragment: {uri}");
+    }
     if scheme == "http" {
         // Loopback only — this is the OAuth-spec carve-out for
         // native apps and dev clients. Anything else over plain
         // HTTP is rejected.
-        let host = parsed.host_str().unwrap_or("");
-        let is_loopback = host == "localhost" || host == "127.0.0.1" || host == "[::1]";
+        //
+        // Avoid string-based host comparison (it stumbles on
+        // `[::1]` vs `::1`, percent-encoding, IDN). `Url::host()`
+        // gives the structured host so IPv4/IPv6 loopback checks
+        // delegate to the standard library.
+        let is_loopback = match parsed.host() {
+            Some(url::Host::Domain(d)) => d == "localhost",
+            Some(url::Host::Ipv4(ip)) => ip.is_loopback(),
+            Some(url::Host::Ipv6(ip)) => ip.is_loopback(),
+            None => false,
+        };
         if !is_loopback {
             bail!("redirect_uri uses plain http on non-loopback host: {uri}");
         }
     }
 
-    if !allowlist.iter().any(|p| matches_pattern(uri, p)) {
-        bail!("redirect_uri not in allowlist: {uri}");
+    // Defense in depth: every pattern must be well-formed even if
+    // [`OAuthAsConfig::validate`] already vetted them at boot.
+    for pattern in allowlist {
+        validate_pattern(pattern)?;
     }
 
-    // Reject any pattern that has `*` in the middle (was let through
-    // by `matches_pattern` only as a trailing wildcard). Defense
-    // against operator typos that would relax matching unexpectedly.
-    if allowlist
-        .iter()
-        .any(|p| p.contains('*') && !p.ends_with('*'))
-    {
-        bail!("redirect_uri allowlist patterns may only use trailing '*'");
+    if !allowlist.iter().any(|p| matches_pattern(uri, p)) {
+        bail!("redirect_uri not in allowlist: {uri}");
     }
 
     Ok(())
@@ -94,6 +127,24 @@ mod tests {
     fn test_http_loopback_allowed() {
         let allow = vec!["http://localhost:1234/cb".to_string()];
         assert!(validate("http://localhost:1234/cb", &allow).is_ok());
+    }
+
+    #[test]
+    fn test_http_ipv6_loopback_allowed() {
+        // Regression for code review on PR #91: `Url::host_str` returns
+        // `"::1"` (no brackets) for `http://[::1]/...`, so an earlier
+        // version that compared against `"[::1]"` would reject valid
+        // IPv6 loopback redirects.
+        let allow = vec!["http://[::1]:9000/cb".to_string()];
+        assert!(validate("http://[::1]:9000/cb", &allow).is_ok());
+    }
+
+    #[test]
+    fn test_redirect_uri_with_fragment_rejected() {
+        // RFC 6749 §3.1.2: redirect_uri MUST NOT contain a fragment.
+        let allow = vec!["https://example.com/cb".to_string()];
+        let err = validate("https://example.com/cb#hash", &allow).unwrap_err();
+        assert!(err.to_string().contains("fragment"));
     }
 
     #[test]

--- a/src/server_auth/oauth_as/redirect_uri.rs
+++ b/src/server_auth/oauth_as/redirect_uri.rs
@@ -1,0 +1,130 @@
+//! Redirect URI matcher for the OAuth Authorization Server.
+//!
+//! Two layers of validation, both required:
+//! 1. The URI must be in the operator's allowlist (`oauthAs.redirectUriAllowlist`).
+//! 2. The URI must also have been registered by the client via DCR.
+//!
+//! Matching against the allowlist supports a single trailing `*`
+//! wildcard so deployments can paste ChatGPT-style
+//! `https://chat.openai.com/aip/*/oauth/callback` without enumerating
+//! every assistant id. Anchored prefix-only — `*` in the middle is
+//! rejected because it muddles open-redirect analysis.
+//!
+//! HTTP redirect URIs are rejected unless they target loopback. This
+//! prevents a registered client from quietly downgrading to plain
+//! HTTP at runtime.
+
+use anyhow::{bail, Result};
+use url::Url;
+
+/// True iff `candidate` matches `pattern`. Pattern may end with `*`
+/// to match any suffix.
+fn matches_pattern(candidate: &str, pattern: &str) -> bool {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        candidate.starts_with(prefix)
+    } else {
+        candidate == pattern
+    }
+}
+
+/// Validate a redirect URI for use in an OAuth flow. Returns `Ok(())`
+/// when the URI passes both the allowlist and the security checks.
+pub fn validate(uri: &str, allowlist: &[String]) -> Result<()> {
+    let parsed = Url::parse(uri).map_err(|_| anyhow::anyhow!("invalid redirect_uri: {uri}"))?;
+
+    let scheme = parsed.scheme();
+    if scheme != "https" && scheme != "http" {
+        bail!("redirect_uri scheme must be http or https: {uri}");
+    }
+    if scheme == "http" {
+        // Loopback only — this is the OAuth-spec carve-out for
+        // native apps and dev clients. Anything else over plain
+        // HTTP is rejected.
+        let host = parsed.host_str().unwrap_or("");
+        let is_loopback = host == "localhost" || host == "127.0.0.1" || host == "[::1]";
+        if !is_loopback {
+            bail!("redirect_uri uses plain http on non-loopback host: {uri}");
+        }
+    }
+
+    if !allowlist.iter().any(|p| matches_pattern(uri, p)) {
+        bail!("redirect_uri not in allowlist: {uri}");
+    }
+
+    // Reject any pattern that has `*` in the middle (was let through
+    // by `matches_pattern` only as a trailing wildcard). Defense
+    // against operator typos that would relax matching unexpectedly.
+    if allowlist
+        .iter()
+        .any(|p| p.contains('*') && !p.ends_with('*'))
+    {
+        bail!("redirect_uri allowlist patterns may only use trailing '*'");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_https_exact_match_allowed() {
+        let allow = vec!["https://claude.ai/api/mcp/auth_callback".to_string()];
+        assert!(validate("https://claude.ai/api/mcp/auth_callback", &allow).is_ok());
+    }
+
+    #[test]
+    fn test_trailing_wildcard_match() {
+        let allow = vec!["https://chat.openai.com/aip/*".to_string()];
+        assert!(validate(
+            "https://chat.openai.com/aip/g-abc123/oauth/callback",
+            &allow
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_outside_allowlist_rejected() {
+        let allow = vec!["https://claude.ai/api/mcp/auth_callback".to_string()];
+        assert!(validate("https://attacker.example.com/cb", &allow).is_err());
+    }
+
+    #[test]
+    fn test_http_loopback_allowed() {
+        let allow = vec!["http://localhost:1234/cb".to_string()];
+        assert!(validate("http://localhost:1234/cb", &allow).is_ok());
+    }
+
+    #[test]
+    fn test_http_non_loopback_rejected_even_if_in_allowlist() {
+        // Defense against an operator allowlisting an http:// URL by
+        // mistake — must still be rejected at validation time.
+        let allow = vec!["http://intranet.example.com/cb".to_string()];
+        assert!(validate("http://intranet.example.com/cb", &allow).is_err());
+    }
+
+    #[test]
+    fn test_non_http_scheme_rejected() {
+        let allow = vec!["custom://nope".to_string()];
+        assert!(validate("custom://nope", &allow).is_err());
+        assert!(validate("javascript:alert(1)", &allow).is_err());
+    }
+
+    #[test]
+    fn test_malformed_uri_rejected() {
+        let allow = vec!["https://example.com/cb".to_string()];
+        assert!(validate("not a uri", &allow).is_err());
+    }
+
+    #[test]
+    fn test_middle_wildcard_pattern_rejected() {
+        // `*` only at the end. Catches operator typos that would
+        // otherwise widen the matcher unpredictably.
+        let allow = vec!["https://*.example.com/cb".to_string()];
+        // A request that matches the literal prefix would get past
+        // `matches_pattern`, but `validate` flags the bad pattern.
+        let res = validate("https://*.example.com/cb", &allow);
+        assert!(res.is_err());
+    }
+}

--- a/src/server_auth/oauth_as/register.rs
+++ b/src/server_auth/oauth_as/register.rs
@@ -197,25 +197,11 @@ mod tests {
         })
     }
 
-    fn save_disabled() -> impl Drop {
-        // Force the inline cache path so save() doesn't write to disk
-        // during the test — keeps these tests hermetic.
-        struct G;
-        std::env::set_var(
-            "MCP_AUTH_SERVER_CONFIG",
-            r#"{"clients":{},"refresh_tokens":{}}"#,
-        );
-        impl Drop for G {
-            fn drop(&mut self) {
-                std::env::remove_var("MCP_AUTH_SERVER_CONFIG");
-            }
-        }
-        G
-    }
+    use super::super::test_helpers::InlineSaveGuard;
 
     #[tokio::test]
     async fn test_register_emits_client_id() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
         let res = register(
             State(ctx),
@@ -235,7 +221,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_rejects_uri_outside_allowlist() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
         let err = register(
             State(ctx),
@@ -255,7 +241,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_rejects_empty_redirect_uris() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
         let err = register(
             State(ctx),
@@ -274,7 +260,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_rejects_unsupported_grant_type() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
         let err = register(
             State(ctx),
@@ -297,7 +283,7 @@ mod tests {
         // Two separate registrations must produce distinct client_ids
         // and independent redirect_uri lists, so a flow started with
         // client A cannot be redirected through B's URIs.
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let ctx = ctx_with(vec![
             "https://claude.ai/api/mcp/auth_callback".to_string(),
             "https://chat.openai.com/aip/*".to_string(),

--- a/src/server_auth/oauth_as/register.rs
+++ b/src/server_auth/oauth_as/register.rs
@@ -1,0 +1,341 @@
+//! POST /register — Dynamic Client Registration (RFC 7591).
+//!
+//! A public client (Claude.ai, ChatGPT, Cursor) calls this once to
+//! get a `client_id`. We do not issue `client_secret` because PKCE
+//! replaces it for public clients.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{extract::State, http::StatusCode, response::Json};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::oauth_primitives::generate_random_string;
+
+use super::redirect_uri;
+use super::types::RegisteredClient;
+use super::{AsState, OAuthAsConfig};
+
+#[derive(Debug, Deserialize)]
+pub struct RegistrationRequest {
+    #[serde(default)]
+    pub client_name: Option<String>,
+    pub redirect_uris: Vec<String>,
+    #[serde(default)]
+    pub grant_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub response_types: Option<Vec<String>>,
+    #[serde(default)]
+    pub token_endpoint_auth_method: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegistrationResponse {
+    pub client_id: String,
+    pub client_id_issued_at: u64,
+    pub redirect_uris: Vec<String>,
+    pub grant_types: Vec<String>,
+    pub token_endpoint_auth_method: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RegistrationError {
+    pub error: &'static str,
+    pub error_description: String,
+}
+
+pub struct AppCtx {
+    pub config: Arc<OAuthAsConfig>,
+    pub state: Arc<AsState>,
+}
+
+pub async fn register(
+    State(ctx): State<Arc<AppCtx>>,
+    Json(req): Json<RegistrationRequest>,
+) -> Result<Json<RegistrationResponse>, (StatusCode, Json<RegistrationError>)> {
+    if req.redirect_uris.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(RegistrationError {
+                error: "invalid_redirect_uri",
+                error_description: "redirect_uris must not be empty".to_string(),
+            }),
+        ));
+    }
+
+    for uri in &req.redirect_uris {
+        if let Err(e) = redirect_uri::validate(uri, &ctx.config.redirect_uri_allowlist) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(RegistrationError {
+                    error: "invalid_redirect_uri",
+                    error_description: e.to_string(),
+                }),
+            ));
+        }
+    }
+
+    let grant_types = req.grant_types.unwrap_or_else(|| {
+        vec![
+            "authorization_code".to_string(),
+            "refresh_token".to_string(),
+        ]
+    });
+
+    // We only ever support these two grants. Reject unknown values
+    // explicitly rather than silently accepting them — clients that
+    // expect e.g. `client_credentials` should fail at registration,
+    // not at first /token call.
+    for g in &grant_types {
+        if g != "authorization_code" && g != "refresh_token" {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(RegistrationError {
+                    error: "invalid_client_metadata",
+                    error_description: format!("unsupported grant_type: {g}"),
+                }),
+            ));
+        }
+    }
+
+    // RFC 7591 metadata fields we honor by validating against our
+    // single supported value. Anything else is operator-visible
+    // misconfiguration in the client, not something to silently
+    // accept.
+    if let Some(response_types) = &req.response_types {
+        for r in response_types {
+            if r != "code" {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    Json(RegistrationError {
+                        error: "invalid_client_metadata",
+                        error_description: format!("unsupported response_type: {r}"),
+                    }),
+                ));
+            }
+        }
+    }
+    if let Some(method) = &req.token_endpoint_auth_method {
+        if method != "none" {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(RegistrationError {
+                    error: "invalid_client_metadata",
+                    error_description: format!(
+                        "token_endpoint_auth_method must be 'none' (PKCE-only public clients): got {method}"
+                    ),
+                }),
+            ));
+        }
+    }
+
+    let client_id = format!("mcp_{}", generate_random_string(32));
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let registered = RegisteredClient {
+        client_id: client_id.clone(),
+        client_name: req.client_name,
+        redirect_uris: req.redirect_uris.clone(),
+        grant_types: grant_types.clone(),
+        created_at_unix: now,
+    };
+
+    if let Err(e) = ctx.state.register_client(registered) {
+        // Capacity error from the AS state — surface as a 503 so the
+        // client backs off rather than retrying immediately.
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(RegistrationError {
+                error: "server_error",
+                error_description: e.to_string(),
+            }),
+        ));
+    }
+
+    // Persist the new registration. A failure here logs but doesn't
+    // refuse the registration: the client is already in memory and
+    // the operator can recover later.
+    if let Err(e) = super::store::save(&ctx.state) {
+        tracing::warn!(
+            error = format!("{e:#}"),
+            "failed to persist AS state after register"
+        );
+    }
+
+    Ok(Json(RegistrationResponse {
+        client_id,
+        client_id_issued_at: now,
+        redirect_uris: req.redirect_uris,
+        grant_types,
+        token_endpoint_auth_method: "none",
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx_with(allowlist: Vec<String>) -> Arc<AppCtx> {
+        Arc::new(AppCtx {
+            config: Arc::new(OAuthAsConfig {
+                issuer_url: "https://mcp.example.com".to_string(),
+                jwt_secret: "x".repeat(32),
+                trusted_user_header: "x-forwarded-user".to_string(),
+                trusted_groups_header: "x-forwarded-groups".to_string(),
+                trusted_source_cidrs: vec!["127.0.0.1/32".to_string()],
+                access_token_ttl_seconds: 3600,
+                refresh_token_ttl_seconds: 2_592_000,
+                authorization_code_ttl_seconds: 60,
+                scopes_supported: vec![],
+                redirect_uri_allowlist: allowlist,
+                injected_roles: vec![],
+            }),
+            state: Arc::new(AsState::default()),
+        })
+    }
+
+    fn save_disabled() -> impl Drop {
+        // Force the inline cache path so save() doesn't write to disk
+        // during the test — keeps these tests hermetic.
+        struct G;
+        std::env::set_var(
+            "MCP_AUTH_SERVER_CONFIG",
+            r#"{"clients":{},"refresh_tokens":{}}"#,
+        );
+        impl Drop for G {
+            fn drop(&mut self) {
+                std::env::remove_var("MCP_AUTH_SERVER_CONFIG");
+            }
+        }
+        G
+    }
+
+    #[tokio::test]
+    async fn test_register_emits_client_id() {
+        let _g = save_disabled();
+        let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
+        let res = register(
+            State(ctx),
+            Json(RegistrationRequest {
+                client_name: Some("Claude".to_string()),
+                redirect_uris: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: None,
+            }),
+        )
+        .await
+        .unwrap();
+        assert!(res.client_id.starts_with("mcp_"));
+        assert_eq!(res.token_endpoint_auth_method, "none");
+    }
+
+    #[tokio::test]
+    async fn test_register_rejects_uri_outside_allowlist() {
+        let _g = save_disabled();
+        let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
+        let err = register(
+            State(ctx),
+            Json(RegistrationRequest {
+                client_name: None,
+                redirect_uris: vec!["https://attacker.example.com/cb".to_string()],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.1.error, "invalid_redirect_uri");
+    }
+
+    #[tokio::test]
+    async fn test_register_rejects_empty_redirect_uris() {
+        let _g = save_disabled();
+        let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
+        let err = register(
+            State(ctx),
+            Json(RegistrationRequest {
+                client_name: None,
+                redirect_uris: vec![],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_register_rejects_unsupported_grant_type() {
+        let _g = save_disabled();
+        let ctx = ctx_with(vec!["https://claude.ai/api/mcp/auth_callback".to_string()]);
+        let err = register(
+            State(ctx),
+            Json(RegistrationRequest {
+                client_name: None,
+                redirect_uris: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+                grant_types: Some(vec!["client_credentials".to_string()]),
+                response_types: None,
+                token_endpoint_auth_method: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.1.error, "invalid_client_metadata");
+    }
+
+    #[tokio::test]
+    async fn test_register_isolates_clients() {
+        // Two separate registrations must produce distinct client_ids
+        // and independent redirect_uri lists, so a flow started with
+        // client A cannot be redirected through B's URIs.
+        let _g = save_disabled();
+        let ctx = ctx_with(vec![
+            "https://claude.ai/api/mcp/auth_callback".to_string(),
+            "https://chat.openai.com/aip/*".to_string(),
+        ]);
+        let a = register(
+            State(ctx.clone()),
+            Json(RegistrationRequest {
+                client_name: Some("A".to_string()),
+                redirect_uris: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: None,
+            }),
+        )
+        .await
+        .unwrap();
+        let b = register(
+            State(ctx.clone()),
+            Json(RegistrationRequest {
+                client_name: Some("B".to_string()),
+                redirect_uris: vec!["https://chat.openai.com/aip/g-xyz/oauth/callback".to_string()],
+                grant_types: None,
+                response_types: None,
+                token_endpoint_auth_method: None,
+            }),
+        )
+        .await
+        .unwrap();
+        assert_ne!(a.client_id, b.client_id);
+        let stored_a = ctx.state.get_client(&a.client_id).unwrap();
+        let stored_b = ctx.state.get_client(&b.client_id).unwrap();
+        assert!(stored_a
+            .redirect_uris
+            .iter()
+            .all(|u| u.starts_with("https://claude.ai")));
+        assert!(stored_b
+            .redirect_uris
+            .iter()
+            .all(|u| u.starts_with("https://chat.openai.com")));
+    }
+}

--- a/src/server_auth/oauth_as/state.rs
+++ b/src/server_auth/oauth_as/state.rs
@@ -1,0 +1,307 @@
+//! Runtime state for the OAuth AS — registered clients (persisted),
+//! authorization codes (in-memory only), and refresh tokens (persisted).
+//!
+//! All mutation goes through `&self` plus interior mutability so the
+//! state can be shared via `Arc<AsState>` across axum handlers without
+//! a per-request lock dance. Persistence is opt-in: handlers call
+//! [`AsState::persist_with`] after mutations that should survive a
+//! restart.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{bail, Result};
+
+use super::types::{AuthorizationCode, IssuedRefreshToken, RegisteredClient};
+
+/// Hard cap on registered clients to keep `/register` from filling
+/// disk via DCR amplification. Operators that legitimately exceed
+/// this should be rotating clients out, not raising the cap.
+pub const MAX_REGISTERED_CLIENTS: usize = 1000;
+
+#[derive(Default)]
+pub struct AsState {
+    inner: RwLock<AsStateInner>,
+}
+
+#[derive(Default)]
+struct AsStateInner {
+    /// Persisted: clients registered via DCR. Survives restart.
+    clients: HashMap<String, RegisteredClient>,
+    /// In-memory only: short-lived authorization codes (TTL ~60s).
+    codes: HashMap<String, AuthorizationCode>,
+    /// Persisted: refresh tokens (TTL ~30d).
+    refresh_tokens: HashMap<String, IssuedRefreshToken>,
+}
+
+/// Snapshot view used by the persistent store.
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PersistedState {
+    #[serde(default)]
+    pub clients: HashMap<String, RegisteredClient>,
+    #[serde(default)]
+    pub refresh_tokens: HashMap<String, IssuedRefreshToken>,
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+impl AsState {
+    pub fn from_persisted(p: PersistedState) -> Self {
+        Self {
+            inner: RwLock::new(AsStateInner {
+                clients: p.clients,
+                refresh_tokens: p.refresh_tokens,
+                codes: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Snapshot the persisted parts of the state — clients and refresh
+    /// tokens. Codes are never persisted by design.
+    pub fn snapshot_persisted(&self) -> PersistedState {
+        let g = self.inner.read().unwrap();
+        PersistedState {
+            clients: g.clients.clone(),
+            refresh_tokens: g.refresh_tokens.clone(),
+        }
+    }
+
+    // ---- clients (DCR) -----------------------------------------------------
+
+    pub fn register_client(&self, client: RegisteredClient) -> Result<()> {
+        let mut g = self.inner.write().unwrap();
+        if g.clients.len() >= MAX_REGISTERED_CLIENTS && !g.clients.contains_key(&client.client_id) {
+            bail!(
+                "registered client limit reached ({}); refusing new registrations",
+                MAX_REGISTERED_CLIENTS
+            );
+        }
+        g.clients.insert(client.client_id.clone(), client);
+        Ok(())
+    }
+
+    pub fn get_client(&self, client_id: &str) -> Option<RegisteredClient> {
+        self.inner.read().unwrap().clients.get(client_id).cloned()
+    }
+
+    // ---- authorization codes (one-shot, in-memory) -------------------------
+
+    pub fn put_code(&self, code: AuthorizationCode) {
+        self.inner
+            .write()
+            .unwrap()
+            .codes
+            .insert(code.code.clone(), code);
+    }
+
+    /// Consume a code — single-use, removes it from state. Returns
+    /// `None` if the code is unknown, already used, or expired.
+    pub fn consume_code(&self, code: &str) -> Option<AuthorizationCode> {
+        let mut g = self.inner.write().unwrap();
+        let entry = g.codes.remove(code)?;
+        if entry.expires_at_unix <= now_unix() {
+            // Expired — drop it without returning.
+            return None;
+        }
+        Some(entry)
+    }
+
+    // ---- refresh tokens ----------------------------------------------------
+
+    pub fn put_refresh(&self, token: IssuedRefreshToken) {
+        self.inner
+            .write()
+            .unwrap()
+            .refresh_tokens
+            .insert(token.token.clone(), token);
+    }
+
+    /// Atomically consume the old refresh token and replace it with a
+    /// new one (rotation). Returns the consumed entry on success.
+    /// Refusal modes: unknown token, expired token, `client_id`
+    /// mismatch (cross-client replay attempt).
+    pub fn rotate_refresh(
+        &self,
+        old_token: &str,
+        client_id: &str,
+        new: IssuedRefreshToken,
+    ) -> Result<IssuedRefreshToken> {
+        let mut g = self.inner.write().unwrap();
+        let prev = match g.refresh_tokens.remove(old_token) {
+            Some(p) => p,
+            None => bail!("unknown refresh token"),
+        };
+        if prev.expires_at_unix <= now_unix() {
+            bail!("refresh token expired");
+        }
+        if prev.client_id != client_id {
+            // Privilege escalation guard: the token does not belong to
+            // the client presenting it.
+            bail!("refresh token does not match client_id");
+        }
+        g.refresh_tokens.insert(new.token.clone(), new);
+        Ok(prev)
+    }
+
+    // ---- garbage collection ------------------------------------------------
+
+    /// Remove expired codes and refresh tokens. Returns the number of
+    /// entries removed total. Caller is responsible for triggering
+    /// persistence afterward when a refresh-token entry was dropped.
+    pub fn gc_expired(&self) -> usize {
+        let cutoff = now_unix();
+        let mut g = self.inner.write().unwrap();
+        let before_codes = g.codes.len();
+        g.codes.retain(|_, c| c.expires_at_unix > cutoff);
+        let before_refresh = g.refresh_tokens.len();
+        g.refresh_tokens.retain(|_, t| t.expires_at_unix > cutoff);
+        (before_codes - g.codes.len()) + (before_refresh - g.refresh_tokens.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_client(id: &str) -> RegisteredClient {
+        RegisteredClient {
+            client_id: id.to_string(),
+            client_name: Some("test".to_string()),
+            redirect_uris: vec!["https://example.com/cb".to_string()],
+            grant_types: vec!["authorization_code".to_string()],
+            created_at_unix: now_unix(),
+        }
+    }
+
+    fn make_code(code: &str, ttl_s: u64) -> AuthorizationCode {
+        AuthorizationCode {
+            code: code.to_string(),
+            client_id: "client-A".to_string(),
+            redirect_uri: "https://example.com/cb".to_string(),
+            code_challenge: "challenge".to_string(),
+            scope: None,
+            subject: "alice".to_string(),
+            roles: vec![],
+            expires_at_unix: now_unix() + ttl_s,
+        }
+    }
+
+    fn make_refresh(token: &str, client_id: &str, ttl_s: u64) -> IssuedRefreshToken {
+        IssuedRefreshToken {
+            token: token.to_string(),
+            client_id: client_id.to_string(),
+            subject: "alice".to_string(),
+            roles: vec![],
+            expires_at_unix: now_unix() + ttl_s,
+        }
+    }
+
+    #[test]
+    fn test_register_then_get_client() {
+        let s = AsState::default();
+        s.register_client(make_client("c1")).unwrap();
+        assert_eq!(s.get_client("c1").unwrap().client_id, "c1");
+    }
+
+    #[test]
+    fn test_client_limit_blocks_new_but_allows_overwrite() {
+        let s = AsState::default();
+        for i in 0..MAX_REGISTERED_CLIENTS {
+            s.register_client(make_client(&format!("c{i}"))).unwrap();
+        }
+        // Overwriting an existing client must still succeed (DCR
+        // allows re-registering with the same id during retries).
+        s.register_client(make_client("c0")).unwrap();
+        // New ids beyond the cap must fail.
+        assert!(s.register_client(make_client("c999999")).is_err());
+    }
+
+    #[test]
+    fn test_consume_code_is_one_shot() {
+        let s = AsState::default();
+        s.put_code(make_code("the-code", 60));
+        assert!(s.consume_code("the-code").is_some());
+        // Replay must fail.
+        assert!(s.consume_code("the-code").is_none());
+    }
+
+    #[test]
+    fn test_consume_expired_code_returns_none() {
+        let s = AsState::default();
+        let mut c = make_code("stale", 60);
+        c.expires_at_unix = 0; // far past
+        s.put_code(c);
+        assert!(s.consume_code("stale").is_none());
+    }
+
+    #[test]
+    fn test_rotate_refresh_succeeds_for_matching_client() {
+        let s = AsState::default();
+        s.put_refresh(make_refresh("old", "client-A", 3600));
+        let new = make_refresh("new", "client-A", 3600);
+        let prev = s.rotate_refresh("old", "client-A", new).unwrap();
+        assert_eq!(prev.client_id, "client-A");
+    }
+
+    #[test]
+    fn test_rotate_refresh_rejects_cross_client_replay() {
+        // Privilege escalation guard: presenting client-A's refresh
+        // token under client-B credentials must NOT mint a new token
+        // for client-B.
+        let s = AsState::default();
+        s.put_refresh(make_refresh("old", "client-A", 3600));
+        let new = make_refresh("new", "client-B", 3600);
+        let err = s.rotate_refresh("old", "client-B", new).unwrap_err();
+        assert!(err.to_string().contains("client_id"));
+    }
+
+    #[test]
+    fn test_rotate_refresh_rejects_expired() {
+        let s = AsState::default();
+        let mut old = make_refresh("old", "client-A", 3600);
+        old.expires_at_unix = 0;
+        s.put_refresh(old);
+        let new = make_refresh("new", "client-A", 3600);
+        assert!(s.rotate_refresh("old", "client-A", new).is_err());
+    }
+
+    #[test]
+    fn test_rotate_refresh_rejects_unknown_token() {
+        let s = AsState::default();
+        let new = make_refresh("new", "client-A", 3600);
+        assert!(s.rotate_refresh("never-issued", "client-A", new).is_err());
+    }
+
+    #[test]
+    fn test_gc_drops_expired_only() {
+        let s = AsState::default();
+        s.put_code(make_code("alive", 60));
+        let mut dead = make_code("dead", 60);
+        dead.expires_at_unix = 0;
+        s.put_code(dead);
+        let removed = s.gc_expired();
+        assert_eq!(removed, 1);
+        assert!(s.consume_code("alive").is_some());
+    }
+
+    #[test]
+    fn test_snapshot_omits_in_memory_codes() {
+        // Codes must NEVER be serialized: a captured snapshot of an
+        // ongoing flow on disk would let an attacker resume it.
+        let s = AsState::default();
+        s.register_client(make_client("c1")).unwrap();
+        s.put_code(make_code("the-code", 60));
+        s.put_refresh(make_refresh("rt", "c1", 3600));
+        let snap = s.snapshot_persisted();
+        assert!(snap.clients.contains_key("c1"));
+        assert!(snap.refresh_tokens.contains_key("rt"));
+        // PersistedState struct doesn't even have a `codes` field —
+        // this is enforced at the type level, not just at runtime.
+    }
+}

--- a/src/server_auth/oauth_as/store.rs
+++ b/src/server_auth/oauth_as/store.rs
@@ -106,9 +106,7 @@ mod tests {
     use super::*;
     use crate::server_auth::oauth_as::types::{IssuedRefreshToken, RegisteredClient};
 
-    /// Serialize env-var access between tests; these tests mutate
-    /// process-wide state.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    use super::super::test_helpers::env_lock;
 
     struct EnvGuard {
         config: Option<String>,
@@ -144,7 +142,7 @@ mod tests {
 
     #[test]
     fn test_save_then_load_roundtrip_via_file() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _guard = EnvGuard::capture();
         reset_cache();
 
@@ -182,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_inline_takes_precedence_over_path() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _guard = EnvGuard::capture();
         reset_cache();
 
@@ -209,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_inline_save_does_not_touch_disk() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _guard = EnvGuard::capture();
         reset_cache();
 
@@ -236,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_inline_invalid_json_returns_empty_state() {
-        let _lock = ENV_LOCK.lock().unwrap();
+        let _lock = env_lock().lock().unwrap_or_else(|p| p.into_inner());
         let _guard = EnvGuard::capture();
         reset_cache();
 

--- a/src/server_auth/oauth_as/store.rs
+++ b/src/server_auth/oauth_as/store.rs
@@ -1,0 +1,249 @@
+//! Disk persistence for the OAuth AS state. Mirrors the precedence
+//! rules of `src/auth/store.rs` (env-var inline → env-var path →
+//! default location), so operators familiar with the client store
+//! get the same model server-side.
+//!
+//! Persistence is intentionally minimal: only registered clients and
+//! refresh tokens cross restart boundaries. Authorization codes are
+//! ephemeral by design (see `state::PersistedState`).
+
+use std::path::PathBuf;
+use std::sync::{Once, OnceLock, RwLock};
+
+use anyhow::{Context, Result};
+
+use crate::config;
+
+use super::state::{AsState, PersistedState};
+
+const STATE_INLINE_ENV: &str = "MCP_AUTH_SERVER_CONFIG";
+const STATE_PATH_ENV: &str = "MCP_AUTH_SERVER_PATH";
+
+fn inline_content() -> Option<String> {
+    std::env::var(STATE_INLINE_ENV)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn inline_cache() -> &'static RwLock<Option<PersistedState>> {
+    static CACHE: OnceLock<RwLock<Option<PersistedState>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(None))
+}
+
+fn parse_inline(content: &str) -> PersistedState {
+    let expanded = config::substitute_env_vars(content);
+    serde_json::from_str(&expanded).unwrap_or_default()
+}
+
+pub fn state_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var(STATE_PATH_ENV) {
+        let path = path.trim();
+        if !path.is_empty() {
+            return Ok(PathBuf::from(path));
+        }
+    }
+    Ok(config::config_dir()?.join("auth_server.json"))
+}
+
+/// Load persisted AS state. Empty default when no source is configured
+/// or content is malformed — same forgiving behavior as the client
+/// store, so a corrupt file does not block proxy startup.
+pub fn load() -> Result<AsState> {
+    if let Some(content) = inline_content() {
+        if let Some(p) = inline_cache().read().unwrap().as_ref() {
+            return Ok(AsState::from_persisted(p.clone()));
+        }
+        let mut w = inline_cache().write().unwrap();
+        if w.is_none() {
+            *w = Some(parse_inline(&content));
+        }
+        return Ok(AsState::from_persisted(w.as_ref().unwrap().clone()));
+    }
+
+    let path = state_path()?;
+    if !path.exists() {
+        return Ok(AsState::default());
+    }
+    let content = std::fs::read_to_string(&path).context("reading auth_server.json")?;
+    let parsed: PersistedState = serde_json::from_str(&content).unwrap_or_default();
+    Ok(AsState::from_persisted(parsed))
+}
+
+/// Persist a snapshot. In inline mode the snapshot is held in memory
+/// only — backing storage is typically a read-only Secret. Otherwise
+/// we write atomically (tempfile + rename) so a crash mid-write
+/// can't leave a partial JSON behind.
+pub fn save(state: &AsState) -> Result<()> {
+    let snap = state.snapshot_persisted();
+
+    if inline_content().is_some() {
+        *inline_cache().write().unwrap() = Some(snap);
+        static WARN_ONCE: Once = Once::new();
+        WARN_ONCE.call_once(|| {
+            tracing::warn!(
+                env = STATE_INLINE_ENV,
+                "inline AS state is read-only on disk; updates kept in memory only"
+            );
+        });
+        return Ok(());
+    }
+
+    let path = state_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut tmp = path.clone();
+    tmp.set_extension("json.tmp");
+    let content = serde_json::to_string_pretty(&snap)?;
+    std::fs::write(&tmp, content).context("writing auth_server.json.tmp")?;
+    std::fs::rename(&tmp, &path).context("renaming auth_server.json.tmp into place")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server_auth::oauth_as::types::{IssuedRefreshToken, RegisteredClient};
+
+    /// Serialize env-var access between tests; these tests mutate
+    /// process-wide state.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvGuard {
+        config: Option<String>,
+        path: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn capture() -> Self {
+            Self {
+                config: std::env::var(STATE_INLINE_ENV).ok(),
+                path: std::env::var(STATE_PATH_ENV).ok(),
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.config {
+                Some(v) => std::env::set_var(STATE_INLINE_ENV, v),
+                None => std::env::remove_var(STATE_INLINE_ENV),
+            }
+            match &self.path {
+                Some(v) => std::env::set_var(STATE_PATH_ENV, v),
+                None => std::env::remove_var(STATE_PATH_ENV),
+            }
+            *inline_cache().write().unwrap() = None;
+        }
+    }
+
+    fn reset_cache() {
+        *inline_cache().write().unwrap() = None;
+    }
+
+    #[test]
+    fn test_save_then_load_roundtrip_via_file() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+        reset_cache();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth_server.json");
+        std::env::remove_var(STATE_INLINE_ENV);
+        std::env::set_var(STATE_PATH_ENV, path.to_str().unwrap());
+
+        let s = AsState::default();
+        s.register_client(RegisteredClient {
+            client_id: "abc".to_string(),
+            client_name: None,
+            redirect_uris: vec!["https://x.example.com/cb".to_string()],
+            grant_types: vec!["authorization_code".to_string()],
+            created_at_unix: 1_700_000_000,
+        })
+        .unwrap();
+        s.put_refresh(IssuedRefreshToken {
+            token: "rt".to_string(),
+            client_id: "abc".to_string(),
+            subject: "alice".to_string(),
+            roles: vec!["dev".to_string()],
+            expires_at_unix: 9_999_999_999,
+        });
+        save(&s).unwrap();
+
+        // Atomic write must not leave a tempfile behind.
+        assert!(path.exists());
+        let stale = path.with_extension("json.tmp");
+        assert!(!stale.exists(), "tempfile was not renamed cleanly");
+
+        let reloaded = load().unwrap();
+        assert!(reloaded.get_client("abc").is_some());
+    }
+
+    #[test]
+    fn test_inline_takes_precedence_over_path() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+        reset_cache();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth_server.json");
+        std::fs::write(
+            &path,
+            r#"{"clients":{"file-client":{"client_id":"file-client","redirect_uris":[],"grant_types":[],"created_at_unix":0}},"refresh_tokens":{}}"#,
+        )
+        .unwrap();
+        std::env::set_var(STATE_PATH_ENV, path.to_str().unwrap());
+        std::env::set_var(
+            STATE_INLINE_ENV,
+            r#"{"clients":{"inline-client":{"client_id":"inline-client","redirect_uris":[],"grant_types":[],"created_at_unix":0}},"refresh_tokens":{}}"#,
+        );
+
+        let s = load().unwrap();
+        assert!(s.get_client("inline-client").is_some());
+        assert!(
+            s.get_client("file-client").is_none(),
+            "file path must NOT be read when inline is set"
+        );
+    }
+
+    #[test]
+    fn test_inline_save_does_not_touch_disk() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+        reset_cache();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth_server.json");
+        std::env::set_var(STATE_PATH_ENV, path.to_str().unwrap());
+        std::env::set_var(STATE_INLINE_ENV, r#"{"clients":{},"refresh_tokens":{}}"#);
+
+        let s = AsState::default();
+        s.register_client(RegisteredClient {
+            client_id: "abc".to_string(),
+            client_name: None,
+            redirect_uris: vec![],
+            grant_types: vec![],
+            created_at_unix: 0,
+        })
+        .unwrap();
+        save(&s).unwrap();
+        assert!(
+            !path.exists(),
+            "save must NOT write to disk in inline mode (typical k8s Secret is read-only)"
+        );
+    }
+
+    #[test]
+    fn test_inline_invalid_json_returns_empty_state() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _guard = EnvGuard::capture();
+        reset_cache();
+
+        std::env::set_var(STATE_INLINE_ENV, "{ not json }");
+        std::env::remove_var(STATE_PATH_ENV);
+
+        let s = load().unwrap();
+        assert!(s.snapshot_persisted().clients.is_empty());
+    }
+}

--- a/src/server_auth/oauth_as/test_helpers.rs
+++ b/src/server_auth/oauth_as/test_helpers.rs
@@ -1,0 +1,58 @@
+//! Test-only helpers shared across the oauth_as submodules.
+//!
+//! Centralizes the env-var lock and the `save_disabled` guard so
+//! tests that touch process-global state serialize correctly. Without
+//! a shared lock, `cargo test` runs the suite in parallel and tests
+//! that mutate `MCP_AUTH_SERVER_CONFIG` race the file-roundtrip test
+//! in `store.rs` — green locally on a fast machine, red in CI.
+
+use std::sync::Mutex;
+
+const STATE_INLINE_ENV: &str = "MCP_AUTH_SERVER_CONFIG";
+
+/// Process-wide lock for any test in `oauth_as` that mutates
+/// `MCP_AUTH_SERVER_CONFIG` or `MCP_AUTH_SERVER_PATH`. Hold it for
+/// the entire body of the test.
+pub(super) fn env_lock() -> &'static Mutex<()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    &LOCK
+}
+
+/// Guard that points the AS state to an in-memory inline blob, so
+/// `super::store::save` becomes a no-op (writes go to the cache,
+/// never to disk) for the lifetime of the guard. Restores the
+/// previous env value on Drop.
+///
+/// Acquires `env_lock()` to serialize against every other test in
+/// the module that touches the same env var. The lock is released
+/// when the guard drops along with the env restoration.
+pub(super) struct InlineSaveGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    prev_inline: Option<String>,
+}
+
+impl InlineSaveGuard {
+    pub(super) fn acquire() -> Self {
+        let lock = match env_lock().lock() {
+            Ok(g) => g,
+            // A previous test panicked while holding the lock — recover
+            // its state and keep going.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let prev_inline = std::env::var(STATE_INLINE_ENV).ok();
+        std::env::set_var(STATE_INLINE_ENV, r#"{"clients":{},"refresh_tokens":{}}"#);
+        Self {
+            _lock: lock,
+            prev_inline,
+        }
+    }
+}
+
+impl Drop for InlineSaveGuard {
+    fn drop(&mut self) {
+        match &self.prev_inline {
+            Some(v) => std::env::set_var(STATE_INLINE_ENV, v),
+            None => std::env::remove_var(STATE_INLINE_ENV),
+        }
+    }
+}

--- a/src/server_auth/oauth_as/token.rs
+++ b/src/server_auth/oauth_as/token.rs
@@ -1,0 +1,623 @@
+//! POST /token — exchanges authorization codes (and refresh tokens)
+//! for JWT access tokens. Validates PKCE S256 against the verifier,
+//! issues fresh refresh tokens with rotation, and signs JWTs with
+//! claims that the matching `OAuthAsAuth` provider knows how to
+//! verify.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{extract::State, http::StatusCode, response::Json, Form};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::oauth_primitives::{generate_random_string, s256_challenge};
+
+use super::jwt;
+use super::register::AppCtx;
+use super::types::{IssuedRefreshToken, JwtClaims};
+
+#[derive(Debug, Deserialize)]
+pub struct TokenRequest {
+    pub grant_type: String,
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub redirect_uri: Option<String>,
+    #[serde(default)]
+    pub client_id: Option<String>,
+    #[serde(default)]
+    pub code_verifier: Option<String>,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub token_type: &'static str,
+    pub expires_in: u64,
+    pub refresh_token: String,
+    pub scope: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenError {
+    pub error: &'static str,
+    pub error_description: String,
+}
+
+fn err(
+    code: StatusCode,
+    kind: &'static str,
+    msg: impl Into<String>,
+) -> (StatusCode, Json<TokenError>) {
+    (
+        code,
+        Json(TokenError {
+            error: kind,
+            error_description: msg.into(),
+        }),
+    )
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn merge_roles(roles: &[String], injected: &[String]) -> Vec<String> {
+    let mut out = roles.to_vec();
+    for r in injected {
+        if !out.contains(r) {
+            out.push(r.clone());
+        }
+    }
+    out
+}
+
+fn issue_jwt(
+    ctx: &AppCtx,
+    client_id: &str,
+    subject: &str,
+    roles: &[String],
+) -> Result<(String, String, u64), (StatusCode, Json<TokenError>)> {
+    let now_ts = now();
+    let access_exp = now_ts + ctx.config.access_token_ttl_seconds;
+
+    let claims = JwtClaims {
+        iss: ctx.config.issuer_url.trim_end_matches('/').to_string(),
+        aud: client_id.to_string(),
+        sub: subject.to_string(),
+        groups: merge_roles(roles, &ctx.config.injected_roles),
+        iat: now_ts,
+        nbf: now_ts,
+        exp: access_exp,
+        jti: generate_random_string(16),
+    };
+
+    let access_token = jwt::sign(&claims, ctx.config.jwt_secret.as_bytes()).map_err(|e| {
+        err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            e.to_string(),
+        )
+    })?;
+
+    let refresh_token = generate_random_string(48);
+    ctx.state.put_refresh(IssuedRefreshToken {
+        token: refresh_token.clone(),
+        client_id: client_id.to_string(),
+        subject: subject.to_string(),
+        roles: roles.to_vec(),
+        expires_at_unix: now_ts + ctx.config.refresh_token_ttl_seconds,
+    });
+
+    Ok((
+        access_token,
+        refresh_token,
+        ctx.config.access_token_ttl_seconds,
+    ))
+}
+
+pub async fn token(
+    State(ctx): State<Arc<AppCtx>>,
+    Form(req): Form<TokenRequest>,
+) -> Result<Json<TokenResponse>, (StatusCode, Json<TokenError>)> {
+    match req.grant_type.as_str() {
+        "authorization_code" => handle_code(&ctx, req).await,
+        "refresh_token" => handle_refresh(&ctx, req).await,
+        other => Err(err(
+            StatusCode::BAD_REQUEST,
+            "unsupported_grant_type",
+            format!("grant_type {other} is not supported"),
+        )),
+    }
+}
+
+async fn handle_code(
+    ctx: &AppCtx,
+    req: TokenRequest,
+) -> Result<Json<TokenResponse>, (StatusCode, Json<TokenError>)> {
+    let code = req.code.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "code is required",
+        )
+    })?;
+    let redirect_uri = req.redirect_uri.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "redirect_uri is required",
+        )
+    })?;
+    let client_id = req.client_id.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "client_id is required",
+        )
+    })?;
+    let verifier = req.code_verifier.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "code_verifier is required (PKCE S256)",
+        )
+    })?;
+
+    let entry = ctx.state.consume_code(&code).ok_or_else(|| {
+        // Same response shape for unknown / used / expired — a
+        // distinguishable error would let an attacker tell which
+        // case they hit.
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "code is invalid, expired, or already used".to_string(),
+        )
+    })?;
+
+    if entry.client_id != client_id {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "client_id does not match authorization code".to_string(),
+        ));
+    }
+    if entry.redirect_uri != redirect_uri {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "redirect_uri does not match authorization code".to_string(),
+        ));
+    }
+
+    // Recompute S256(verifier) and compare against the stored
+    // challenge. Constant-time comparison is overkill for non-secret
+    // identifiers, but cheap to do via `subtle` if we ever add it.
+    let computed = s256_challenge(&verifier);
+    if computed != entry.code_challenge {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "PKCE verifier does not match challenge".to_string(),
+        ));
+    }
+
+    let (access, refresh, expires_in) = issue_jwt(ctx, &client_id, &entry.subject, &entry.roles)?;
+
+    if let Err(e) = super::store::save(&ctx.state) {
+        tracing::warn!(
+            error = format!("{e:#}"),
+            "failed to persist AS state after token issuance"
+        );
+    }
+
+    Ok(Json(TokenResponse {
+        access_token: access,
+        token_type: "Bearer",
+        expires_in,
+        refresh_token: refresh,
+        scope: entry.scope,
+    }))
+}
+
+async fn handle_refresh(
+    ctx: &AppCtx,
+    req: TokenRequest,
+) -> Result<Json<TokenResponse>, (StatusCode, Json<TokenError>)> {
+    let old = req.refresh_token.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "refresh_token is required",
+        )
+    })?;
+    let client_id = req.client_id.ok_or_else(|| {
+        err(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "client_id is required",
+        )
+    })?;
+
+    // Snapshot subject + roles BEFORE rotating, so the new JWT carries
+    // the same identity. We bind to client_id to detect cross-client
+    // replay.
+    let prev_view = match ctx
+        .state
+        .snapshot_persisted()
+        .refresh_tokens
+        .get(&old)
+        .cloned()
+    {
+        Some(t) => t,
+        None => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                "refresh token is invalid".to_string(),
+            ));
+        }
+    };
+    if prev_view.client_id != client_id {
+        // Privilege escalation guard: refresh tokens are bound to
+        // the client that received them. Same generic error to avoid
+        // probing.
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "refresh token is invalid".to_string(),
+        ));
+    }
+
+    let new_token = generate_random_string(48);
+    let new_entry = IssuedRefreshToken {
+        token: new_token.clone(),
+        client_id: client_id.clone(),
+        subject: prev_view.subject.clone(),
+        roles: prev_view.roles.clone(),
+        expires_at_unix: now() + ctx.config.refresh_token_ttl_seconds,
+    };
+
+    if let Err(_e) = ctx.state.rotate_refresh(&old, &client_id, new_entry) {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "refresh token is invalid".to_string(),
+        ));
+    }
+
+    // Mint the JWT after rotation succeeded.
+    let now_ts = now();
+    let claims = JwtClaims {
+        iss: ctx.config.issuer_url.trim_end_matches('/').to_string(),
+        aud: client_id.clone(),
+        sub: prev_view.subject.clone(),
+        groups: merge_roles(&prev_view.roles, &ctx.config.injected_roles),
+        iat: now_ts,
+        nbf: now_ts,
+        exp: now_ts + ctx.config.access_token_ttl_seconds,
+        jti: generate_random_string(16),
+    };
+    let access = jwt::sign(&claims, ctx.config.jwt_secret.as_bytes()).map_err(|e| {
+        err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            e.to_string(),
+        )
+    })?;
+
+    if let Err(e) = super::store::save(&ctx.state) {
+        tracing::warn!(
+            error = format!("{e:#}"),
+            "failed to persist AS state after refresh"
+        );
+    }
+
+    Ok(Json(TokenResponse {
+        access_token: access,
+        token_type: "Bearer",
+        expires_in: ctx.config.access_token_ttl_seconds,
+        refresh_token: new_token,
+        scope: None,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::oauth_primitives::generate_pkce;
+    use crate::server_auth::oauth_as::types::{AuthorizationCode, RegisteredClient};
+
+    fn save_disabled() -> impl Drop {
+        struct G;
+        std::env::set_var(
+            "MCP_AUTH_SERVER_CONFIG",
+            r#"{"clients":{},"refresh_tokens":{}}"#,
+        );
+        impl Drop for G {
+            fn drop(&mut self) {
+                std::env::remove_var("MCP_AUTH_SERVER_CONFIG");
+            }
+        }
+        G
+    }
+
+    fn ctx_with_code(code: &str, challenge: &str) -> Arc<AppCtx> {
+        let config = Arc::new(super::super::OAuthAsConfig {
+            issuer_url: "https://mcp.example.com".to_string(),
+            jwt_secret: "x".repeat(32),
+            trusted_user_header: "x-forwarded-user".to_string(),
+            trusted_groups_header: "x-forwarded-groups".to_string(),
+            trusted_source_cidrs: vec!["127.0.0.1/32".to_string()],
+            access_token_ttl_seconds: 3600,
+            refresh_token_ttl_seconds: 2_592_000,
+            authorization_code_ttl_seconds: 60,
+            scopes_supported: vec!["mcp".to_string()],
+            redirect_uri_allowlist: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+            injected_roles: vec!["oauth-user".to_string()],
+        });
+        let state = Arc::new(super::super::AsState::default());
+        state
+            .register_client(RegisteredClient {
+                client_id: "client-A".to_string(),
+                client_name: None,
+                redirect_uris: vec!["https://claude.ai/api/mcp/auth_callback".to_string()],
+                grant_types: vec!["authorization_code".to_string()],
+                created_at_unix: 0,
+            })
+            .unwrap();
+        state.put_code(AuthorizationCode {
+            code: code.to_string(),
+            client_id: "client-A".to_string(),
+            redirect_uri: "https://claude.ai/api/mcp/auth_callback".to_string(),
+            code_challenge: challenge.to_string(),
+            scope: Some("mcp".to_string()),
+            subject: "alice".to_string(),
+            roles: vec!["dev".to_string()],
+            expires_at_unix: now() + 60,
+        });
+        Arc::new(AppCtx { config, state })
+    }
+
+    #[tokio::test]
+    async fn test_authorization_code_grant_happy_path() {
+        let _g = save_disabled();
+        let (verifier, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        let resp = token(
+            State(ctx.clone()),
+            Form(TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("the-code".to_string()),
+                redirect_uri: Some("https://claude.ai/api/mcp/auth_callback".to_string()),
+                client_id: Some("client-A".to_string()),
+                code_verifier: Some(verifier),
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.token_type, "Bearer");
+        assert_eq!(resp.expires_in, 3600);
+        assert!(!resp.access_token.is_empty());
+        assert!(!resp.refresh_token.is_empty());
+
+        // Issued JWT must verify with the AS's secret and carry the
+        // injected role.
+        let claims = jwt::verify(
+            &resp.access_token,
+            ctx.config.jwt_secret.as_bytes(),
+            "https://mcp.example.com",
+            "client-A",
+        )
+        .unwrap();
+        assert_eq!(claims.sub, "alice");
+        assert!(claims.groups.contains(&"oauth-user".to_string()));
+        assert!(claims.groups.contains(&"dev".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_pkce_verifier_mismatch_rejected() {
+        // Critical bypass guard: wrong verifier must fail.
+        let _g = save_disabled();
+        let (_, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        let err = token(
+            State(ctx),
+            Form(TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("the-code".to_string()),
+                redirect_uri: Some("https://claude.ai/api/mcp/auth_callback".to_string()),
+                client_id: Some("client-A".to_string()),
+                code_verifier: Some("wrong-verifier".to_string()),
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.1.error, "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_code_replay_rejected() {
+        let _g = save_disabled();
+        let (verifier, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        let req = || TokenRequest {
+            grant_type: "authorization_code".to_string(),
+            code: Some("the-code".to_string()),
+            redirect_uri: Some("https://claude.ai/api/mcp/auth_callback".to_string()),
+            client_id: Some("client-A".to_string()),
+            code_verifier: Some(verifier.clone()),
+            refresh_token: None,
+        };
+        // First use succeeds.
+        let _ = token(State(ctx.clone()), Form(req())).await.unwrap();
+        // Replay must fail.
+        let err = token(State(ctx), Form(req())).await.unwrap_err();
+        assert_eq!(err.1.error, "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_redirect_uri_mismatch_rejected() {
+        let _g = save_disabled();
+        let (verifier, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        let err = token(
+            State(ctx),
+            Form(TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("the-code".to_string()),
+                redirect_uri: Some("https://attacker.example.com/cb".to_string()),
+                client_id: Some("client-A".to_string()),
+                code_verifier: Some(verifier),
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.1.error, "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_client_id_mismatch_rejected() {
+        // Token confusion guard: code was issued for client-A,
+        // presenting it as client-B must fail.
+        let _g = save_disabled();
+        let (verifier, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        let err = token(
+            State(ctx),
+            Form(TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("the-code".to_string()),
+                redirect_uri: Some("https://claude.ai/api/mcp/auth_callback".to_string()),
+                client_id: Some("client-B".to_string()),
+                code_verifier: Some(verifier),
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.1.error, "invalid_grant");
+    }
+
+    #[tokio::test]
+    async fn test_refresh_grant_rotates_token() {
+        let _g = save_disabled();
+        let (verifier, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        // First, an authorization_code grant to seed a refresh token.
+        let initial = token(
+            State(ctx.clone()),
+            Form(TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("the-code".to_string()),
+                redirect_uri: Some("https://claude.ai/api/mcp/auth_callback".to_string()),
+                client_id: Some("client-A".to_string()),
+                code_verifier: Some(verifier),
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap();
+        let first_refresh = initial.refresh_token.clone();
+
+        // Then the refresh grant.
+        let refreshed = token(
+            State(ctx.clone()),
+            Form(TokenRequest {
+                grant_type: "refresh_token".to_string(),
+                code: None,
+                redirect_uri: None,
+                client_id: Some("client-A".to_string()),
+                code_verifier: None,
+                refresh_token: Some(first_refresh.clone()),
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(
+            refreshed.refresh_token, first_refresh,
+            "refresh token must rotate on every refresh"
+        );
+        // Old refresh token must be invalidated.
+        let replay = token(
+            State(ctx),
+            Form(TokenRequest {
+                grant_type: "refresh_token".to_string(),
+                code: None,
+                redirect_uri: None,
+                client_id: Some("client-A".to_string()),
+                code_verifier: None,
+                refresh_token: Some(first_refresh),
+            }),
+        )
+        .await;
+        assert!(replay.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_grant_rejects_cross_client_replay() {
+        // Privilege escalation: refresh token from client-A must NOT
+        // mint a token under client-B credentials.
+        let _g = save_disabled();
+        let (verifier, challenge) = generate_pkce();
+        let ctx = ctx_with_code("the-code", &challenge);
+        let initial = token(
+            State(ctx.clone()),
+            Form(TokenRequest {
+                grant_type: "authorization_code".to_string(),
+                code: Some("the-code".to_string()),
+                redirect_uri: Some("https://claude.ai/api/mcp/auth_callback".to_string()),
+                client_id: Some("client-A".to_string()),
+                code_verifier: Some(verifier),
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let attempt = token(
+            State(ctx),
+            Form(TokenRequest {
+                grant_type: "refresh_token".to_string(),
+                code: None,
+                redirect_uri: None,
+                client_id: Some("client-B".to_string()),
+                code_verifier: None,
+                refresh_token: Some(initial.refresh_token.clone()),
+            }),
+        )
+        .await;
+        assert!(attempt.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_grant_type_rejected() {
+        let _g = save_disabled();
+        let ctx = ctx_with_code("the-code", "ignored");
+        let err = token(
+            State(ctx),
+            Form(TokenRequest {
+                grant_type: "client_credentials".to_string(),
+                code: None,
+                redirect_uri: None,
+                client_id: None,
+                code_verifier: None,
+                refresh_token: None,
+            }),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert_eq!(err.1.error, "unsupported_grant_type");
+    }
+}

--- a/src/server_auth/oauth_as/token.rs
+++ b/src/server_auth/oauth_as/token.rs
@@ -333,19 +333,7 @@ mod tests {
     use crate::auth::oauth_primitives::generate_pkce;
     use crate::server_auth::oauth_as::types::{AuthorizationCode, RegisteredClient};
 
-    fn save_disabled() -> impl Drop {
-        struct G;
-        std::env::set_var(
-            "MCP_AUTH_SERVER_CONFIG",
-            r#"{"clients":{},"refresh_tokens":{}}"#,
-        );
-        impl Drop for G {
-            fn drop(&mut self) {
-                std::env::remove_var("MCP_AUTH_SERVER_CONFIG");
-            }
-        }
-        G
-    }
+    use super::super::test_helpers::InlineSaveGuard;
 
     fn ctx_with_code(code: &str, challenge: &str) -> Arc<AppCtx> {
         let config = Arc::new(super::super::OAuthAsConfig {
@@ -386,7 +374,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_authorization_code_grant_happy_path() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (verifier, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         let resp = token(
@@ -424,7 +412,7 @@ mod tests {
     #[tokio::test]
     async fn test_pkce_verifier_mismatch_rejected() {
         // Critical bypass guard: wrong verifier must fail.
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (_, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         let err = token(
@@ -446,7 +434,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_code_replay_rejected() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (verifier, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         let req = || TokenRequest {
@@ -466,7 +454,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_redirect_uri_mismatch_rejected() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (verifier, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         let err = token(
@@ -489,7 +477,7 @@ mod tests {
     async fn test_client_id_mismatch_rejected() {
         // Token confusion guard: code was issued for client-A,
         // presenting it as client-B must fail.
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (verifier, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         let err = token(
@@ -510,7 +498,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_refresh_grant_rotates_token() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (verifier, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         // First, an authorization_code grant to seed a refresh token.
@@ -568,7 +556,7 @@ mod tests {
     async fn test_refresh_grant_rejects_cross_client_replay() {
         // Privilege escalation: refresh token from client-A must NOT
         // mint a token under client-B credentials.
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let (verifier, challenge) = generate_pkce();
         let ctx = ctx_with_code("the-code", &challenge);
         let initial = token(
@@ -602,7 +590,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_unsupported_grant_type_rejected() {
-        let _g = save_disabled();
+        let _g = InlineSaveGuard::acquire();
         let ctx = ctx_with_code("the-code", "ignored");
         let err = token(
             State(ctx),

--- a/src/server_auth/oauth_as/types.rs
+++ b/src/server_auth/oauth_as/types.rs
@@ -1,0 +1,83 @@
+//! Persistent state shapes for the OAuth Authorization Server.
+//!
+//! These structs are what the AS persists across restarts (registered
+//! clients, refresh tokens) plus what lives only in memory between
+//! `/authorize` and `/token` (authorization codes). JWT access tokens
+//! are stateless — they don't appear here.
+
+use serde::{Deserialize, Serialize};
+
+/// A client registered via `POST /register` (RFC 7591 Dynamic Client
+/// Registration). Public clients only — no `client_secret` is issued
+/// because PKCE replaces the need for one (and Claude.ai and other
+/// MCP-aware clients are public clients anyway).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisteredClient {
+    pub client_id: String,
+    #[serde(default)]
+    pub client_name: Option<String>,
+    pub redirect_uris: Vec<String>,
+    pub grant_types: Vec<String>,
+    /// Unix seconds when the registration happened. Useful for
+    /// expiring stale clients in a future cleanup pass; for v1 it is
+    /// purely informational.
+    pub created_at_unix: u64,
+}
+
+/// One-shot authorization code emitted by `/authorize` and consumed
+/// at `/token`. Lives only in memory (TTL ~60s) — it is intentionally
+/// not part of the on-disk store, so a restart simply drops in-flight
+/// authorizations rather than letting an attacker replay a captured
+/// code post-restart.
+#[derive(Debug, Clone)]
+pub struct AuthorizationCode {
+    pub code: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub code_challenge: String,
+    pub scope: Option<String>,
+    pub subject: String,
+    pub roles: Vec<String>,
+    pub expires_at_unix: u64,
+}
+
+/// A long-lived refresh token. Persisted so refresh works across
+/// restarts (Claude.ai will hold a refresh token for ~30 days).
+/// Rotation: every successful refresh invalidates the previous token
+/// and issues a new one, so capture-and-replay buys a single use at
+/// most.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssuedRefreshToken {
+    pub token: String,
+    pub client_id: String,
+    pub subject: String,
+    pub roles: Vec<String>,
+    pub expires_at_unix: u64,
+}
+
+/// Claims serialized into the JWT access token. Names follow standard
+/// JWT / OIDC conventions so existing tooling can introspect tokens
+/// without custom logic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JwtClaims {
+    /// Issuer — must match the AS issuerUrl on verification.
+    pub iss: String,
+    /// Audience — the `client_id` the token was issued for. Single
+    /// value; arrays are not supported in v1.
+    pub aud: String,
+    /// Subject — the authenticated user (from the trusted header at
+    /// `/authorize` time).
+    pub sub: String,
+    /// Groups / roles. Becomes `AuthIdentity.roles` after validation.
+    /// Empty vec serializes as `[]` rather than being omitted, so
+    /// downstream consumers don't have to special-case "no roles".
+    pub groups: Vec<String>,
+    /// Expiry (unix seconds).
+    pub exp: u64,
+    /// Not-before (unix seconds).
+    pub nbf: u64,
+    /// Issued at (unix seconds).
+    pub iat: u64,
+    /// Unique token id — useful for audit trails and future revocation.
+    pub jti: String,
+}

--- a/src/server_auth/providers.rs
+++ b/src/server_auth/providers.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::{AuthIdentity, AuthProvider, BearerToken, Credentials};
 
@@ -50,6 +51,63 @@ impl AuthProvider for BearerTokenAuth {
     }
 }
 
+/// Composite provider: tries each inner provider in order and returns
+/// the first successful identity. Designed for the case where one
+/// `mcp serve` instance must accept *both* static bearer tokens (used
+/// by local CLI / dev tools) **and** OAuth-issued JWTs (used by
+/// Claude.ai / ChatGPT / Cursor) on the same `/mcp` endpoint.
+///
+/// Ordering note: providers are tried in array order. Cheaper checks
+/// (static map lookup) belong first; HMAC verification belongs last.
+/// Ordering is a performance choice, not a correctness one — every
+/// configured provider gets a fair shot until one accepts.
+///
+/// Oracle defense: when *all* providers reject, the chain returns the
+/// error of the **first** configured provider, never something
+/// derived from which provider got further. Otherwise an attacker
+/// could probe the chain to learn which token format is in use.
+pub struct ProviderChain {
+    providers: Vec<Arc<dyn AuthProvider>>,
+}
+
+impl ProviderChain {
+    pub fn new(providers: Vec<Arc<dyn AuthProvider>>) -> Self {
+        Self { providers }
+    }
+}
+
+#[async_trait]
+impl AuthProvider for ProviderChain {
+    async fn authenticate(&self, creds: &Credentials) -> Result<AuthIdentity> {
+        // Empty chain is equivalent to NoAuth — degenerate but valid.
+        if self.providers.is_empty() {
+            return NoAuth.authenticate(creds).await;
+        }
+
+        let mut first_error: Option<anyhow::Error> = None;
+        for (idx, provider) in self.providers.iter().enumerate() {
+            match provider.authenticate(creds).await {
+                Ok(identity) => {
+                    // Debug-only: never log at info level — that would leak
+                    // which provider format the request used to anyone with
+                    // access to logs.
+                    tracing::debug!(provider_index = idx, "auth chain matched provider");
+                    return Ok(identity);
+                }
+                Err(e) => {
+                    if first_error.is_none() {
+                        first_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        // Unwrap is safe: providers is non-empty, so at least one error
+        // was recorded.
+        Err(first_error.unwrap())
+    }
+}
+
 /// Trusts a reverse proxy header (e.g. X-Forwarded-User).
 /// Only use behind a trusted proxy that sets this header.
 ///
@@ -74,7 +132,7 @@ impl ForwardedUserAuth {
 /// Parse a comma-separated groups header into a list of role names.
 /// Trims each entry and drops empty ones. Case is preserved (role matching
 /// is case-sensitive).
-fn parse_groups(raw: &str) -> Vec<String> {
+pub(crate) fn parse_groups(raw: &str) -> Vec<String> {
     raw.split(',')
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -82,23 +140,42 @@ fn parse_groups(raw: &str) -> Vec<String> {
         .collect()
 }
 
+/// Extract the trusted user identity from request credentials, using
+/// the same shape `ForwardedUserAuth` does. Returned `(subject, roles)`
+/// is suitable for both per-request authentication (the existing
+/// provider) and for OAuth `/authorize` where the AS reads the
+/// reverse-proxy-set headers to identify the human before issuing a
+/// code.
+///
+/// Header names are matched case-insensitively (HTTP convention) and
+/// roles default to an empty vec when the groups header is absent.
+/// Returns `None` when the user header is missing or empty.
+pub(crate) fn read_trusted_user(
+    creds: &Credentials,
+    user_header: &str,
+    groups_header: &str,
+) -> Option<(String, Vec<String>)> {
+    let user = creds.get(&user_header.to_lowercase())?;
+    if user.is_empty() {
+        return None;
+    }
+    let roles = creds
+        .get(&groups_header.to_lowercase())
+        .map(|raw| parse_groups(raw))
+        .unwrap_or_default();
+    Some((user.clone(), roles))
+}
+
 #[async_trait]
 impl AuthProvider for ForwardedUserAuth {
     async fn authenticate(&self, creds: &Credentials) -> Result<AuthIdentity> {
-        let user = creds
-            .get(&self.header)
-            .ok_or_else(|| anyhow::anyhow!("missing {} header", self.header))?;
-
-        if user.is_empty() {
-            bail!("{} header is empty", self.header);
+        match read_trusted_user(creds, &self.header, &self.groups_header) {
+            Some((subject, roles)) => Ok(AuthIdentity::new(subject, roles)),
+            None => match creds.get(&self.header) {
+                Some(_) => bail!("{} header is empty", self.header),
+                None => bail!("missing {} header", self.header),
+            },
         }
-
-        let roles = creds
-            .get(&self.groups_header)
-            .map(|raw| parse_groups(raw))
-            .unwrap_or_default();
-
-        Ok(AuthIdentity::new(user.clone(), roles))
     }
 }
 
@@ -525,5 +602,234 @@ mod tests {
         let mut creds = Credentials::new();
         creds.insert("x-forwarded-groups".to_string(), "admin".to_string());
         assert!(provider.authenticate(&creds).await.is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // ProviderChain — composite provider running multiple auth backends
+    // in parallel on the same /mcp endpoint. Models the issue #90 use case:
+    // dev local with static bearer + Claude.ai web with OAuth JWT, both on
+    // the same instance, no config swap.
+    // ---------------------------------------------------------------------
+
+    /// Test-only provider that mimics a JWT validator: accepts a single
+    /// bearer value mapped to an identity. Lets us exercise chain
+    /// behavior without pulling in real JWT crypto.
+    struct StubBearerOnly {
+        token: String,
+        identity: AuthIdentity,
+    }
+
+    #[async_trait]
+    impl AuthProvider for StubBearerOnly {
+        async fn authenticate(&self, creds: &Credentials) -> Result<AuthIdentity> {
+            let header = creds
+                .get("authorization")
+                .ok_or_else(|| anyhow::anyhow!("missing Authorization header"))?;
+            if header.len() < 7 || !header[..7].eq_ignore_ascii_case("bearer ") {
+                bail!("Authorization header must use Bearer scheme");
+            }
+            if &header[7..] == self.token {
+                Ok(self.identity.clone())
+            } else {
+                bail!("invalid token (stub)")
+            }
+        }
+    }
+
+    fn local_dev_provider() -> Arc<dyn AuthProvider> {
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            "tok-local-dev".to_string(),
+            BearerToken::Extended {
+                subject: "avelino".to_string(),
+                roles: vec!["admin".to_string()],
+            },
+        );
+        Arc::new(BearerTokenAuth::new(tokens))
+    }
+
+    fn jwt_like_provider() -> Arc<dyn AuthProvider> {
+        Arc::new(StubBearerOnly {
+            token: "fake.jwt.token".to_string(),
+            identity: AuthIdentity::new(
+                "alice@example.com",
+                vec!["dev".to_string(), "oauth-user".to_string()],
+            ),
+        })
+    }
+
+    fn auth_creds(token: &str) -> Credentials {
+        let mut c = Credentials::new();
+        c.insert("authorization".to_string(), format!("Bearer {token}"));
+        c
+    }
+
+    #[tokio::test]
+    async fn test_chain_static_bearer_authenticates_local_dev() {
+        // First provider in chain accepts → second provider never runs.
+        let chain = ProviderChain::new(vec![local_dev_provider(), jwt_like_provider()]);
+        let id = chain
+            .authenticate(&auth_creds("tok-local-dev"))
+            .await
+            .unwrap();
+        assert_eq!(id.subject, "avelino");
+        assert_eq!(id.roles, vec!["admin".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_chain_jwt_authenticates_when_static_fails() {
+        // Static rejects, JWT-like accepts → chain returns JWT identity.
+        // This is the cross-provider case that the briefing required.
+        let chain = ProviderChain::new(vec![local_dev_provider(), jwt_like_provider()]);
+        let id = chain
+            .authenticate(&auth_creds("fake.jwt.token"))
+            .await
+            .unwrap();
+        assert_eq!(id.subject, "alice@example.com");
+        assert!(id.roles.contains(&"oauth-user".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_chain_returns_first_provider_error_when_all_fail() {
+        // Oracle defense: must not leak which provider got further.
+        // The error returned must come from the FIRST configured provider,
+        // not the most informative one.
+        let chain = ProviderChain::new(vec![local_dev_provider(), jwt_like_provider()]);
+        let err = chain.authenticate(&auth_creds("nope")).await.unwrap_err();
+        // BearerTokenAuth's error is "invalid bearer token"; StubBearerOnly's
+        // is "invalid token (stub)". The first must win.
+        assert!(
+            err.to_string().contains("invalid bearer token"),
+            "expected first provider's error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chain_does_not_leak_jwt_role_to_static_user() {
+        // Privilege isolation: JWT identity has role `oauth-user` but a
+        // static-bearer auth must never inherit it. Ensures providers
+        // remain isolated state-wise.
+        let chain = ProviderChain::new(vec![local_dev_provider(), jwt_like_provider()]);
+        let id = chain
+            .authenticate(&auth_creds("tok-local-dev"))
+            .await
+            .unwrap();
+        assert!(
+            !id.roles.contains(&"oauth-user".to_string()),
+            "static bearer must not inherit OAuth role"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chain_empty_acts_as_no_auth() {
+        // Degenerate but valid: empty chain == anonymous identity.
+        let chain = ProviderChain::new(vec![]);
+        let id = chain.authenticate(&Credentials::new()).await.unwrap();
+        assert_eq!(id.subject, "anonymous");
+        assert!(id.roles.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_chain_short_circuits_on_first_success() {
+        // Performance contract: provider 2 must NOT be called when
+        // provider 1 already accepted. Wired with a counting stub.
+        struct CountingAccept(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+
+        #[async_trait]
+        impl AuthProvider for CountingAccept {
+            async fn authenticate(&self, _: &Credentials) -> Result<AuthIdentity> {
+                self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(AuthIdentity::new("counted", vec![]))
+            }
+        }
+
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let chain = ProviderChain::new(vec![
+            local_dev_provider(),
+            Arc::new(CountingAccept(counter.clone())),
+        ]);
+        chain
+            .authenticate(&auth_creds("tok-local-dev"))
+            .await
+            .unwrap();
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "second provider must not be invoked when first accepts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_chain_order_does_not_change_correctness() {
+        // Reversing provider order must still accept the same tokens.
+        let normal = ProviderChain::new(vec![local_dev_provider(), jwt_like_provider()]);
+        let reversed = ProviderChain::new(vec![jwt_like_provider(), local_dev_provider()]);
+
+        for tok in ["tok-local-dev", "fake.jwt.token"] {
+            let a = normal.authenticate(&auth_creds(tok)).await;
+            let b = reversed.authenticate(&auth_creds(tok)).await;
+            assert!(a.is_ok(), "normal order rejected token {tok}");
+            assert!(b.is_ok(), "reversed order rejected token {tok}");
+            assert_eq!(a.unwrap().subject, b.unwrap().subject);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_chain_rejects_bypass_via_missing_header() {
+        // No Authorization header → every provider in the chain rejects.
+        let chain = ProviderChain::new(vec![local_dev_provider(), jwt_like_provider()]);
+        assert!(chain.authenticate(&Credentials::new()).await.is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // read_trusted_user — extracted helper, reused by ForwardedUserAuth and
+    // by the OAuth AS /authorize handler (issue #90).
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_read_trusted_user_present() {
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        creds.insert("x-forwarded-groups".to_string(), "dev,admin".to_string());
+        let (subject, roles) =
+            read_trusted_user(&creds, "x-forwarded-user", "x-forwarded-groups").unwrap();
+        assert_eq!(subject, "alice");
+        assert_eq!(roles, vec!["dev".to_string(), "admin".to_string()]);
+    }
+
+    #[test]
+    fn test_read_trusted_user_case_insensitive_header_lookup() {
+        // Operator may declare headers with any casing in config; lookup
+        // must still find the lowercased credentials map entry.
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "bob".to_string());
+        let (subject, _) =
+            read_trusted_user(&creds, "X-Forwarded-User", "X-Forwarded-Groups").unwrap();
+        assert_eq!(subject, "bob");
+    }
+
+    #[test]
+    fn test_read_trusted_user_missing_returns_none() {
+        let creds = Credentials::new();
+        assert!(read_trusted_user(&creds, "x-forwarded-user", "x-forwarded-groups").is_none());
+    }
+
+    #[test]
+    fn test_read_trusted_user_empty_returns_none() {
+        // Empty user header is treated as "no identity" — never as an
+        // anonymous one. Important for the AS: an empty header must
+        // refuse to issue a code, not issue a code for "" subject.
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), String::new());
+        assert!(read_trusted_user(&creds, "x-forwarded-user", "x-forwarded-groups").is_none());
+    }
+
+    #[test]
+    fn test_read_trusted_user_no_groups_header_yields_empty_roles() {
+        let mut creds = Credentials::new();
+        creds.insert("x-forwarded-user".to_string(), "alice".to_string());
+        let (_, roles) =
+            read_trusted_user(&creds, "x-forwarded-user", "x-forwarded-groups").unwrap();
+        assert!(roles.is_empty());
     }
 }

--- a/src/server_auth/providers.rs
+++ b/src/server_auth/providers.rs
@@ -171,7 +171,12 @@ impl AuthProvider for ForwardedUserAuth {
     async fn authenticate(&self, creds: &Credentials) -> Result<AuthIdentity> {
         match read_trusted_user(creds, &self.header, &self.groups_header) {
             Some((subject, roles)) => Ok(AuthIdentity::new(subject, roles)),
-            None => match creds.get(&self.header) {
+            // Mirror the case-insensitive lookup `read_trusted_user`
+            // performs on the header name. The constructor already
+            // lowercases `self.header`, but redoing it here keeps the
+            // error branch correct even if a future change relaxes
+            // that invariant.
+            None => match creds.get(&self.header.to_lowercase()) {
                 Some(_) => bail!("{} header is empty", self.header),
                 None => bail!("missing {} header", self.header),
             },


### PR DESCRIPTION
Claude.ai, ChatGPT, Cursor and other AI clients consuming the MCP authorization spec can't connect with a static bearer token — they probe `.well-known/*` and `/register`, expect an OAuth flow with Dynamic Client Registration, and walk away when the server returns
404. Local dev still needs the static token though, so we can't just swap providers.

Implement an OAuth 2.0 AS (PKCE S256, RFC 7591 DCR, JWT HS256) inside `mcp serve` and refactor `serverAuth` to take a `providers` array so multiple providers run as a chain on the same /mcp. Static bearer + JWT coexist on a single instance; ACL discriminates per role via the existing role-based schema (no dispatcher changes). User authentication is delegated to a trusted reverse proxy via X-Forwarded-User, gated by required CIDR allowlist to block direct-client header spoofing. Old `provider: "..."` schema is not auto-migrated — listed as a breaking change in the docs.

Closes #90