### PR TITLE
Add native OpenTelemetry traces and metrics to mcp serve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,6 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1183,11 +1182,10 @@ dependencies = [
  "open",
  "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "rand 0.10.1",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2",
@@ -1299,8 +1297,11 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "opentelemetry",
- "reqwest 0.12.28",
+ "tokio",
 ]
 
 [[package]]
@@ -1315,7 +1316,6 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
@@ -1333,12 +1333,6 @@ dependencies = [
  "tonic",
  "tonic-prost",
 ]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -1696,44 +1690,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
 
 [[package]]
 name = "reqwest"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,6 +481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +521,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -597,6 +620,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +723,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -702,8 +745,22 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -914,6 +971,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,9 +1181,13 @@ dependencies = [
  "indicatif",
  "jsonwebtoken",
  "open",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
  "rand 0.10.1",
  "regex",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sha2",
@@ -1127,6 +1197,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "uuid",
@@ -1207,6 +1278,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,6 +1397,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1300,6 +1471,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1502,6 +1696,44 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "reqwest"
@@ -2093,6 +2325,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,9 +2369,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2180,6 +2452,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,10 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "metrics",
   "grpc-tonic",
   "http-proto",
-  "reqwest-client",
-  "reqwest-rustls",
+  # `hyper-client` reuses the hyper 1.x stack axum 0.8 already pulls,
+  # avoiding a second copy of reqwest in the binary.
+  "hyper-client",
 ] }
-opentelemetry-semantic-conventions = "0.31"
 tracing-opentelemetry = "0.32"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,29 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 jsonwebtoken = { version = "10", default-features = false, features = ["aws_lc_rs"] }
 
+# OpenTelemetry — default-off, ativado via OTEL_EXPORTER_OTLP_ENDPOINT.
+# Suporta gRPC (tonic) e HTTP/protobuf (reqwest) — operador escolhe via
+# OTEL_EXPORTER_OTLP_PROTOCOL. Reqwest reutiliza nossa stack já existente.
+opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.31", default-features = false, features = [
+  "rt-tokio",
+  "trace",
+  "metrics",
+  # Required so the batch span processor runs on the tokio runtime (rather
+  # than spawning its own thread, which can't drive reqwest futures).
+  "experimental_trace_batch_span_processor_with_async_runtime",
+  "experimental_metrics_periodicreader_with_async_runtime",
+] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = [
+  "trace",
+  "metrics",
+  "grpc-tonic",
+  "http-proto",
+  "reqwest-client",
+  "reqwest-rustls",
+] }
+opentelemetry-semantic-conventions = "0.31"
+tracing-opentelemetry = "0.32"
+
 [dev-dependencies]
 tempfile = "3"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -19,6 +19,7 @@
 * [CLI as MCP](guides/cli-as-mcp.md)
 * [Proxy mode](guides/proxy-mode.md)
 * [Audit logging](guides/audit-logging.md)
+* [Observability](guides/observability.md)
 * [Enterprise token management](guides/enterprise-token-management.md)
 
 ## How-to
@@ -26,6 +27,7 @@
 * [Docker](howto/docker.md)
 * [Kubernetes](howto/kubernetes.md)
 * [OAuth Authorization Server (Claude.ai, ChatGPT, Cursor)](howto/oauth-as.md)
+* [Observability quickstart (Jaeger + OTel collector)](howto/observability-quickstart.md)
 * [Supported services](howto/services.md)
 * [Troubleshooting](howto/troubleshooting.md)
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,156 @@
+# Observability — OpenTelemetry traces & metrics
+
+`mcp serve` (proxy mode) emite **traces** e **métricas** OTLP nativas. Default-off:
+sem env var, comportamento é bit-idêntico à 0.5.2 — log estruturado em stderr +
+audit local em chrondb.
+
+> **Quer testar agora?** Vai direto pro [quickstart hands-on](../howto/observability-quickstart.md)
+> — sobe Jaeger + `mcp serve` em 3 minutos e prova end-to-end (incluindo `traceparent`
+> propagation e métricas).
+>
+> Esta página aqui é a **referência** — o que cada atributo significa, como
+> configurar pra cada vendor, e os escape hatches pra quando algo der ruim.
+
+## Escape hatches (lê isso primeiro)
+
+Roda `mcp serve` em produção e tá nervoso de ligar OTel? Dois switches que valem
+ouro:
+
+- **Unset `OTEL_EXPORTER_OTLP_ENDPOINT`** → telemetria **inteira** desliga. Comportamento
+  idêntico ao 0.5.2. Sem rebuild, sem rollback, é só remover do deploy.
+- **`MCP_OTEL_INJECT_TRACEPARENT=0`** → mantém traces e métricas, **só** desliga a
+  injeção do header `traceparent` em chamadas outbound. Use se algum backend MCP
+  estranho rejeitar header desconhecido (W3C `traceparent` é padrão, mas servidor
+  ruim existe).
+
+## Configuração — env vars padrão OTel
+
+Tudo controlado por env var OTel. **Nada** vai pro `servers.json`.
+
+| Variável | Efeito |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | **Único ativador.** Vazio ou ausente = OTel off. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) ou `http/protobuf`. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | CSV `k1=v1,k2=v2`. Só HTTP por spec. |
+| `OTEL_SERVICE_NAME` | Resource `service.name`. Default `mcp`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Resource attrs extras, CSV. |
+| `MCP_OTEL_INJECT_TRACEPARENT` | `0`/`false`/`no` desliga injeção outbound. |
+
+> **Diagnóstico rápido**: a primeira linha do stderr quando OTel inicia é
+> `[telemetry] OpenTelemetry initialized — endpoint=... protocol=...`.
+> Sai direto pra stderr, **não** respeita `MCP_LOG_LEVEL`. Se essa linha não
+> aparece, OTel não subiu — confere o env var.
+
+## Recipes por vendor
+
+### Honeycomb
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_EXPORTER_OTLP_HEADERS="x-honeycomb-team=YOUR_API_KEY" \
+OTEL_SERVICE_NAME=mcp-prod \
+OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production" \
+mcp serve --http 0.0.0.0:7331 --insecure
+```
+
+Honeycomb público **só aceita HTTP/protobuf** — gRPC não roda. Não esquece o
+`x-honeycomb-team` header.
+
+### Grafana Tempo (self-hosted)
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4317 \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_SERVICE_NAME=mcp \
+mcp serve --http 0.0.0.0:7331 --insecure
+```
+
+`grpc` é o default da spec OTel — pode omitir `OTEL_EXPORTER_OTLP_PROTOCOL` se
+quiser.
+
+### Datadog (via Agent)
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://datadog-agent:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_SERVICE_NAME=mcp \
+OTEL_RESOURCE_ATTRIBUTES="env=prod,team=platform" \
+mcp serve --http 0.0.0.0:7331 --insecure
+```
+
+Datadog Agent expõe OTLP receiver na 4317/4318 quando habilitado.
+
+### Local (desenvolvimento)
+
+Pra subir Jaeger + ver tudo end-to-end na sua máquina, segue o
+[quickstart hands-on](../howto/observability-quickstart.md).
+
+## Span attributes
+
+Toda request gera um span raiz `mcp.request` com:
+
+| Attribute | Significado |
+|---|---|
+| `otel.kind` | `server` |
+| `mcp.method` | método JSON-RPC (`tools/call`, `tools/list`, `resources/read`, …) |
+| `mcp.transport` | `serve:http` ou `serve:stdio` |
+| `mcp.identity` | subject autenticado (JWT `sub`, nome do bearer-token, ou `anonymous`) |
+| `mcp.server` | alias do backend, **só** depois que routing resolve (tools/call, resources/read, prompts/get) |
+| `mcp.tool` | nome do tool no backend |
+| `mcp.status` | `ok` ou `error` |
+
+A duração do span = tempo total do `dispatch_request`. Inclui ACL, lock do
+proxy, conexão com backend e o backend call em si — útil pra entender onde tá
+gastando latência.
+
+`traceparent` inbound (do cliente) é honrado: o span da `mcp` vira filho do
+span do cliente, não cria trace novo. Saindo pra backends HTTP, a `mcp` injeta
+`traceparent`/`tracestate` automaticamente — backend instrumentado continua o
+trace.
+
+## Metrics
+
+| Métrica | Tipo | Unidade | Atributos |
+|---|---|---|---|
+| `mcp.proxy.requests` | counter | — | `mcp.method`, `mcp.transport`, `mcp.status`, `mcp.identity`, `mcp.server`*, `mcp.tool`* |
+| `mcp.proxy.request.duration` | histogram | ms | mesmos da counter |
+| `mcp.proxy.classifier.cache.hits` | counter | — | `mcp.server` |
+| `mcp.proxy.classifier.cache.misses` | counter | — | `mcp.server` |
+| `mcp.proxy.backends.connected` | gauge | — | — |
+| `mcp.proxy.sessions.active` | gauge | — | — |
+
+\* `mcp.server` e `mcp.tool` só presentes quando a request resolve pra um
+backend (ausentes em `auth/failure`, métodos desconhecidos, payload
+malformado).
+
+PeriodicReader exporta a cada 60s (default OTel SDK). Se for testar local, espera
+~65s depois do primeiro request pra ver no exporter.
+
+## Cardinalidade — atenção
+
+`mcp.identity` discrimina por subject autenticado. Se subjects são UUIDs por
+usuário (JWT `sub` único), você gera muita série. Honeycomb/Tempo/Datadog
+aguentam, mas é trade-off consciente — se só interessa breakdown por role,
+remove o label upstream (config do collector).
+
+## O que NÃO faz
+
+- **Sem Sentry / panic tracking.** Erros viram `mcp.status=error` no span.
+  Sentry vai em issue separada.
+- **Sem profiling contínuo.**
+- **Sem OTLP logs signal.** Audit fica em chrondb (`mcp logs`); log
+  estruturado continua em stderr controlado por `MCP_LOG_LEVEL` /
+  `MCP_LOG_FORMAT`.
+
+## Troubleshooting
+
+Se algo deu ruim, [o quickstart](../howto/observability-quickstart.md#troubleshooting)
+tem checklist mais completo. Resumo:
+
+- **Sem `[telemetry] OpenTelemetry initialized` no stderr** = env var não foi
+  lido. Confere `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- **Inicializou mas nada chega** = endpoint errado, firewall, ou vendor que só
+  aceita HTTP (`OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`).
+- **`traceparent` não chega no backend** = telemetria não inicializou OU
+  `MCP_OTEL_INJECT_TRACEPARENT=0` está setado.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,47 +1,49 @@
 # Observability — OpenTelemetry traces & metrics
 
-`mcp serve` (proxy mode) emite **traces** e **métricas** OTLP nativas. Default-off:
-sem env var, comportamento é bit-idêntico à 0.5.2 — log estruturado em stderr +
-audit local em chrondb.
+`mcp serve` (proxy mode) emits native OTLP **traces** and **metrics**.
+Default-off: without an env var, behavior is byte-identical to 0.5.2 —
+structured logs on stderr + local audit trail in chrondb.
 
