### PR TITLE
Bump chrondb to fix native library install on macOS aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "chrondb"
-version = "0.2.3-dev.12298e3"
+version = "0.2.3-dev.ed9ada3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c234715a25f8e5a3aa5c86459f8de593e60e6a9acd24054c3a150d735cd4820"
+checksum = "e70c25253adc5c4022a7d6246da674d61badbe0d8a2f83b7c7338ba4983c7c9e"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ console = "0.16"
 axum = "0.8"
 tokio-stream = "0.1"
 uuid = { version = "1", features = ["v4"] }
-chrondb = "0.2.3-dev.12298e3"
+chrondb = "0.2.3-dev.ed9ada3"
 chrono = { version = "0.4", features = ["serde"] }
 shell-words = "1"
 socket2 = { version = "0.6", features = ["all"] }


### PR DESCRIPTION
## Summary
- On macOS aarch64, chrondb's native-library auto-download fails every run with `SetupFailed("Archive did not contain expected directory structure")`, which silently breaks audit logging since the ChronDB pool never comes up — see avelino/chrondb#145
- avelino/chrondb#146 fixes the underlying extraction bug and has been merged and published to crates.io as `0.2.3-dev.ed9ada3`
- This bumps `chrondb` from `0.2.3-dev.12298e3` to `0.2.3-dev.ed9ada3` to pick up the fix

(Supersedes #101, which couldn't be reopened after a force-push — same branch, same fix, now with a minimal `Cargo.lock` diff limited to the `chrondb` entry.)

## Test plan
- `cargo build --release --locked` and `cargo test --locked` (full suite) pass
- Cleared `~/.chrondb` and ran `mcp rubymine --health` against a real MCP server config on macOS aarch64: native library downloads and installs cleanly, no `SetupFailed` warning, health check returns `{"server":"rubymine","status":"ok"}`
- Confirmed audit logging comes up and `mcp logs` shows the call