-> **Quer testar agora?** Vai direto pro [quickstart hands-on](../howto/observability-quickstart.md)
-> — sobe Jaeger + `mcp serve` em 3 minutos e prova end-to-end (incluindo `traceparent`
-> propagation e métricas).
+> **Want to try it now?** Jump to the [hands-on quickstart](../howto/observability-quickstart.md)
+> — it spins up Jaeger + `mcp serve` in 3 minutes and proves the full path
+> end-to-end (including `traceparent` propagation and metrics).
 >
-> Esta página aqui é a **referência** — o que cada atributo significa, como
-> configurar pra cada vendor, e os escape hatches pra quando algo der ruim.
+> This page is the **reference** — what each attribute means, how to
+> configure each vendor, and the escape hatches for when something goes
+> sideways.
 
-## Escape hatches (lê isso primeiro)
+## Escape hatches (read this first)
 
-Roda `mcp serve` em produção e tá nervoso de ligar OTel? Dois switches que valem
-ouro:
+Running `mcp serve` in production and nervous about turning OTel on? Two
+switches worth knowing:
 
-- **Unset `OTEL_EXPORTER_OTLP_ENDPOINT`** → telemetria **inteira** desliga. Comportamento
-  idêntico ao 0.5.2. Sem rebuild, sem rollback, é só remover do deploy.
-- **`MCP_OTEL_INJECT_TRACEPARENT=0`** → mantém traces e métricas, **só** desliga a
-  injeção do header `traceparent` em chamadas outbound. Use se algum backend MCP
-  estranho rejeitar header desconhecido (W3C `traceparent` é padrão, mas servidor
-  ruim existe).
+- **Unset `OTEL_EXPORTER_OTLP_ENDPOINT`** → telemetry is **fully**
+  disabled. Behavior is identical to 0.5.2. No rebuild, no rollback,
+  just remove the env var from the deploy.
+- **`MCP_OTEL_INJECT_TRACEPARENT=0`** → keeps traces and metrics on,
+  **only** disables `traceparent` injection on outbound calls. Use this
+  if some odd backend rejects unknown headers (W3C `traceparent` is
+  standard, but bad servers exist).
 
-## Configuração — env vars padrão OTel
+## Configuration — standard OTel env vars
 
-Tudo controlado por env var OTel. **Nada** vai pro `servers.json`.
+Everything is driven by OTel env vars. **Nothing** lives in `servers.json`.
 
-| Variável | Efeito |
+| Variable | Effect |
 |---|---|
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | **Único ativador.** Vazio ou ausente = OTel off. |
-| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) ou `http/protobuf`. |
-| `OTEL_EXPORTER_OTLP_HEADERS` | CSV `k1=v1,k2=v2`. Só HTTP por spec. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | **Sole activator.** Empty or unset = OTel off. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) or `http/protobuf`. |
+| `OTEL_EXPORTER_OTLP_HEADERS` | CSV `k1=v1,k2=v2`. HTTP only per spec. |
 | `OTEL_SERVICE_NAME` | Resource `service.name`. Default `mcp`. |
-| `OTEL_RESOURCE_ATTRIBUTES` | Resource attrs extras, CSV. |
-| `MCP_OTEL_INJECT_TRACEPARENT` | `0`/`false`/`no` desliga injeção outbound. |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, CSV format. |
+| `MCP_OTEL_INJECT_TRACEPARENT` | `0`/`false`/`no` disables outbound injection. |
 
-> **Diagnóstico rápido**: a primeira linha do stderr quando OTel inicia é
+> **Quick diagnostic**: when OTel boots, the very first line on stderr is
 > `[telemetry] OpenTelemetry initialized — endpoint=... protocol=...`.
-> Sai direto pra stderr, **não** respeita `MCP_LOG_LEVEL`. Se essa linha não
-> aparece, OTel não subiu — confere o env var.
+> It prints directly to stderr and **does not** respect `MCP_LOG_LEVEL`.
+> If you don't see it, OTel didn't start — check the env var.
 
-## Recipes por vendor
+## Vendor recipes
 
 ### Honeycomb
 
@@ -54,8 +56,8 @@ OTEL_RESOURCE_ATTRIBUTES="deployment.environment=production" \
 mcp serve --http 0.0.0.0:7331 --insecure
 ```
 
-Honeycomb público **só aceita HTTP/protobuf** — gRPC não roda. Não esquece o
-`x-honeycomb-team` header.
+The public Honeycomb ingest **only accepts HTTP/protobuf** — gRPC won't
+work. Don't forget the `x-honeycomb-team` header.
 
 ### Grafana Tempo (self-hosted)
 
@@ -66,8 +68,8 @@ OTEL_SERVICE_NAME=mcp \
 mcp serve --http 0.0.0.0:7331 --insecure
 ```
 
-`grpc` é o default da spec OTel — pode omitir `OTEL_EXPORTER_OTLP_PROTOCOL` se
-quiser.
+`grpc` is the OTel SDK default — you can omit `OTEL_EXPORTER_OTLP_PROTOCOL`
+if you want.
 
 ### Datadog (via Agent)
 
@@ -79,78 +81,80 @@ OTEL_RESOURCE_ATTRIBUTES="env=prod,team=platform" \
 mcp serve --http 0.0.0.0:7331 --insecure
 ```
 
-Datadog Agent expõe OTLP receiver na 4317/4318 quando habilitado.
+The Datadog Agent exposes an OTLP receiver on 4317/4318 once enabled.
 
-### Local (desenvolvimento)
+### Local (development)
 
-Pra subir Jaeger + ver tudo end-to-end na sua máquina, segue o
-[quickstart hands-on](../howto/observability-quickstart.md).
+To bring up Jaeger + see the whole flow on your machine, follow the
+[hands-on quickstart](../howto/observability-quickstart.md).
 
 ## Span attributes
 
-Toda request gera um span raiz `mcp.request` com:
+Every request produces a single root span `mcp.request` with:
 
-| Attribute | Significado |
+| Attribute | Meaning |
 |---|---|
 | `otel.kind` | `server` |
-| `mcp.method` | método JSON-RPC (`tools/call`, `tools/list`, `resources/read`, …) |
-| `mcp.transport` | `serve:http` ou `serve:stdio` |
-| `mcp.identity` | subject autenticado (JWT `sub`, nome do bearer-token, ou `anonymous`) |
-| `mcp.server` | alias do backend, **só** depois que routing resolve (tools/call, resources/read, prompts/get) |
-| `mcp.tool` | nome do tool no backend |
-| `mcp.status` | `ok` ou `error` |
+| `mcp.method` | JSON-RPC method (`tools/call`, `tools/list`, `resources/read`, …) |
+| `mcp.transport` | `serve:http` or `serve:stdio` |
+| `mcp.identity` | Authenticated subject (JWT `sub`, bearer-token name, or `anonymous`) |
+| `mcp.server` | Backend alias, **only** after routing resolves (tools/call, resources/read, prompts/get) |
+| `mcp.tool` | Backend tool name |
+| `mcp.status` | `ok` or `error` |
 
-A duração do span = tempo total do `dispatch_request`. Inclui ACL, lock do
-proxy, conexão com backend e o backend call em si — útil pra entender onde tá
-gastando latência.
+Span duration = total time inside `dispatch_request`. Includes ACL
+evaluation, the brief proxy lock, the backend connection, and the backend
+call itself — useful to see where latency is going.
 
-`traceparent` inbound (do cliente) é honrado: o span da `mcp` vira filho do
-span do cliente, não cria trace novo. Saindo pra backends HTTP, a `mcp` injeta
-`traceparent`/`tracestate` automaticamente — backend instrumentado continua o
-trace.
+Inbound `traceparent` (from the client) is honored: the `mcp` span
+becomes a child of the client's span, no new trace is created. Outbound,
+`mcp` injects `traceparent`/`tracestate` automatically — an instrumented
+backend continues the trace.
 
 ## Metrics
 
-| Métrica | Tipo | Unidade | Atributos |
+| Metric | Type | Unit | Attributes |
 |---|---|---|---|
 | `mcp.proxy.requests` | counter | — | `mcp.method`, `mcp.transport`, `mcp.status`, `mcp.identity`, `mcp.server`*, `mcp.tool`* |
-| `mcp.proxy.request.duration` | histogram | ms | mesmos da counter |
+| `mcp.proxy.request.duration` | histogram | ms | same as the counter |
 | `mcp.proxy.classifier.cache.hits` | counter | — | `mcp.server` |
 | `mcp.proxy.classifier.cache.misses` | counter | — | `mcp.server` |
 | `mcp.proxy.backends.connected` | gauge | — | — |
 | `mcp.proxy.sessions.active` | gauge | — | — |
 
-\* `mcp.server` e `mcp.tool` só presentes quando a request resolve pra um
-backend (ausentes em `auth/failure`, métodos desconhecidos, payload
-malformado).
+\* `mcp.server` and `mcp.tool` only appear when the request resolves to
+a backend (absent on `auth/failure`, unknown methods, malformed payload).
+The `mcp.tool` label carries the backend tool name (un-namespaced) — the
+namespace lives in `mcp.server`.
 
-PeriodicReader exporta a cada 60s (default OTel SDK). Se for testar local, espera
-~65s depois do primeiro request pra ver no exporter.
+The PeriodicReader exports every 60s (OTel SDK default). When testing
+locally, wait ~65s after the first request before checking the exporter.
 
-## Cardinalidade — atenção
+## Cardinality — heads-up
 
-`mcp.identity` discrimina por subject autenticado. Se subjects são UUIDs por
-usuário (JWT `sub` único), você gera muita série. Honeycomb/Tempo/Datadog
-aguentam, mas é trade-off consciente — se só interessa breakdown por role,
-remove o label upstream (config do collector).
+`mcp.identity` discriminates per authenticated subject. If your subjects
+are per-user UUID JWTs, you'll generate many series. Honeycomb / Tempo /
+Datadog handle it, but it's a deliberate trade-off — if you only care
+about role-level breakdowns, drop the label upstream (in your collector
+config).
 
-## O que NÃO faz
+## What it does NOT do
 
-- **Sem Sentry / panic tracking.** Erros viram `mcp.status=error` no span.
-  Sentry vai em issue separada.
-- **Sem profiling contínuo.**
-- **Sem OTLP logs signal.** Audit fica em chrondb (`mcp logs`); log
-  estruturado continua em stderr controlado por `MCP_LOG_LEVEL` /
-  `MCP_LOG_FORMAT`.
+- **No Sentry / panic tracking.** Errors flow as `mcp.status=error` on
+  the span. Sentry is tracked in a separate issue.
+- **No continuous profiling.**
+- **No OTLP logs signal.** The audit trail stays in chrondb (`mcp logs`);
+  the structured log keeps going to stderr, controlled by `MCP_LOG_LEVEL`
+  / `MCP_LOG_FORMAT`.
 
 ## Troubleshooting
 
-Se algo deu ruim, [o quickstart](../howto/observability-quickstart.md#troubleshooting)
-tem checklist mais completo. Resumo:
+If something went wrong, [the quickstart](../howto/observability-quickstart.md#troubleshooting)
+has a longer checklist. In short:
 
-- **Sem `[telemetry] OpenTelemetry initialized` no stderr** = env var não foi
-  lido. Confere `OTEL_EXPORTER_OTLP_ENDPOINT`.
-- **Inicializou mas nada chega** = endpoint errado, firewall, ou vendor que só
-  aceita HTTP (`OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`).
-- **`traceparent` não chega no backend** = telemetria não inicializou OU
-  `MCP_OTEL_INJECT_TRACEPARENT=0` está setado.
+- **No `[telemetry] OpenTelemetry initialized` on stderr** = the env var
+  wasn't read. Check `OTEL_EXPORTER_OTLP_ENDPOINT`.
+- **It initialized but nothing arrives** = wrong endpoint, firewall, or
+  a vendor that only accepts HTTP (`OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`).
+- **`traceparent` not reaching the backend** = either telemetry didn't
+  initialize, or `MCP_OTEL_INJECT_TRACEPARENT=0` is set.

--- a/docs/guides/proxy-mode.md
+++ b/docs/guides/proxy-mode.md
@@ -717,6 +717,14 @@ All standard `mcp` env vars apply:
 
 See [environment variables reference](../reference/environment-variables.md) for full details.
 
+## Observability (OpenTelemetry)
+
+`mcp serve` natively emits **traces** and **metrics** via OTLP when
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set. Default-off; standard OTel env
+vars only. See [observability guide](./observability.md) for span
+attributes, metrics list, Honeycomb / Tempo / collector recipes, and
+escape hatches for production rollback.
+
 ## When to use each mode
 
 | Scenario | Mode |

--- a/docs/howto/observability-quickstart.md
+++ b/docs/howto/observability-quickstart.md
@@ -1,0 +1,330 @@
+# Quickstart — OpenTelemetry no `mcp serve`
+
+Tutorial copy-paste pra subir traces + metrics em ~3 minutos. Roda local
+com Jaeger (UI bonita) e depois mostra como ver métricas com OTel
+Collector. No final tem o teste de regressão (default-off).
+
+Pré-requisito: Docker + `mcp` 0.6.0+ (`mcp --version`).
+
+> Por que rodar isso? Antes de plugar `mcp serve` num Honeycomb /
+> Datadog / Tempo de produção, você quer **provar local** que o trace
+> tá fluindo, que o `traceparent` propaga, e que sem env var nada
+> muda. Esse passo a passo prova as três coisas.
+
+---
+
+## 1. Sobe Jaeger
+
+Jaeger v2 já fala OTLP nativo (gRPC em `:4317`, HTTP em `:4318`) e tem
+UI em `:16686`. Um container só:
+
+```bash
+docker run -d --rm --name mcp-jaeger \
+  -p 16686:16686 -p 4317:4317 -p 4318:4318 \
+  jaegertracing/jaeger:latest
+```
+
+Espera ficar de pé:
+
+```bash
+until curl -fsS http://127.0.0.1:16686/api/services >/dev/null; do sleep 1; done
+echo READY
+```
+
+UI: <http://localhost:16686>.
+
+---
+
+## 2. Sobe `mcp serve` com OTel ligado
+
+Aponta pra Jaeger HTTP (porta 4318). `OTEL_EXPORTER_OTLP_ENDPOINT` é o
+**único** ativador — qualquer outro env var abaixo é opcional:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+OTEL_SERVICE_NAME=mcp-local \
+mcp serve --http 127.0.0.1:7331
+```
+
+No stderr, **a primeira linha** tem que ser:
+
+```
+[telemetry] OpenTelemetry initialized — endpoint=http://127.0.0.1:4318 protocol=HttpProto
+```
+
+> Sem essa linha = OTel **não** subiu. Confere o env var.
+
+Deixa rodando.
+
+---
+
+## 3. Dispara requests
+
+Em outro terminal, dispara umas chamadas:
+
+```bash
+# tools/list — span sem mcp.tool/mcp.server (não resolve em backend)
+for i in 1 2 3; do
+  curl -s -X POST http://127.0.0.1:7331/mcp \
+    -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":$i,\"method\":\"tools/list\"}" \
+    -o /dev/null -w "tools/list $i: %{http_code}\n"
+done
+
+# tools/call — span com mcp.tool e mcp.server resolvidos
+# (troca filesystem__list_allowed_directories por algum tool seu)
+curl -s -X POST http://127.0.0.1:7331/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":99,"method":"tools/call",
+       "params":{"name":"filesystem__list_allowed_directories","arguments":{}}}' \
+  -o /dev/null -w "tools/call: %{http_code}\n"
+```
+
+Aguarda o batch flushar (default ~5s):
+
+```bash
+sleep 8
+```
+
+---
+
+## 4. Vê os spans no Jaeger
+
+Abre <http://localhost:16686>:
+
+1. **Service:** escolhe `mcp-local`
+2. **Operation:** `mcp.request`
+3. Click **Find Traces**
+
+Aparecem N traces, cada um com 1 span `mcp.request`. Click em qualquer
+um — em **Tags** você vê:
+
+```
+otel.kind       = server
+mcp.method      = tools/list (ou tools/call)
+mcp.transport   = serve:http
+mcp.identity    = anonymous
+mcp.status      = ok
+mcp.server      = filesystem      ← só nos tools/call resolvidos
+mcp.tool        = list_allowed_directories
+```
+
+A duração do span é o tempo total que o `dispatch_request` levou —
+inclui ACL, lock do proxy, conexão com backend e o backend call em si.
+
+### Sanity check via API (sem clicar)
+
+```bash
+curl -s "http://127.0.0.1:16686/api/traces?service=mcp-local&limit=3" \
+  | python3 -c '
+import json, sys
+for t in json.load(sys.stdin)["data"]:
+    for s in t["spans"]:
+        tags = {tg["key"]: tg.get("value") for tg in s["tags"]}
+        mcp = {k:v for k,v in tags.items() if k.startswith("mcp.")}
+        print(f"{s[\"operationName\"]:14} dur={s[\"duration\"]:>7}us {mcp}")
+'
+```
+
+---
+
+## 5. Testa parent context (`traceparent` inbound)
+
+Quando o cliente é OTel-aware (Claude.ai, gateway instrumentado, OTel
+SDK), ele manda `traceparent` no header. O `mcp serve` deve **continuar
+o trace** — span dele vira filho do span do cliente, não cria trace
+novo.
+
+Manda um `traceparent` fake e confere stitching:
+
+```bash
+TRACEPARENT='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01'
+
+curl -s -X POST http://127.0.0.1:7331/mcp \
+  -H 'Content-Type: application/json' \
+  -H "traceparent: $TRACEPARENT" \
+  -d '{"jsonrpc":"2.0","id":42,"method":"tools/list"}' \
+  -o /dev/null -w "HTTP %{http_code}\n"
+
+sleep 5
+
+# Pega o trace pelo traceID que injetamos
+curl -s "http://127.0.0.1:16686/api/traces/0af7651916cd43dd8448eb211c80319c" \
+  | python3 -c '
+import json, sys
+data = json.load(sys.stdin)["data"]
+if not data:
+    print("FAIL: parent context não funcionou")
+else:
+    for s in data[0]["spans"]:
+        refs = s.get("references", [])
+        parent = refs[0]["spanID"] if refs else "ROOT"
+        print(f"  span {s[\"operationName\"]} parent={parent}")
+'
+```
+
+Saída esperada:
+
+```
+  span mcp.request parent=b7ad6b7169203331
+```
+
+`parent=b7ad6b7169203331` confirma que o span do `mcp.request` virou
+filho do span que mandamos no `traceparent`. Trace stitching ✓.
+
+---
+
+## 6. Vê as métricas
+
+Jaeger v2 só guarda traces. Pra ver counter/histogram/gauge, troca por
+um OTel Collector com debug exporter:
+
+```bash
+docker stop mcp-jaeger
+
+cat > /tmp/otel-debug.yaml <<'EOF'
+receivers:
+  otlp:
+    protocols:
+      grpc: { endpoint: 0.0.0.0:4317 }
+      http: { endpoint: 0.0.0.0:4318 }
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:  { receivers: [otlp], exporters: [debug] }
+    metrics: { receivers: [otlp], exporters: [debug] }
+EOF
+
+docker run -d --rm --name mcp-otelcol \
+  -v /tmp/otel-debug.yaml:/etc/otelcol-contrib/config.yaml \
+  -p 4317:4317 -p 4318:4318 \
+  otel/opentelemetry-collector-contrib:latest
+```
+
+Continua disparando requests no `mcp serve`. **Importante:** o
+PeriodicReader exporta métricas a cada 60s (default OTel SDK), então
+**aguarda ~65 segundos** depois do primeiro request.
+
+Depois de 65s:
+
+```bash
+docker logs mcp-otelcol 2>&1 | grep -E "Name:|Value:|mcp\." | head -40
+```
+
+Saída esperada:
+
+```
+     -> Name: mcp.proxy.requests
+     -> mcp.method: Str(tools/call)
+     -> mcp.server: Str(filesystem)
+     -> mcp.tool: Str(filesystem__list_allowed_directories)
+Value: 6
+     -> Name: mcp.proxy.classifier.cache.hits
+     -> mcp.server: Str(filesystem)
+Value: 28
+     -> Name: mcp.proxy.backends.connected
+Value: 6
+     -> Name: mcp.proxy.sessions.active
+Value: 0
+```
+
+> Métricas que a `mcp` emite, em uma frase:
+> - `mcp.proxy.requests` (counter) e `mcp.proxy.request.duration` (histogram, ms) — uma por request, com labels `method/server/tool/status/transport/identity`
+> - `mcp.proxy.classifier.cache.hits/misses` por server
+> - `mcp.proxy.backends.connected` e `mcp.proxy.sessions.active` (gauges) atualizados a cada export
+
+---
+
+## 7. Teste de regressão — sem OTel = comportamento 0.5.2
+
+Esse é o passo que **prova que sua versão atual em produção não
+quebra**. Mata o serve atual e religa **sem nenhuma env var OTel**:
+
+```bash
+# em outro terminal
+pkill -f "mcp serve"
+sleep 1
+
+mcp serve --http 127.0.0.1:7331
+```
+
+No stderr você **não pode ver** a linha `[telemetry] OpenTelemetry
+initialized`. Boot tem que abrir igualzinho à 0.5.2:
+
+```
+INFO database opened idle_timeout=120s
+INFO HTTP server listening addr=127.0.0.1:7331
+```
+
+`tools/list` continua respondendo:
+
+```bash
+curl -s -X POST http://127.0.0.1:7331/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+  -o /dev/null -w "no-otel HTTP %{http_code}\n"
+# no-otel HTTP 200
+```
+
+Esse é o **fail-safe**: se o OTel der pau em produção, basta
+**unset** do `OTEL_EXPORTER_OTLP_ENDPOINT` no deploy e o sistema
+volta exatamente ao comportamento anterior. Sem rebuild, sem
+rollback de imagem.
+
+---
+
+## 8. Cleanup
+
+```bash
+pkill -f "mcp serve"
+docker stop mcp-otelcol mcp-jaeger 2>/dev/null
+rm -f /tmp/otel-debug.yaml
+```
+
+---
+
+## Próximos passos
+
+- Em produção, troca o endpoint pra Honeycomb / Tempo / Datadog —
+  exemplos no [guia conceitual de observability](../guides/observability.md).
+- Se um backend MCP rejeitar `traceparent` (raro, é header W3C
+  padrão), ative o escape hatch sem mexer no resto:
+  `MCP_OTEL_INJECT_TRACEPARENT=0`.
+- Sampling fica do lado do exporter — `mcp serve` sempre cria o span;
+  Honeycomb/Tempo/seu collector decide o que sample. Configure lá, não
+  aqui.
+
+## Troubleshooting
+
+**Não aparece nada no Jaeger nem nos logs do collector.**
+Confere a primeira linha do stderr do `mcp serve` — se não tem
+`[telemetry] OpenTelemetry initialized`, o env var não foi lido. A
+linha sai **direto pra stderr**, antes do logging subscriber, **não**
+respeita `MCP_LOG_LEVEL`.
+
+**Saiu "OpenTelemetry initialized" mas nada chega no collector.**
+Provavelmente o endpoint está errado. A `mcp` espera o **base URL**
+(ex: `http://host:4318`), não o caminho completo (`/v1/traces`). Mas
+ela aceita ambos. Se você trocou de receiver e não cleanou env var
+antiga, ainda pode estar mandando pro lugar errado.
+
+**Span sem `mcp.server`/`mcp.tool`.**
+Isso é normal pra `tools/list`, `auth/failure`, métodos
+desconhecidos, ou requests com payload malformado — esses não
+resolvem pra um backend específico. Em `tools/call` resolvido eles
+sempre aparecem.
+
+**`tonic` connection refused em endpoint HTTPS.**
+Honeycomb (e alguns outros vendors) **só aceitam HTTP/protobuf** no
+endpoint público. Defina `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
+e use `https://` no endpoint.
+
+**Métricas não aparecem mesmo depois de 60s.**
+PeriodicReader é "best-effort": se o processo cair antes do primeiro
+flush, o export some. O `TelemetryGuard` no `Drop` de `main` faz
+shutdown gracioso (que força flush). Em prod isso é coberto pelo
+SIGTERM normal — mas se você der `kill -9` pode perder o último
+batch.

--- a/docs/howto/observability-quickstart.md
+++ b/docs/howto/observability-quickstart.md
@@ -1,22 +1,23 @@
-# Quickstart — OpenTelemetry no `mcp serve`
+# Quickstart — OpenTelemetry on `mcp serve`
 
-Tutorial copy-paste pra subir traces + metrics em ~3 minutos. Roda local
-com Jaeger (UI bonita) e depois mostra como ver métricas com OTel
-Collector. No final tem o teste de regressão (default-off).
+Copy-paste tutorial to bring up traces + metrics in ~3 minutes. Runs
+locally with Jaeger (nice UI) and then shows how to inspect metrics
+with the OTel Collector. Ends with the regression test (default-off).
 
-Pré-requisito: Docker + `mcp` 0.6.0+ (`mcp --version`).
+Prerequisites: Docker + a build of `mcp` that includes native OTel
+support (any post-OpenTelemetry release; check `mcp --version`).
 
-> Por que rodar isso? Antes de plugar `mcp serve` num Honeycomb /
-> Datadog / Tempo de produção, você quer **provar local** que o trace
-> tá fluindo, que o `traceparent` propaga, e que sem env var nada
-> muda. Esse passo a passo prova as três coisas.
+> Why bother running this? Before pointing `mcp serve` at a production
+> Honeycomb / Datadog / Tempo, you want to **prove locally** that the
+> trace flows, that `traceparent` propagates, and that without the env
+> var nothing changes. This walkthrough proves all three.
 
 ---
 
-## 1. Sobe Jaeger
+## 1. Start Jaeger
 
-Jaeger v2 já fala OTLP nativo (gRPC em `:4317`, HTTP em `:4318`) e tem
-UI em `:16686`. Um container só:
+Jaeger v2 speaks OTLP natively (gRPC on `:4317`, HTTP on `:4318`) and
+ships a UI on `:16686`. One container does it:
 
 ```bash
 docker run -d --rm --name mcp-jaeger \
@@ -24,7 +25,7 @@ docker run -d --rm --name mcp-jaeger \
   jaegertracing/jaeger:latest
 ```
 
-Espera ficar de pé:
+Wait until it's up:
 
 ```bash
 until curl -fsS http://127.0.0.1:16686/api/services >/dev/null; do sleep 1; done
@@ -35,10 +36,11 @@ UI: <http://localhost:16686>.
 
 ---
 
-## 2. Sobe `mcp serve` com OTel ligado
+## 2. Start `mcp serve` with OTel enabled
 
-Aponta pra Jaeger HTTP (porta 4318). `OTEL_EXPORTER_OTLP_ENDPOINT` é o
-**único** ativador — qualquer outro env var abaixo é opcional:
+Point it at Jaeger's HTTP receiver (port 4318).
+`OTEL_EXPORTER_OTLP_ENDPOINT` is the **sole** activator — every other
+env var below is optional:
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 \
@@ -47,24 +49,24 @@ OTEL_SERVICE_NAME=mcp-local \
 mcp serve --http 127.0.0.1:7331
 ```
 
-No stderr, **a primeira linha** tem que ser:
+On stderr, **the very first line** must be:
 
 ```
 [telemetry] OpenTelemetry initialized — endpoint=http://127.0.0.1:4318 protocol=HttpProto
 ```
 
-> Sem essa linha = OTel **não** subiu. Confere o env var.
+> Without that line, OTel did **not** start. Double-check the env var.
 
-Deixa rodando.
+Leave it running.
 
 ---
 
-## 3. Dispara requests
+## 3. Fire some requests
 
-Em outro terminal, dispara umas chamadas:
+In another terminal:
 
 ```bash
-# tools/list — span sem mcp.tool/mcp.server (não resolve em backend)
+# tools/list — span without mcp.tool/mcp.server (no backend resolved)
 for i in 1 2 3; do
   curl -s -X POST http://127.0.0.1:7331/mcp \
     -H 'Content-Type: application/json' \
@@ -72,8 +74,8 @@ for i in 1 2 3; do
     -o /dev/null -w "tools/list $i: %{http_code}\n"
 done
 
-# tools/call — span com mcp.tool e mcp.server resolvidos
-# (troca filesystem__list_allowed_directories por algum tool seu)
+# tools/call — span with mcp.tool and mcp.server resolved
+# (replace filesystem__list_allowed_directories with one of your own tools)
 curl -s -X POST http://127.0.0.1:7331/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":99,"method":"tools/call",
@@ -81,7 +83,7 @@ curl -s -X POST http://127.0.0.1:7331/mcp \
   -o /dev/null -w "tools/call: %{http_code}\n"
 ```
 
-Aguarda o batch flushar (default ~5s):
+Wait for the batch to flush (default ~5s):
 
 ```bash
 sleep 8
@@ -89,31 +91,31 @@ sleep 8
 
 ---
 
-## 4. Vê os spans no Jaeger
+## 4. Inspect the spans in Jaeger
 
-Abre <http://localhost:16686>:
+Open <http://localhost:16686>:
 
-1. **Service:** escolhe `mcp-local`
+1. **Service:** pick `mcp-local`
 2. **Operation:** `mcp.request`
 3. Click **Find Traces**
 
-Aparecem N traces, cada um com 1 span `mcp.request`. Click em qualquer
-um — em **Tags** você vê:
+You'll see N traces, each with one `mcp.request` span. Click any of
+them — under **Tags** you should find:
 
 ```
 otel.kind       = server
-mcp.method      = tools/list (ou tools/call)
+mcp.method      = tools/list (or tools/call)
 mcp.transport   = serve:http
 mcp.identity    = anonymous
 mcp.status      = ok
-mcp.server      = filesystem      ← só nos tools/call resolvidos
+mcp.server      = filesystem      ← only on resolved tools/call
 mcp.tool        = list_allowed_directories
 ```
 
-A duração do span é o tempo total que o `dispatch_request` levou —
-inclui ACL, lock do proxy, conexão com backend e o backend call em si.
+Span duration is the total time `dispatch_request` took — includes ACL,
+the proxy lock, backend connection, and the backend call itself.
 
-### Sanity check via API (sem clicar)
+### Sanity check via API (no clicking)
 
 ```bash
 curl -s "http://127.0.0.1:16686/api/traces?service=mcp-local&limit=3" \
@@ -129,14 +131,14 @@ for t in json.load(sys.stdin)["data"]:
 
 ---
 
-## 5. Testa parent context (`traceparent` inbound)
+## 5. Test parent context (inbound `traceparent`)
 
-Quando o cliente é OTel-aware (Claude.ai, gateway instrumentado, OTel
-SDK), ele manda `traceparent` no header. O `mcp serve` deve **continuar
-o trace** — span dele vira filho do span do cliente, não cria trace
-novo.
+When the client is OTel-aware (Claude.ai, an instrumented gateway, an
+OTel SDK), it sends `traceparent` in the headers. `mcp serve` should
+**continue the trace** — its span becomes a child of the client's
+span instead of starting a new trace.
 
-Manda um `traceparent` fake e confere stitching:
+Send a fake `traceparent` and check stitching:
 
 ```bash
 TRACEPARENT='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01'
@@ -149,13 +151,13 @@ curl -s -X POST http://127.0.0.1:7331/mcp \
 
 sleep 5
 
-# Pega o trace pelo traceID que injetamos
+# Pull the trace by the traceID we injected
 curl -s "http://127.0.0.1:16686/api/traces/0af7651916cd43dd8448eb211c80319c" \
   | python3 -c '
 import json, sys
 data = json.load(sys.stdin)["data"]
 if not data:
-    print("FAIL: parent context não funcionou")
+    print("FAIL: parent context did not work")
 else:
     for s in data[0]["spans"]:
         refs = s.get("references", [])
@@ -164,21 +166,21 @@ else:
 '
 ```
 
-Saída esperada:
+Expected output:
 
 ```
   span mcp.request parent=b7ad6b7169203331
 ```
 
-`parent=b7ad6b7169203331` confirma que o span do `mcp.request` virou
-filho do span que mandamos no `traceparent`. Trace stitching ✓.
+`parent=b7ad6b7169203331` confirms the `mcp.request` span became a child
+of the span we sent in `traceparent`. Trace stitching ✓.
 
 ---
 
-## 6. Vê as métricas
+## 6. Inspect the metrics
 
-Jaeger v2 só guarda traces. Pra ver counter/histogram/gauge, troca por
-um OTel Collector com debug exporter:
+Jaeger v2 only stores traces. To see counters / histograms / gauges,
+swap it out for an OTel Collector with a debug exporter:
 
 ```bash
 docker stop mcp-jaeger
@@ -204,23 +206,23 @@ docker run -d --rm --name mcp-otelcol \
   otel/opentelemetry-collector-contrib:latest
 ```
 
-Continua disparando requests no `mcp serve`. **Importante:** o
-PeriodicReader exporta métricas a cada 60s (default OTel SDK), então
-**aguarda ~65 segundos** depois do primeiro request.
+Keep firing requests at `mcp serve`. **Important:** the PeriodicReader
+exports metrics every 60s (OTel SDK default), so **wait ~65 seconds**
+after the first request.
 
-Depois de 65s:
+After 65s:
 
 ```bash
 docker logs mcp-otelcol 2>&1 | grep -E "Name:|Value:|mcp\." | head -40
 ```
 
-Saída esperada:
+Expected output:
 
 ```
      -> Name: mcp.proxy.requests
      -> mcp.method: Str(tools/call)
      -> mcp.server: Str(filesystem)
-     -> mcp.tool: Str(filesystem__list_allowed_directories)
+     -> mcp.tool: Str(list_allowed_directories)
 Value: 6
      -> Name: mcp.proxy.classifier.cache.hits
      -> mcp.server: Str(filesystem)
@@ -231,35 +233,36 @@ Value: 6
 Value: 0
 ```
 
-> Métricas que a `mcp` emite, em uma frase:
-> - `mcp.proxy.requests` (counter) e `mcp.proxy.request.duration` (histogram, ms) — uma por request, com labels `method/server/tool/status/transport/identity`
-> - `mcp.proxy.classifier.cache.hits/misses` por server
-> - `mcp.proxy.backends.connected` e `mcp.proxy.sessions.active` (gauges) atualizados a cada export
+> The metrics `mcp` emits, in one line:
+> - `mcp.proxy.requests` (counter) and `mcp.proxy.request.duration` (histogram, ms) — one per request, with labels `method/server/tool/status/transport/identity`
+> - `mcp.proxy.classifier.cache.hits/misses` per server
+> - `mcp.proxy.backends.connected` and `mcp.proxy.sessions.active` (gauges) refreshed at every export
 
 ---
 
-## 7. Teste de regressão — sem OTel = comportamento 0.5.2
+## 7. Regression test — no OTel = 0.5.2 behavior
 
-Esse é o passo que **prova que sua versão atual em produção não
-quebra**. Mata o serve atual e religa **sem nenhuma env var OTel**:
+This is the step that **proves your current production version won't
+break**. Kill the running `mcp serve` and bring it back up **without
+any OTel env var**:
 
 ```bash
-# em outro terminal
+# from another terminal
 pkill -f "mcp serve"
 sleep 1
 
 mcp serve --http 127.0.0.1:7331
 ```
 
-No stderr você **não pode ver** a linha `[telemetry] OpenTelemetry
-initialized`. Boot tem que abrir igualzinho à 0.5.2:
+On stderr you **must not** see `[telemetry] OpenTelemetry initialized`.
+Boot should look exactly like 0.5.2:
 
 ```
 INFO database opened idle_timeout=120s
 INFO HTTP server listening addr=127.0.0.1:7331
 ```
 
-`tools/list` continua respondendo:
+`tools/list` keeps responding:
 
 ```bash
 curl -s -X POST http://127.0.0.1:7331/mcp \
@@ -269,10 +272,9 @@ curl -s -X POST http://127.0.0.1:7331/mcp \
 # no-otel HTTP 200
 ```
 
-Esse é o **fail-safe**: se o OTel der pau em produção, basta
-**unset** do `OTEL_EXPORTER_OTLP_ENDPOINT` no deploy e o sistema
-volta exatamente ao comportamento anterior. Sem rebuild, sem
-rollback de imagem.
+This is the **fail-safe**: if OTel ever goes wrong in production, just
+**unset** `OTEL_EXPORTER_OTLP_ENDPOINT` in the deploy and the system
+reverts to the previous behavior. No rebuild, no image rollback.
 
 ---
 
@@ -286,45 +288,43 @@ rm -f /tmp/otel-debug.yaml
 
 ---
 
-## Próximos passos
+## Next steps
 
-- Em produção, troca o endpoint pra Honeycomb / Tempo / Datadog —
-  exemplos no [guia conceitual de observability](../guides/observability.md).
-- Se um backend MCP rejeitar `traceparent` (raro, é header W3C
-  padrão), ative o escape hatch sem mexer no resto:
+- In production, swap the endpoint for Honeycomb / Tempo / Datadog —
+  examples in the [observability reference guide](../guides/observability.md).
+- If a backend MCP rejects `traceparent` (rare, it's a W3C standard
+  header), enable the escape hatch without touching anything else:
   `MCP_OTEL_INJECT_TRACEPARENT=0`.
-- Sampling fica do lado do exporter — `mcp serve` sempre cria o span;
-  Honeycomb/Tempo/seu collector decide o que sample. Configure lá, não
-  aqui.
+- Sampling lives at the exporter side — `mcp serve` always creates the
+  span; Honeycomb / Tempo / your collector decides what to keep.
+  Configure it there, not here.
 
 ## Troubleshooting
 
-**Não aparece nada no Jaeger nem nos logs do collector.**
-Confere a primeira linha do stderr do `mcp serve` — se não tem
-`[telemetry] OpenTelemetry initialized`, o env var não foi lido. A
-linha sai **direto pra stderr**, antes do logging subscriber, **não**
-respeita `MCP_LOG_LEVEL`.
+**Nothing shows up in Jaeger or in the collector logs.** Check the very
+first line of `mcp serve` stderr — if `[telemetry] OpenTelemetry
+initialized` is missing, the env var wasn't read. The line goes
+**straight to stderr**, before the logging subscriber wires up, and
+**does not** respect `MCP_LOG_LEVEL`.
 
-**Saiu "OpenTelemetry initialized" mas nada chega no collector.**
-Provavelmente o endpoint está errado. A `mcp` espera o **base URL**
-(ex: `http://host:4318`), não o caminho completo (`/v1/traces`). Mas
-ela aceita ambos. Se você trocou de receiver e não cleanou env var
-antiga, ainda pode estar mandando pro lugar errado.
+**It said "OpenTelemetry initialized" but nothing reaches the
+collector.** Endpoint is probably wrong. `mcp` accepts the **base URL**
+(e.g. `http://host:4318`), not the full path (`/v1/traces`) — but it
+also tolerates a pre-suffixed value. If you swapped receivers and didn't
+clean up the old env var, you might still be sending elsewhere.
 
-**Span sem `mcp.server`/`mcp.tool`.**
-Isso é normal pra `tools/list`, `auth/failure`, métodos
-desconhecidos, ou requests com payload malformado — esses não
-resolvem pra um backend específico. Em `tools/call` resolvido eles
-sempre aparecem.
+**Span without `mcp.server`/`mcp.tool`.** Normal for `tools/list`,
+`auth/failure`, unknown methods, or requests with malformed payloads —
+those don't resolve to a specific backend. On a resolved `tools/call`
+they always show up.
 
-**`tonic` connection refused em endpoint HTTPS.**
-Honeycomb (e alguns outros vendors) **só aceitam HTTP/protobuf** no
-endpoint público. Defina `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`
-e use `https://` no endpoint.
+**`tonic` connection refused on an HTTPS endpoint.** Honeycomb (and a
+few other vendors) **only accept HTTP/protobuf** on the public ingest.
+Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` and use `https://` in
+the endpoint.
 
-**Métricas não aparecem mesmo depois de 60s.**
-PeriodicReader é "best-effort": se o processo cair antes do primeiro
-flush, o export some. O `TelemetryGuard` no `Drop` de `main` faz
-shutdown gracioso (que força flush). Em prod isso é coberto pelo
-SIGTERM normal — mas se você der `kill -9` pode perder o último
-batch.
+**Metrics don't show up even after 60s.** PeriodicReader is "best
+effort": if the process dies before the first flush, the export is
+gone. The `TelemetryGuard` in `main`'s `Drop` performs a graceful
+shutdown (which forces a flush). In production this is covered by a
+normal SIGTERM — but a `kill -9` may drop the last batch.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,29 +1,49 @@
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer, Registry};
+
+use crate::telemetry::TelemetryGuard;
 
 /// Initialize the tracing subscriber for structured logging.
 ///
 /// Reads `MCP_LOG_LEVEL` (default: "info") and `MCP_LOG_FORMAT` (default: "text").
 /// When `MCP_LOG_FORMAT=json`, emits newline-delimited JSON to stderr — ideal for
 /// container log drivers and centralized logging pipelines.
-pub fn init() {
+///
+/// When an active [`TelemetryGuard`] is supplied, the OpenTelemetry tracing
+/// layer is attached so spans created via `tracing` automatically flow to
+/// the OTLP exporter. With `None`, behavior is byte-identical to the
+/// pre-OTel logging path.
+pub fn init(otel: Option<&TelemetryGuard>) {
     let level = std::env::var("MCP_LOG_LEVEL").unwrap_or_else(|_| "info".into());
     let format = std::env::var("MCP_LOG_FORMAT").unwrap_or_else(|_| "text".into());
 
     let filter = EnvFilter::try_new(&level).unwrap_or_else(|_| EnvFilter::new("info"));
 
-    match format.as_str() {
-        "json" => {
-            tracing_subscriber::fmt()
+    // Box the fmt layer so the json/text branches share a single concrete
+    // type. `with_filter` keeps the EnvFilter scoped to the stderr layer so
+    // OTel spans aren't suppressed when MCP_LOG_LEVEL is restrictive.
+    let fmt_layer: Box<dyn Layer<Registry> + Send + Sync> = match format.as_str() {
+        "json" => Box::new(
+            tracing_subscriber::fmt::layer()
                 .json()
-                .with_env_filter(filter)
                 .with_target(false)
-                .init();
-        }
-        _ => {
-            tracing_subscriber::fmt()
-                .with_env_filter(filter)
+                .with_filter(filter),
+        ),
+        _ => Box::new(
+            tracing_subscriber::fmt::layer()
                 .with_target(false)
-                .init();
-        }
-    }
+                .with_filter(filter),
+        ),
+    };
+
+    // OTel layer is an `Option` — `tracing_subscriber` provides a blanket
+    // `Layer` impl for `Option<L>` so it's a no-op when telemetry is off.
+    // Building the layer in-place lets `S` get inferred to whatever the
+    // composed subscriber is.
+    let otel_layer = otel
+        .and_then(|g| g.tracer())
+        .map(tracing_opentelemetry::OpenTelemetryLayer::new);
+
+    Registry::default().with(fmt_layer).with(otel_layer).init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod registry;
 mod serve;
 mod server_auth;
 mod spinner;
+mod telemetry;
 mod transport;
 
 use anyhow::{bail, Result};
@@ -25,7 +26,11 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    logging::init();
+    // OTel guard is RAII — keeping it alive in `main` flushes spans/metrics
+    // on normal exit. `None` when telemetry is disabled (no env var) — and
+    // in that case logging+behavior is byte-identical to the pre-OTel path.
+    let telemetry = telemetry::init();
+    logging::init(telemetry.as_ref());
     if let Err(e) = run().await {
         tracing::error!(error = format!("{e:#}"), "fatal error");
         std::process::exit(1);

--- a/src/serve/dispatch.rs
+++ b/src/serve/dispatch.rs
@@ -28,6 +28,24 @@ enum DiscoveryAction {
 /// backends run fully in parallel, and many concurrent calls to the same
 /// backend share the same `Arc<McpClient>` (whose transport multiplexes
 /// internally where possible).
+///
+/// The `#[tracing::instrument]` here is the OTel root span for every
+/// proxied request. Empty fields are filled in via `Span::record` once the
+/// tool/server are resolved or once the response is built — using
+/// `tracing::field::Empty` avoids any allocation when telemetry is off.
+#[tracing::instrument(
+    name = "mcp.request",
+    skip_all,
+    fields(
+        otel.kind = "server",
+        mcp.method = %req.method,
+        mcp.transport = %source,
+        mcp.identity = %identity.subject,
+        mcp.server = tracing::field::Empty,
+        mcp.tool = tracing::field::Empty,
+        mcp.status = tracing::field::Empty,
+    )
+)]
 pub(crate) async fn dispatch_request(
     proxy: &SharedProxy,
     req: JsonRpcRequest,
@@ -167,6 +185,12 @@ pub(crate) async fn dispatch_request(
                         // namespaced tool resolves to a real backend.
                         tool_name_for_audit = Some(format!("{server}{SEPARATOR}{orig}"));
                         server_name_for_audit = Some(server.clone());
+                        // Fill the OTel span attributes now that resolution
+                        // succeeded — Empty fields are no-ops when telemetry
+                        // is off, so this is safe to do unconditionally.
+                        let span = tracing::Span::current();
+                        span.record("mcp.server", server.as_str());
+                        span.record("mcp.tool", orig.as_str());
                         Ok((server, orig, args, client, decision))
                     }
                     Err((maybe_decision, resp)) => {
@@ -620,6 +644,36 @@ pub(crate) struct AuditCtx<'a> {
 }
 
 pub(crate) fn finish_audit(ctx: AuditCtx<'_>, response: JsonRpcResponse) -> JsonRpcResponse {
+    // Record the final OTel status on the root span. No-op when the field
+    // wasn't declared (i.e. caller wasn't instrumented) or telemetry is off.
+    let status = if response.error.is_none() {
+        "ok"
+    } else {
+        "error"
+    };
+    tracing::Span::current().record("mcp.status", status);
+
+    let duration_ms = ctx.start.elapsed().as_millis() as u64;
+
+    // OTel metrics — emit when an exporter was wired. Reuse the same
+    // `duration_ms` the audit path computes, so we never measure twice.
+    if let Some(metrics) = crate::telemetry::metrics() {
+        let mut labels = vec![
+            opentelemetry::KeyValue::new("mcp.method", ctx.method.clone()),
+            opentelemetry::KeyValue::new("mcp.transport", ctx.source.to_string()),
+            opentelemetry::KeyValue::new("mcp.status", status.to_string()),
+            opentelemetry::KeyValue::new("mcp.identity", ctx.identity.subject.clone()),
+        ];
+        if let Some(server) = ctx.server_name.as_ref() {
+            labels.push(opentelemetry::KeyValue::new("mcp.server", server.clone()));
+        }
+        if let Some(tool) = ctx.tool_name.as_ref() {
+            labels.push(opentelemetry::KeyValue::new("mcp.tool", tool.clone()));
+        }
+        metrics.requests.add(1, &labels);
+        metrics.request_duration.record(duration_ms as f64, &labels);
+    }
+
     let (acl_decision, acl_matched_rule, acl_access_kind, cls_kind, cls_source, cls_conf) =
         match &ctx.decision {
             Some(d) => (
@@ -640,7 +694,7 @@ pub(crate) fn finish_audit(ctx: AuditCtx<'_>, response: JsonRpcResponse) -> Json
         tool_name: ctx.tool_name,
         server_name: ctx.server_name,
         identity: ctx.identity.subject.clone(),
-        duration_ms: ctx.start.elapsed().as_millis() as u64,
+        duration_ms,
         success: response.error.is_none(),
         error_message: response.error.as_ref().map(|e| e.message.clone()),
         arguments: None,

--- a/src/serve/dispatch.rs
+++ b/src/serve/dispatch.rs
@@ -667,8 +667,20 @@ pub(crate) fn finish_audit(ctx: AuditCtx<'_>, response: JsonRpcResponse) -> Json
         if let Some(server) = ctx.server_name.as_ref() {
             labels.push(opentelemetry::KeyValue::new("mcp.server", server.clone()));
         }
+        // Audit stores tool_name namespaced (`{server}__{tool}`) on
+        // resolved tools/call so the audit log stays self-contained. For
+        // the metric, strip the server prefix when present so `mcp.tool`
+        // mirrors the span attribute (un-namespaced) and avoids
+        // multiplying cardinality with `mcp.server`.
         if let Some(tool) = ctx.tool_name.as_ref() {
-            labels.push(opentelemetry::KeyValue::new("mcp.tool", tool.clone()));
+            let bare = match ctx.server_name.as_ref() {
+                Some(server) => {
+                    let prefix = format!("{server}{SEPARATOR}");
+                    tool.strip_prefix(&prefix).unwrap_or(tool).to_string()
+                }
+                None => tool.clone(),
+            };
+            labels.push(opentelemetry::KeyValue::new("mcp.tool", bare));
         }
         metrics.requests.add(1, &labels);
         metrics.request_duration.record(duration_ms as f64, &labels);

--- a/src/serve/http.rs
+++ b/src/serve/http.rs
@@ -19,6 +19,7 @@ use crate::config::Config;
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
 use crate::server_auth::oauth_as::{self, AsState};
 use crate::server_auth::{self, AclConfig, AuthIdentity, AuthProvider, Credentials};
+use crate::telemetry::extract_parent_context;
 
 use super::discovery::discover_pending_backends;
 use super::dispatch::dispatch_request;
@@ -179,6 +180,36 @@ pub async fn run_http(config: Config, bind_addr: &str, insecure: bool) -> Result
         sessions: Arc::new(Mutex::new(HashMap::new())),
         shutdown: shutdown_rx,
     };
+
+    // OTel observable gauges. The closures hold `Weak` refs so they don't
+    // keep the proxy alive past shutdown. `try_lock` is best-effort: if the
+    // mutex is contended at observation time we report 0 instead of stalling
+    // the metrics export task.
+    {
+        let proxy_weak = Arc::downgrade(&shared);
+        let sessions_weak = Arc::downgrade(&state.sessions);
+        crate::telemetry::register_proxy_observers(
+            move || {
+                proxy_weak
+                    .upgrade()
+                    .and_then(|p| {
+                        p.try_lock().ok().map(|p| {
+                            p.backends
+                                .values()
+                                .filter(|s| matches!(s, BackendState::Connected { .. }))
+                                .count() as u64
+                        })
+                    })
+                    .unwrap_or(0)
+            },
+            move || {
+                sessions_weak
+                    .upgrade()
+                    .and_then(|s| s.try_lock().ok().map(|m| m.len() as u64))
+                    .unwrap_or(0)
+            },
+        );
+    }
 
     // Background GC for the OAuth AS — drops expired authorization
     // codes and refresh tokens. Cheap pass; runs every 60s.
@@ -429,12 +460,14 @@ async fn mcp_handler(
             .unwrap_or(120),
     );
     let req_id = req.id.clone();
-    let response_json = match tokio::time::timeout(
-        request_timeout,
-        dispatch_request(&state.proxy, req, &identity, &state.acl, "serve:http"),
-    )
-    .await
-    {
+    // W3C parent context from inbound headers. When the client is OTel-aware
+    // (Claude.ai, an instrumented gateway), this stitches the proxy span
+    // under the caller's trace. With telemetry off, this is a no-op.
+    use opentelemetry::trace::FutureExt as _;
+    let parent_cx = extract_parent_context(&headers);
+    let dispatch_fut = dispatch_request(&state.proxy, req, &identity, &state.acl, "serve:http")
+        .with_context(parent_cx);
+    let response_json = match tokio::time::timeout(request_timeout, dispatch_fut).await {
         Ok(resp) => serde_json::to_value(&resp).unwrap(),
         Err(_) => {
             let err = JsonRpcResponse::error(

--- a/src/serve/proxy.rs
+++ b/src/serve/proxy.rs
@@ -272,8 +272,26 @@ impl ProxyServer {
                     tool.annotations.as_ref(),
                 );
                 if let Some(cached) = self.classifier_cache.get(&key).cloned() {
+                    if let Some(m) = crate::telemetry::metrics() {
+                        m.classifier_hits.add(
+                            1,
+                            &[opentelemetry::KeyValue::new(
+                                "mcp.server",
+                                server_name.to_string(),
+                            )],
+                        );
+                    }
                     cached
                 } else {
+                    if let Some(m) = crate::telemetry::metrics() {
+                        m.classifier_misses.add(
+                            1,
+                            &[opentelemetry::KeyValue::new(
+                                "mcp.server",
+                                server_name.to_string(),
+                            )],
+                        );
+                    }
                     let c = classify(tool, None);
                     self.classifier_cache.put(key, c.clone());
                     c

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,24 +1,25 @@
-//! OpenTelemetry integration — default-off, ativado via env vars padrão OTel.
+//! OpenTelemetry integration — default-off, activated via standard OTel env vars.
 //!
-//! Quando `OTEL_EXPORTER_OTLP_ENDPOINT` está setado, [`init`] configura:
-//! - `TracerProvider` global com batch exporter OTLP (gRPC ou HTTP/protobuf,
-//!   conforme `OTEL_EXPORTER_OTLP_PROTOCOL`).
-//! - `MeterProvider` global com periodic reader (default: 60s).
-//! - `TraceContextPropagator` global (W3C `traceparent`).
+//! When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, [`init`] wires:
+//! - A global `TracerProvider` with an OTLP batch exporter (gRPC or
+//!   HTTP/protobuf, picked via `OTEL_EXPORTER_OTLP_PROTOCOL`).
+//! - A global `MeterProvider` with a periodic reader (default: 60s).
+//! - The W3C `TraceContextPropagator` (used for `traceparent`/`tracestate`).
 //!
-//! O guard retornado faz flush+shutdown no Drop. Sem o env var, [`init`]
-//! retorna `None` e o sistema se comporta exatamente como antes.
+//! The returned guard flushes and shuts down providers on `Drop`. Without
+//! the env var, [`init`] returns `None` and the rest of the binary behaves
+//! exactly like the pre-OTel build.
 //!
-//! Env vars suportadas (todas opcionais exceto endpoint):
-//! - `OTEL_EXPORTER_OTLP_ENDPOINT` — único ativador.
-//! - `OTEL_EXPORTER_OTLP_PROTOCOL` — `grpc` (default) ou `http/protobuf`.
-//! - `OTEL_EXPORTER_OTLP_HEADERS` — CSV `k1=v1,k2=v2` (HTTP only por spec).
-//! - `OTEL_SERVICE_NAME` — default `mcp`.
-//! - `OTEL_RESOURCE_ATTRIBUTES` — CSV adicionado ao Resource.
+//! Supported env vars (all optional except the endpoint):
+//! - `OTEL_EXPORTER_OTLP_ENDPOINT` — sole activator.
+//! - `OTEL_EXPORTER_OTLP_PROTOCOL` — `grpc` (default) or `http/protobuf`.
+//! - `OTEL_EXPORTER_OTLP_HEADERS` — CSV `k1=v1,k2=v2` (HTTP only per spec).
+//! - `OTEL_SERVICE_NAME` — defaults to `mcp`.
+//! - `OTEL_RESOURCE_ATTRIBUTES` — CSV merged into the Resource.
 //!
-//! Escape hatch: se algum backend MCP rejeitar `traceparent` injetado,
-//! `MCP_OTEL_INJECT_TRACEPARENT=0` desliga apenas a injeção outbound sem
-//! mexer no resto.
+//! Escape hatch: if some MCP backend rejects the injected `traceparent`,
+//! set `MCP_OTEL_INJECT_TRACEPARENT=0` to disable outbound injection only,
+//! leaving traces and metrics untouched.
 
 use std::collections::HashMap;
 use std::sync::OnceLock;
@@ -441,6 +442,13 @@ pub fn inject_traceparent(headers: &mut HashMap<String, String>) {
 mod tests {
     use super::*;
 
+    /// `cargo test` runs in parallel by default. Any test that mutates a
+    /// process-wide env var must hold this lock or it can race with both
+    /// peer tests in this module and tests elsewhere reading OTel vars
+    /// (e.g. via [`init`]). Pattern matches `src/config.rs` /
+    /// `src/auth/store.rs`.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn parse_headers_csv_basic() {
         let h = parse_headers(Some("k1=v1,k2=v2"));
@@ -464,14 +472,14 @@ mod tests {
 
     #[test]
     fn parse_protocol_default_is_grpc() {
-        // SAFETY: tests run in-process; we don't rely on absence in parallel
-        // tests because we set explicitly.
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::remove_var(PROTOCOL_VAR);
         assert_eq!(parse_protocol(), WireProtocol::Grpc);
     }
 
     #[test]
     fn parse_protocol_http() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var(PROTOCOL_VAR, "http/protobuf");
         assert_eq!(parse_protocol(), WireProtocol::HttpProto);
         std::env::remove_var(PROTOCOL_VAR);
@@ -479,12 +487,14 @@ mod tests {
 
     #[test]
     fn init_returns_none_without_endpoint() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::remove_var(ENDPOINT_VAR);
         assert!(init().is_none(), "init must be a no-op without endpoint");
     }
 
     #[test]
     fn init_returns_none_with_empty_endpoint() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var(ENDPOINT_VAR, "   ");
         assert!(init().is_none(), "blank endpoint must not enable OTel");
         std::env::remove_var(ENDPOINT_VAR);

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,500 @@
+//! OpenTelemetry integration — default-off, ativado via env vars padrão OTel.
+//!
+//! Quando `OTEL_EXPORTER_OTLP_ENDPOINT` está setado, [`init`] configura:
+//! - `TracerProvider` global com batch exporter OTLP (gRPC ou HTTP/protobuf,
+//!   conforme `OTEL_EXPORTER_OTLP_PROTOCOL`).
+//! - `MeterProvider` global com periodic reader (default: 60s).
+//! - `TraceContextPropagator` global (W3C `traceparent`).
+//!
+//! O guard retornado faz flush+shutdown no Drop. Sem o env var, [`init`]
+//! retorna `None` e o sistema se comporta exatamente como antes.
+//!
+//! Env vars suportadas (todas opcionais exceto endpoint):
+//! - `OTEL_EXPORTER_OTLP_ENDPOINT` — único ativador.
+//! - `OTEL_EXPORTER_OTLP_PROTOCOL` — `grpc` (default) ou `http/protobuf`.
+//! - `OTEL_EXPORTER_OTLP_HEADERS` — CSV `k1=v1,k2=v2` (HTTP only por spec).
+//! - `OTEL_SERVICE_NAME` — default `mcp`.
+//! - `OTEL_RESOURCE_ATTRIBUTES` — CSV adicionado ao Resource.
+//!
+//! Escape hatch: se algum backend MCP rejeitar `traceparent` injetado,
+//! `MCP_OTEL_INJECT_TRACEPARENT=0` desliga apenas a injeção outbound sem
+//! mexer no resto.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use axum::http::HeaderMap;
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Histogram, Meter};
+use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{Context, KeyValue};
+use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicReader;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::runtime;
+use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_sdk::trace::Tracer;
+use opentelemetry_sdk::Resource;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+const ENDPOINT_VAR: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const PROTOCOL_VAR: &str = "OTEL_EXPORTER_OTLP_PROTOCOL";
+const HEADERS_VAR: &str = "OTEL_EXPORTER_OTLP_HEADERS";
+const SERVICE_NAME_VAR: &str = "OTEL_SERVICE_NAME";
+const RESOURCE_ATTR_VAR: &str = "OTEL_RESOURCE_ATTRIBUTES";
+
+const TRACER_NAME: &str = "mcp";
+
+/// Stash so the rest of the codebase can read what was actually wired without
+/// re-parsing env vars. `None` when telemetry is disabled.
+static TELEMETRY_STATE: OnceLock<TelemetryState> = OnceLock::new();
+
+/// Pre-built instruments published once a `MeterProvider` is wired. `None`
+/// when telemetry is disabled — call sites should `if let Some(m) = ...`
+/// before recording.
+static METRICS: OnceLock<Metrics> = OnceLock::new();
+
+/// Hot-path metric instruments. Cheap to clone via `Counter`/`Histogram`
+/// internal `Arc`, but we expose them by reference behind a `OnceLock`
+/// to keep the API ergonomic.
+pub struct Metrics {
+    pub requests: Counter<u64>,
+    pub request_duration: Histogram<f64>,
+    pub classifier_hits: Counter<u64>,
+    pub classifier_misses: Counter<u64>,
+}
+
+/// Access the pre-built metric instruments. `None` when telemetry is
+/// disabled — emit calls become no-ops.
+pub fn metrics() -> Option<&'static Metrics> {
+    METRICS.get()
+}
+
+fn build_metrics(meter: &Meter) -> Metrics {
+    Metrics {
+        requests: meter
+            .u64_counter("mcp.proxy.requests")
+            .with_description("Total MCP proxy requests handled")
+            .build(),
+        request_duration: meter
+            .f64_histogram("mcp.proxy.request.duration")
+            .with_description("MCP proxy request duration")
+            .with_unit("ms")
+            .build(),
+        classifier_hits: meter
+            .u64_counter("mcp.proxy.classifier.cache.hits")
+            .with_description("Tool classifier cache hits")
+            .build(),
+        classifier_misses: meter
+            .u64_counter("mcp.proxy.classifier.cache.misses")
+            .with_description("Tool classifier cache misses")
+            .build(),
+    }
+}
+
+/// Register periodic-observation gauges for proxy state. Each closure is
+/// invoked by the OTel SDK on every metrics export — they MUST be cheap
+/// and non-blocking. No-op when telemetry is disabled. Safe to call once
+/// per `mcp serve` boot; subsequent calls add additional gauges.
+pub fn register_proxy_observers<B, S>(backends_connected: B, sessions_active: S)
+where
+    B: Fn() -> u64 + Send + Sync + 'static,
+    S: Fn() -> u64 + Send + Sync + 'static,
+{
+    if METRICS.get().is_none() {
+        return;
+    }
+    let meter = global::meter("mcp");
+    let _ = meter
+        .u64_observable_gauge("mcp.proxy.backends.connected")
+        .with_description("Connected MCP backends")
+        .with_callback(move |obs| {
+            obs.observe(backends_connected(), &[]);
+        })
+        .build();
+    let _ = meter
+        .u64_observable_gauge("mcp.proxy.sessions.active")
+        .with_description("Active SSE/Streamable HTTP sessions")
+        .with_callback(move |obs| {
+            obs.observe(sessions_active(), &[]);
+        })
+        .build();
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WireProtocol {
+    Grpc,
+    HttpProto,
+}
+
+#[derive(Debug)]
+struct TelemetryState {
+    inject_traceparent: bool,
+}
+
+/// RAII guard. Drop = flush + shutdown of tracer/meter providers.
+pub struct TelemetryGuard {
+    tracer: Option<SdkTracerProvider>,
+    meter: Option<SdkMeterProvider>,
+}
+
+impl TelemetryGuard {
+    /// Returns the OTel `Tracer` so the caller can build a
+    /// `tracing_opentelemetry::Layer` in-place — letting the subscriber's
+    /// `S` type get inferred at the call site.
+    pub fn tracer(&self) -> Option<Tracer> {
+        self.tracer.as_ref().map(|tp| tp.tracer(TRACER_NAME))
+    }
+}
+
+impl Drop for TelemetryGuard {
+    fn drop(&mut self) {
+        // Flush in a synchronous best-effort way. Any error here is logged at
+        // debug — the process is exiting, we cannot recover.
+        if let Some(tp) = self.tracer.take() {
+            if let Err(e) = tp.shutdown() {
+                tracing::debug!(error = %e, "tracer provider shutdown failed");
+            }
+        }
+        if let Some(mp) = self.meter.take() {
+            if let Err(e) = mp.shutdown() {
+                tracing::debug!(error = %e, "meter provider shutdown failed");
+            }
+        }
+    }
+}
+
+/// Initialize OpenTelemetry if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+/// Returns `None` (no-op) otherwise — preserving the 0.5.2 behavior.
+pub fn init() -> Option<TelemetryGuard> {
+    let endpoint = std::env::var(ENDPOINT_VAR).ok()?;
+    let endpoint = endpoint.trim().to_string();
+    if endpoint.is_empty() {
+        return None;
+    }
+
+    let protocol = parse_protocol();
+    let headers = parse_headers(std::env::var(HEADERS_VAR).ok().as_deref());
+    let resource = build_resource();
+
+    // Tracer — the runtime-aware batch processor is required because we run
+    // under tokio. The default (thread-based) processor would panic the
+    // moment reqwest tries to spawn from a non-runtime thread.
+    let tracer_provider = match build_span_exporter(&endpoint, protocol, &headers) {
+        Ok(exporter) => {
+            let processor = BatchSpanProcessor::builder(exporter, runtime::Tokio).build();
+            SdkTracerProvider::builder()
+                .with_resource(resource.clone())
+                .with_span_processor(processor)
+                .build()
+        }
+        Err(e) => {
+            // Stay non-fatal: the proxy must keep serving even if telemetry
+            // fails to bootstrap (bad endpoint, network down at boot, etc.).
+            // `eprintln!` here on purpose — `logging::init` only runs after
+            // we return, so a `tracing::warn!` would be silently dropped.
+            eprintln!("[telemetry] OTel tracer init failed: {e}; continuing without traces");
+            return None;
+        }
+    };
+    global::set_tracer_provider(tracer_provider.clone());
+
+    // Meter — same story: use the runtime-aware periodic reader so the
+    // export task lives on the tokio runtime.
+    let meter_provider = match build_metric_exporter(&endpoint, protocol, &headers) {
+        Ok(exporter) => {
+            let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
+            SdkMeterProvider::builder()
+                .with_resource(resource)
+                .with_reader(reader)
+                .build()
+        }
+        Err(e) => {
+            eprintln!("[telemetry] OTel meter init failed: {e}; continuing without metrics");
+            // Tracer was already wired — keep it; just skip metrics.
+            let inject = inject_traceparent_enabled();
+            let _ = TELEMETRY_STATE.set(TelemetryState {
+                inject_traceparent: inject,
+            });
+            global::set_text_map_propagator(TraceContextPropagator::new());
+            return Some(TelemetryGuard {
+                tracer: Some(tracer_provider),
+                meter: None,
+            });
+        }
+    };
+    global::set_meter_provider(meter_provider.clone());
+
+    // Build the hot-path instruments now that the global meter provider is
+    // wired. Stored in OnceLock so call sites can read by reference.
+    let _ = METRICS.set(build_metrics(&global::meter("mcp")));
+
+    // W3C propagator — required for traceparent inbound/outbound.
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let inject = inject_traceparent_enabled();
+    let _ = TELEMETRY_STATE.set(TelemetryState {
+        inject_traceparent: inject,
+    });
+
+    eprintln!("[telemetry] OpenTelemetry initialized — endpoint={endpoint} protocol={protocol:?}");
+
+    Some(TelemetryGuard {
+        tracer: Some(tracer_provider),
+        meter: Some(meter_provider),
+    })
+}
+
+/// Whether traceparent injection is enabled. Always `false` when telemetry
+/// is off; `true` by default when on (operator can opt out via
+/// `MCP_OTEL_INJECT_TRACEPARENT=0`).
+pub fn should_inject_traceparent() -> bool {
+    TELEMETRY_STATE
+        .get()
+        .map(|s| s.inject_traceparent)
+        .unwrap_or(false)
+}
+
+fn inject_traceparent_enabled() -> bool {
+    !matches!(
+        std::env::var("MCP_OTEL_INJECT_TRACEPARENT").ok().as_deref(),
+        Some("0") | Some("false") | Some("no")
+    )
+}
+
+fn parse_protocol() -> WireProtocol {
+    match std::env::var(PROTOCOL_VAR)
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("http/protobuf") | Some("http") => WireProtocol::HttpProto,
+        // Default per OTel spec is gRPC.
+        _ => WireProtocol::Grpc,
+    }
+}
+
+fn parse_headers(raw: Option<&str>) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    let Some(raw) = raw else { return out };
+    for pair in raw.split(',') {
+        let pair = pair.trim();
+        if pair.is_empty() {
+            continue;
+        }
+        if let Some((k, v)) = pair.split_once('=') {
+            let k = k.trim();
+            let v = v.trim();
+            if !k.is_empty() {
+                out.insert(k.to_string(), v.to_string());
+            }
+        }
+    }
+    out
+}
+
+fn build_resource() -> Resource {
+    let service_name = std::env::var(SERVICE_NAME_VAR).unwrap_or_else(|_| "mcp".to_string());
+
+    let mut builder = Resource::builder()
+        .with_service_name(service_name)
+        .with_attribute(KeyValue::new(
+            "service.version",
+            env!("CARGO_PKG_VERSION").to_string(),
+        ));
+
+    if let Ok(extra) = std::env::var(RESOURCE_ATTR_VAR) {
+        for pair in extra.split(',') {
+            let pair = pair.trim();
+            if pair.is_empty() {
+                continue;
+            }
+            if let Some((k, v)) = pair.split_once('=') {
+                let k = k.trim();
+                let v = v.trim();
+                if !k.is_empty() {
+                    builder = builder.with_attribute(KeyValue::new(k.to_string(), v.to_string()));
+                }
+            }
+        }
+    }
+
+    builder.build()
+}
+
+/// Append the per-signal path to a base OTLP HTTP endpoint. Programmatic
+/// `with_endpoint` does NOT auto-suffix `/v1/traces` etc. (only the
+/// `OTEL_EXPORTER_OTLP_ENDPOINT` env var does, and only when the SDK reads
+/// it itself). We read the env var ourselves, so we have to suffix.
+///
+/// Honors a pre-suffixed endpoint (`http://host/v1/traces`) by leaving it
+/// untouched. gRPC ignores paths — only used in the HTTP branch.
+fn http_endpoint_for(base: &str, signal_path: &str) -> String {
+    let trimmed = base.trim_end_matches('/');
+    if trimmed.ends_with(signal_path) {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}{signal_path}")
+    }
+}
+
+fn build_span_exporter(
+    endpoint: &str,
+    protocol: WireProtocol,
+    headers: &HashMap<String, String>,
+) -> Result<opentelemetry_otlp::SpanExporter, opentelemetry_otlp::ExporterBuildError> {
+    match protocol {
+        WireProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint)
+            .with_protocol(Protocol::Grpc)
+            .with_timeout(Duration::from_secs(10))
+            .build(),
+        WireProtocol::HttpProto => opentelemetry_otlp::SpanExporter::builder()
+            .with_http()
+            .with_endpoint(http_endpoint_for(endpoint, "/v1/traces"))
+            .with_protocol(Protocol::HttpBinary)
+            .with_headers(headers.clone())
+            .with_timeout(Duration::from_secs(10))
+            .build(),
+    }
+}
+
+fn build_metric_exporter(
+    endpoint: &str,
+    protocol: WireProtocol,
+    headers: &HashMap<String, String>,
+) -> Result<opentelemetry_otlp::MetricExporter, opentelemetry_otlp::ExporterBuildError> {
+    match protocol {
+        WireProtocol::Grpc => opentelemetry_otlp::MetricExporter::builder()
+            .with_tonic()
+            .with_endpoint(endpoint)
+            .with_protocol(Protocol::Grpc)
+            .with_timeout(Duration::from_secs(10))
+            .build(),
+        WireProtocol::HttpProto => opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_endpoint(http_endpoint_for(endpoint, "/v1/metrics"))
+            .with_protocol(Protocol::HttpBinary)
+            .with_headers(headers.clone())
+            .with_timeout(Duration::from_secs(10))
+            .build(),
+    }
+}
+
+// -- W3C trace context propagation helpers --------------------------------
+
+/// Adapter so the OTel `TextMapPropagator` can read from an axum `HeaderMap`.
+struct HeaderMapExtractor<'a>(&'a HeaderMap);
+
+impl<'a> Extractor for HeaderMapExtractor<'a> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(|k| k.as_str()).collect()
+    }
+}
+
+/// Adapter so the OTel `TextMapPropagator` can write into a plain
+/// `HashMap<String, String>` — convenient when the outbound transport
+/// builds headers as a `String` map (as `transport::http`).
+pub struct HashMapInjector<'a>(pub &'a mut HashMap<String, String>);
+
+impl<'a> Injector for HashMapInjector<'a> {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_string(), value);
+    }
+}
+
+/// Extract a parent OTel context from inbound HTTP headers (W3C
+/// `traceparent`/`tracestate`). When telemetry is disabled, the global
+/// propagator is a no-op and this returns an empty `Context`.
+pub fn extract_parent_context(headers: &HeaderMap) -> Context {
+    global::get_text_map_propagator(|prop| prop.extract(&HeaderMapExtractor(headers)))
+}
+
+/// Inject the W3C trace context of the current `tracing` span into a
+/// string header map. No-op when telemetry is off or when the operator
+/// opted out via `MCP_OTEL_INJECT_TRACEPARENT=0`.
+///
+/// Reads the OTel context attached to the current span by
+/// `tracing-opentelemetry`, so the propagated trace stays in sync with
+/// the proxy's own root span — not with `Context::current()` which is
+/// only updated when the OTel SDK API is used directly.
+pub fn inject_traceparent(headers: &mut HashMap<String, String>) {
+    if !should_inject_traceparent() {
+        return;
+    }
+    let cx = tracing::Span::current().context();
+    global::get_text_map_propagator(|prop| prop.inject_context(&cx, &mut HashMapInjector(headers)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_headers_csv_basic() {
+        let h = parse_headers(Some("k1=v1,k2=v2"));
+        assert_eq!(h.get("k1").unwrap(), "v1");
+        assert_eq!(h.get("k2").unwrap(), "v2");
+    }
+
+    #[test]
+    fn parse_headers_handles_whitespace_and_empty() {
+        let h = parse_headers(Some(" key = value , ,malformed,empty="));
+        assert_eq!(h.get("key").unwrap(), "value");
+        assert_eq!(h.get("empty").unwrap(), "");
+        assert!(!h.contains_key("malformed"));
+        assert_eq!(h.len(), 2);
+    }
+
+    #[test]
+    fn parse_headers_none() {
+        assert!(parse_headers(None).is_empty());
+    }
+
+    #[test]
+    fn parse_protocol_default_is_grpc() {
+        // SAFETY: tests run in-process; we don't rely on absence in parallel
+        // tests because we set explicitly.
+        std::env::remove_var(PROTOCOL_VAR);
+        assert_eq!(parse_protocol(), WireProtocol::Grpc);
+    }
+
+    #[test]
+    fn parse_protocol_http() {
+        std::env::set_var(PROTOCOL_VAR, "http/protobuf");
+        assert_eq!(parse_protocol(), WireProtocol::HttpProto);
+        std::env::remove_var(PROTOCOL_VAR);
+    }
+
+    #[test]
+    fn init_returns_none_without_endpoint() {
+        std::env::remove_var(ENDPOINT_VAR);
+        assert!(init().is_none(), "init must be a no-op without endpoint");
+    }
+
+    #[test]
+    fn init_returns_none_with_empty_endpoint() {
+        std::env::set_var(ENDPOINT_VAR, "   ");
+        assert!(init().is_none(), "blank endpoint must not enable OTel");
+        std::env::remove_var(ENDPOINT_VAR);
+    }
+
+    #[test]
+    fn should_inject_traceparent_off_when_telemetry_disabled() {
+        // Without init() succeeding, default is false.
+        // (TELEMETRY_STATE may have been set by another test; this test
+        // only asserts the API exists and doesn't panic.)
+        let _ = should_inject_traceparent();
+    }
+}

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -92,6 +92,14 @@ impl HttpTransport {
             req = req.header("Mcp-Session-Id", session_id);
         }
 
+        // W3C traceparent/tracestate so the upstream MCP backend can
+        // continue the trace. Empty when telemetry is off — zero overhead.
+        let mut otel_headers = HashMap::<String, String>::new();
+        crate::telemetry::inject_traceparent(&mut otel_headers);
+        for (k, v) in otel_headers {
+            req = req.header(k, v);
+        }
+
         req.body(body.to_string())
     }
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -93,11 +93,15 @@ impl HttpTransport {
         }
 
         // W3C traceparent/tracestate so the upstream MCP backend can
-        // continue the trace. Empty when telemetry is off — zero overhead.
-        let mut otel_headers = HashMap::<String, String>::new();
-        crate::telemetry::inject_traceparent(&mut otel_headers);
-        for (k, v) in otel_headers {
-            req = req.header(k, v);
+        // continue the trace. Skip the allocation entirely when telemetry
+        // is disabled or the operator opted out — this is the proxy's
+        // hottest path.
+        if crate::telemetry::should_inject_traceparent() {
+            let mut otel_headers = HashMap::<String, String>::new();
+            crate::telemetry::inject_traceparent(&mut otel_headers);
+            for (k, v) in otel_headers {
+                req = req.header(k, v);
+            }
         }
 
         req.body(body.to_string())


### PR DESCRIPTION
Operating mcp serve in production today is a blackbox: stderr logs only, no spans to measure tools/call latency, no metrics for error rate per backend, no traceparent propagation so traces break at the proxy boundary. Anyone running it in k8s has zero visibility beyond kubectl logs.

Wired OTel SDK behind the standard env vars (OTEL_EXPORTER_OTLP_ENDPOINT is the only activator). Spans flow through tracing-opentelemetry from a single #[instrument] on dispatch_request — every JSON-RPC call gets one mcp.request span tagged with method, transport, identity, server, tool, status. Inbound traceparent is honored as parent context; outbound HTTP backends get traceparent injected. Metrics cover requests counter, duration histogram, classifier cache hits/misses, plus gauges for connected backends and active sessions. Default-off: without the env var, behavior is byte-identical to 0.5.2. Two escape hatches for production rollback: unset the endpoint, or MCP_OTEL_INJECT_TRACEPARENT=0 to keep telemetry on but stop touching outbound headers.

fixed: #93